### PR TITLE
Raise errors when langgraph is missing

### DIFF
--- a/src/backend/flows/feedback.py
+++ b/src/backend/flows/feedback.py
@@ -2,8 +2,10 @@ from typing import Any
 
 try:
     from langgraph import Graph
-except Exception:  # pragma: no cover - library optional
-    Graph = Any  # type: ignore
+except Exception as exc:  # pragma: no cover - library required
+    raise ImportError(
+        "FeedbackFlow requires the 'langgraph' package. Install it to use this flow."
+    ) from exc
 
 
 class FeedbackFlow:

--- a/src/backend/flows/reading_assist.py
+++ b/src/backend/flows/reading_assist.py
@@ -2,8 +2,10 @@ from typing import Any
 
 try:
     from langgraph import Graph
-except Exception:  # pragma: no cover - library optional
-    Graph = Any  # type: ignore
+except Exception as exc:  # pragma: no cover - library required
+    raise ImportError(
+        "ReadingAssistFlow requires the 'langgraph' package. Install it to use this flow."
+    ) from exc
 
 try:
     import chromadb

--- a/src/backend/flows/word_pack.py
+++ b/src/backend/flows/word_pack.py
@@ -2,8 +2,10 @@ from typing import Any
 
 try:
     from langgraph import Graph
-except Exception:  # pragma: no cover - library optional
-    Graph = Any  # type: ignore
+except Exception as exc:  # pragma: no cover - library required
+    raise ImportError(
+        "WordPackFlow requires the 'langgraph' package. Install it to use this flow."
+    ) from exc
 
 try:
     import chromadb


### PR DESCRIPTION
## Summary
- raise explicit ImportError if langgraph is unavailable for feedback, reading-assist, and word-pack flows

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc068d684c832c9077c635fa548cee