### PR TITLE
fix: initialize abort controller refs in panels

### DIFF
--- a/src/frontend/src/components/AssistPanel.tsx
+++ b/src/frontend/src/components/AssistPanel.tsx
@@ -11,7 +11,7 @@ export const AssistPanel: React.FC<Props> = ({ focusRef }) => {
   const [result, setResult] = useState('');
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState<{ kind: 'status' | 'alert'; text: string } | null>(null);
-  const abortRef = useRef<AbortController>();
+  const abortRef = useRef<AbortController | null>(null);
 
   const assist = async () => {
     abortRef.current?.abort();

--- a/src/frontend/src/components/CardPanel.tsx
+++ b/src/frontend/src/components/CardPanel.tsx
@@ -16,7 +16,7 @@ export const CardPanel: React.FC<Props> = ({ focusRef }) => {
   const [card, setCard] = useState<Card | null>(null);
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState<{ kind: 'status' | 'alert'; text: string } | null>(null);
-  const abortRef = useRef<AbortController>();
+  const abortRef = useRef<AbortController | null>(null);
 
   const getCard = async () => {
     abortRef.current?.abort();

--- a/src/frontend/src/components/SentencePanel.tsx
+++ b/src/frontend/src/components/SentencePanel.tsx
@@ -11,7 +11,7 @@ export const SentencePanel: React.FC<Props> = ({ focusRef }) => {
   const [result, setResult] = useState('');
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState<{ kind: 'status' | 'alert'; text: string } | null>(null);
-  const abortRef = useRef<AbortController>();
+  const abortRef = useRef<AbortController | null>(null);
 
   const checkSentence = async () => {
     abortRef.current?.abort();


### PR DESCRIPTION
## Summary
- initialize AbortController refs with null in CardPanel, SentencePanel, and AssistPanel to satisfy useRef requirements

## Testing
- `npm install --no-save --no-package-lock` *(fails: 403 Forbidden @types/react)*
- `npm test`
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68bc17d07dd8832c98c11c652d9e2198