### PR TITLE
Strictモード導入（本番同等のFail-Fast）: 設定不足時のダミー/フォールバックを原則禁止し、準備不足を即エラー化

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,11 @@ pytest -q --cov=src/backend --cov-report=term-missing --cov-fail-under=60
     - `sentry_dsn` … Sentry DSN（設定すると例外を自動送信）
 
 ### 6-1. env.example（サンプル）
-`env.example` を参考に `.env` を作成してください。
+`env.example` を参考に `.env` を作成してください。特に以下の新設定があります。
+
+- `STRICT_MODE`（既定: `true`）
+  - 本番/実運用では `true` を推奨。必須設定が不足している場合はフォールバックせずエラーにします（Fail-Fast）。
+  - テスト/オフライン開発では `false` に設定することで、従来のローカル/ダミー挙動（LLMローカル、SimpleEmbedding、Chromaインメモリ等）を許容します。
 
 補足（互換キーの無視）:
 - 旧サンプル/別アプリ由来のキー（例: `API_KEY`/`ALLOWED_ORIGINS` など）が `.env` に残っていても、`src/backend/config.py` は未使用の環境変数を無視する設定になっています（`extra="ignore"`）。

--- a/UserManual.md
+++ b/UserManual.md
@@ -49,6 +49,10 @@
   cd src/frontend
   npm run dev
   ```
+ヒント（strict モード）:
+- 本番/実運用では `STRICT_MODE=true` を推奨（既定）。必須設定が不足している場合はエラーとなり早期に検出できます。
+- テスト/オフライン開発では `STRICT_MODE=false` を設定すると、LLM/Embeddings/RAG のダミー/インメモリ挙動を許容します。
+
 
 ---
 

--- a/env.example
+++ b/env.example
@@ -1,5 +1,6 @@
 # Backend settings
 ENVIRONMENT=development
+STRICT_MODE=true
 
 # LLM providers: openai | azure-openai | local
 LLM_PROVIDER=local

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -101,6 +101,12 @@ class Settings(BaseSettings):
     )
     sentry_dsn: str | None = Field(default=None, description="Sentry DSN (enable if set)")
 
+    # --- Strict mode ---
+    strict_mode: bool = Field(
+        default=True,
+        description="Fail fast on missing/invalid configuration (disable only for tests)",
+    )
+
     # Pydantic v2 settings config
     # - env_file: .env を読み込む
     # - extra: .env に存在する未使用キー（例: api_key/allowed_origins など）を無視

--- a/src/backend/flows/reading_assist.py
+++ b/src/backend/flows/reading_assist.py
@@ -63,6 +63,8 @@ class ReadingAssistFlow:
                 if isinstance(out, str) and out.strip():
                     paraphrase = out.strip()
         except Exception:
+            if settings.strict_mode:
+                raise
             pass
 
         return AssistedSentence(
@@ -91,6 +93,8 @@ class ReadingAssistFlow:
                     metas = (res.get("metadatas") or [[]])[0]
                     for d, m in zip(docs, metas):
                         citations.append(Citation(text=d, meta=m))
+                elif settings.strict_mode:
+                    raise RuntimeError("RAG is enabled but no citations were retrieved (strict mode)")
         # 確度ヒューリスティクス: RAG あり + LLM パラフレーズ成功で high / 片方で medium
         used_llm = any(s.paraphrase and s.paraphrase != s.raw for s in sentences)
         if citations and used_llm:

--- a/src/backend/flows/word_pack.py
+++ b/src/backend/flows/word_pack.py
@@ -62,8 +62,11 @@ class WordPackFlow:
                 metas = (res.get("metadatas") or [[]])[0]
                 for d, m in zip(docs, metas):
                     citations.append(Citation(text=d, meta=m))
-        # 最低限のフォールバック: 近傍が空でも citations を1件返す（テスト要件を満たす）
+        # strict_mode の場合、RAG 有効で引用が得られなければエラーで早期に気付けるようにする
         if settings.rag_enabled and not citations:
+            if settings.strict_mode:
+                raise RuntimeError("RAG is enabled but no citations were retrieved (strict mode)")
+            # 非 strict: 最低限のフォールバック（テスト/開発用途）
             citations.append(Citation(text=f"{lemma}: example snippet (fallback).", meta={"source": "fallback"}))
         return {"lemma": lemma, "citations": citations}
 

--- a/src/backend/routers/word.py
+++ b/src/backend/routers/word.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 
 from ..flows.word_pack import WordPackFlow
 from ..providers import ChromaClientFactory, get_llm_provider
@@ -12,8 +12,11 @@ router = APIRouter(tags=["word"])
 async def lookup_word() -> dict[str, object]:
     """暫定の語義参照（プレースホルダ）。
 
-    tests/test_api.py の互換用: {"definition": None, "examples": []}
+    strict_mode の場合は未実装として 501 を返す。テスト互換のため非 strict では固定応答。
     """
+    from ..config import settings
+    if settings.strict_mode:
+        raise HTTPException(status_code=501, detail="Not Implemented: /api/word in strict mode")
     return {"definition": None, "examples": []}
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,6 +9,9 @@ from fastapi.testclient import TestClient
 @pytest.fixture(scope="module")
 def client():
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+    # tests: strict を無効化（ダミー・フォールバック許可）
+    import os
+    os.environ["STRICT_MODE"] = "false"
     # langgraph を本物のモジュールとしてスタブ（パッケージ/サブモジュール両方）
     lg_mod = types.ModuleType("langgraph")
     graph_mod = types.ModuleType("langgraph.graph")

--- a/tests/test_e2e_backend_frontend.py
+++ b/tests/test_e2e_backend_frontend.py
@@ -10,6 +10,8 @@ from fastapi.testclient import TestClient
 def app_client():
     # src を import パスに追加
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+    import os
+    os.environ["STRICT_MODE"] = "false"
     # langgraph を最小スタブ化（バックエンドのみのE2Eに留める）
     lg_mod = types.ModuleType("langgraph")
     graph_mod = types.ModuleType("langgraph.graph")

--- a/tests/test_integration_rag.py
+++ b/tests/test_integration_rag.py
@@ -12,6 +12,7 @@ def client_with_chroma(tmp_path_factory):
     # テスト専用の Chroma 永続ディレクトリ
     persist_dir = tmp_path_factory.mktemp("chroma")
     os.environ["CHROMA_PERSIST_DIR"] = str(persist_dir)
+    os.environ["STRICT_MODE"] = "false"
 
     # 先にスタブが注入されている可能性をクリア
     for mod in ["chromadb", "langgraph", "langgraph.graph"]:

--- a/tests/test_load_and_regression.py
+++ b/tests/test_load_and_regression.py
@@ -9,6 +9,8 @@ from fastapi.testclient import TestClient
 @pytest.fixture(scope="module")
 def client():
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+    import os
+    os.environ["STRICT_MODE"] = "false"
     from backend.main import app
     return TestClient(app)
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -15,6 +15,7 @@ def test_get_llm_provider_without_keys_returns_safe_client(monkeypatch):
     from backend import providers
 
     # Force provider to local or unset keys
+    monkeypatch.setenv("STRICT_MODE", "false")
     monkeypatch.setenv("LLM_PROVIDER", "local")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
@@ -32,6 +33,7 @@ def test_get_llm_provider_without_keys_returns_safe_client(monkeypatch):
 
 def test_get_llm_provider_is_singleton(monkeypatch):
     # LLM プロバイダはモジュール内でキャッシュされ、同一インスタンスが返る
+    monkeypatch.setenv("STRICT_MODE", "false")
     monkeypatch.setenv("LLM_PROVIDER", "local")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
@@ -48,6 +50,7 @@ def test_get_llm_provider_is_singleton(monkeypatch):
 def test_chroma_client_fallback_when_module_missing(monkeypatch):
     # remove chromadb module to trigger in-memory fallback
     sys.modules.pop("chromadb", None)
+    monkeypatch.setenv("STRICT_MODE", "false")
     from backend.providers import ChromaClientFactory
 
     client = ChromaClientFactory().create_client()
@@ -60,6 +63,7 @@ def test_chroma_client_fallback_when_module_missing(monkeypatch):
 
 def test_embedding_provider_default_is_callable(monkeypatch):
     # Ensure no OpenAI key -> fallback SimpleEmbeddingFunction
+    monkeypatch.setenv("STRICT_MODE", "false")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     from backend.providers import get_embedding_provider
 


### PR DESCRIPTION
config: strict_mode を追加（既定 true）
providers:
strict時 LLM_PROVIDER=local 不許可
strict時 Embedding は openai のみ許可（OPENAI_API_KEY と SDK必須）
RAG有効で chromadb 未導入/初期化失敗はエラー
flows (word_pack/reading_assist/feedback):
RAG有効で引用ゼロ→strict時エラー
LLM呼出失敗→strict時は再送出
routers:
GET /api/word は strict時 501 (Not Implemented)
docs: env.example に STRICT_MODE=true 追加、README.md/UserManual.md に運用方針と切替手順を追記
tests: 互換性維持のため STRICT_MODE=false を設定して従来のダミー挙動で実行
背景: ダミー/固定応答が最低限の準備不足を隠蔽する問題に対応。ローカル運用でも本番同等の厳格性を確保するため、strictモードでFail-Fastを徹底。