### PR TITLE
test: ensure src dir on sys.path

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 import sys
 import types
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -7,6 +8,7 @@ from fastapi.testclient import TestClient
 
 @pytest.fixture(scope="module")
 def client():
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
     sys.modules.setdefault("langgraph", types.SimpleNamespace(Graph=object))
     sys.modules.setdefault("chromadb", types.SimpleNamespace())
     from backend.main import app


### PR DESCRIPTION
## Summary
- allow API tests to import backend by prepending repository's src folder to sys.path

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68bc381824a8832c9b0a9382cb75da14