### PR TITLE
Azure OpenAI を廃止し、OpenAI のみに一本化（コード・設定・ドキュメントの整理）

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ pytest -q --cov=src/backend --cov-report=term-missing --cov-fail-under=60
 - `src/backend/config.py`
   - 共通:
     - `environment`
-    - `llm_provider` … `openai` | `azure-openai` | `local`
+    - `llm_provider` … `openai` | `local`
     - `llm_model` … 既定 `gpt-5-mini`（OpenAIを使う場合は実在モデルに置換推奨: 例 `gpt-4o-mini`）
     - `llm_timeout_ms` / `llm_max_retries`
     - `embedding_provider` … 既定 `openai`
@@ -282,9 +282,8 @@ pytest -q --cov=src/backend --cov-report=term-missing --cov-fail-under=60
   - RAG/Chroma:
     - `rag_enabled`, `rag_timeout_ms`, `rag_max_retries`, `rag_rate_limit_per_min`
     - `chroma_persist_dir`, `chroma_server_url`
-  - APIキー/プロバイダ:
+  - APIキー:
     - `openai_api_key`
-    - `azure_openai_api_key`, `azure_openai_endpoint`, `azure_openai_deployment`, `azure_openai_api_version`
     - `voyage_api_key`（将来）
   - SRS（SQLite）
     - `srs_db_path`, `srs_max_today`

--- a/env.example
+++ b/env.example
@@ -2,7 +2,7 @@
 ENVIRONMENT=development
 STRICT_MODE=true
 
-# LLM providers: openai | azure-openai | local
+# LLM providers: openai | local
 LLM_PROVIDER=local
 LLM_MODEL=gpt-5-mini
 LLM_TIMEOUT_MS=8000
@@ -15,11 +15,7 @@ EMBEDDING_MODEL=text-embedding-3-small
 # OpenAI
 OPENAI_API_KEY=
 
-# Azure OpenAI
-AZURE_OPENAI_API_KEY=
-AZURE_OPENAI_ENDPOINT=
-AZURE_OPENAI_DEPLOYMENT=
-AZURE_OPENAI_API_VERSION=2024-02-15-preview
+ 
 
 # RAG/Chroma
 RAG_ENABLED=true

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -25,7 +25,7 @@ class Settings(BaseSettings):
     )
     llm_model: str = Field(
         default="gpt-5-mini",
-        description="LLM model name or deployment / 利用するLLMモデル名（Azureではデプロイ名）",
+        description="LLM model name / 利用するLLMモデル名",
     )
     embedding_model: str = Field(
         default="text-embedding-3-small",
@@ -70,15 +70,9 @@ class Settings(BaseSettings):
         description="Optional Chroma server URL / 任意の Chroma サーバURL（未指定ならローカル）",
     )
 
-    # --- API Keys / Provider Specific ---
+    # --- API Keys ---
     openai_api_key: str | None = Field(default=None, description="OpenAI API Key")
-    azure_openai_api_key: str | None = Field(default=None, description="Azure OpenAI API Key")
     voyage_api_key: str | None = Field(default=None, description="Voyage API Key")
-
-    # Azure OpenAI 用（エンドポイント/デプロイ/バージョン）
-    azure_openai_endpoint: str | None = Field(default=None, description="Azure OpenAI endpoint URL")
-    azure_openai_deployment: str | None = Field(default=None, description="Azure OpenAI deployment name (model)")
-    azure_openai_api_version: str = Field(default="2024-02-15-preview", description="Azure OpenAI API version")
 
     # --- SRS（復習）の永続化設定 ---
     srs_db_path: str = Field(

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -18,7 +18,6 @@ def test_get_llm_provider_without_keys_returns_safe_client(monkeypatch):
     monkeypatch.setenv("STRICT_MODE", "false")
     monkeypatch.setenv("LLM_PROVIDER", "local")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
 
     # Reload settings to pick env
     from importlib import reload
@@ -36,7 +35,6 @@ def test_get_llm_provider_is_singleton(monkeypatch):
     monkeypatch.setenv("STRICT_MODE", "false")
     monkeypatch.setenv("LLM_PROVIDER", "local")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
 
     from importlib import reload
     from backend import providers

--- a/終了済みor参考ドキュメント/環境変数の意味.md
+++ b/終了済みor参考ドキュメント/環境変数の意味.md
@@ -23,8 +23,8 @@
 
 ### 2) LLM_PROVIDER, LLM_MODEL, LLM_TIMEOUT_MS, LLM_MAX_RETRIES
 - 用途:
-  - `LLM_PROVIDER`: LLM クライアントの選択。`openai` | `azure-openai` | `local`
-  - `LLM_MODEL`: 使うモデル名（Azure はデプロイ名）
+  - `LLM_PROVIDER`: LLM クライアントの選択。`openai` | `local`
+  - `LLM_MODEL`: 使うモデル名
   - `LLM_TIMEOUT_MS`: 1回の LLM 呼び出しのタイムアウト
   - `LLM_MAX_RETRIES`: LLM 呼び出しの最大リトライ回数
 - 既定値:
@@ -38,17 +38,7 @@
         if provider == "openai" and settings.openai_api_key:
             _LLM_INSTANCE = _llm_with_policy(_OpenAILLM(api_key=settings.openai_api_key, model=settings.llm_model))
             return _LLM_INSTANCE
-        if provider in {"azure", "azure-openai"} and settings.azure_openai_api_key and settings.azure_openai_endpoint:
-            deployment = settings.azure_openai_deployment or settings.llm_model
-            _LLM_INSTANCE = _llm_with_policy(
-                _AzureOpenAILLM(
-                    api_key=settings.azure_openai_api_key,
-                    endpoint=settings.azure_openai_endpoint,
-                    deployment=deployment,
-                    api_version=settings.azure_openai_api_version,
-                )
-            )
-            return _LLM_INSTANCE
+        # 未対応プロバイダはローカルフォールバック
         _LLM_INSTANCE = _llm_with_policy(_LocalEchoLLM())
         return _LLM_INSTANCE
 ```
@@ -72,7 +62,6 @@
   - 失敗時は例外を投げず空文字を返す設計（上位はフォールバック前提）。
 - 設定例:
   - OpenAI: `LLM_PROVIDER=openai`, `LLM_MODEL=gpt-4o-mini` など + `OPENAI_API_KEY`
-  - Azure: `LLM_PROVIDER=azure-openai`, `AZURE_OPENAI_*` を合わせて設定（下記参照）
   - オフライン学習/テスト: `LLM_PROVIDER=local`
 
 ---
@@ -107,23 +96,7 @@
 
 ---
 
-### 5) AZURE_OPENAI_API_KEY / AZURE_OPENAI_ENDPOINT / AZURE_OPENAI_DEPLOYMENT / AZURE_OPENAI_API_VERSION
-- 用途: Azure OpenAI の認証・接続・モデル（デプロイ名）・API バージョン。
-- 既定値: env.example にサンプルあり、API 版は `2024-02-15-preview` が既定。
-- 使われ方:
-```72:86:src/backend/providers.py
-class _AzureOpenAILLM(_LLMBase):
-    def __init__(self, *, api_key: str, endpoint: str, deployment: str, api_version: str) -> None:
-        ...
-    def complete(self, prompt: str) -> str:
-        resp = self._client.chat.completions.create(
-            model=self._deployment,
-            messages=[{"role": "user", "content": prompt}],
-            ...
-        )
-```
-- 未設定/誤設定: `LLM_PROVIDER=azure-openai` でも `API_KEY`/`ENDPOINT` が無ければ local にフォールバック。
-- 設定例: `AZURE_OPENAI_DEPLOYMENT` は“デプロイ名”（例: `gpt-4o-mini` から作成したデプロイ名）。
+ 
 
 ---
 
@@ -255,8 +228,6 @@ if settings.sentry_dsn:
 - ステージング/本番（OpenAI）:
   - `LLM_PROVIDER=openai`, `LLM_MODEL=gpt-4o-mini`, `OPENAI_API_KEY=...`
   - `EMBEDDING_PROVIDER=openai`, `EMBEDDING_MODEL=text-embedding-3-small`
-- ステージング/本番（Azure）:
-  - `LLM_PROVIDER=azure-openai`, `AZURE_OPENAI_*` を設定（`AZURE_OPENAI_DEPLOYMENT` は“デプロイ名”）
 - 負荷制御:
   - API 全体は `RATE_LIMIT_PER_MIN_*`、RAG は `RAG_RATE_LIMIT_PER_MIN` で個別制御
 - 監視:


### PR DESCRIPTION
### ブランチ名
- chore/remove-azure-openai-support

### PRタイトル
- Azure OpenAI を廃止し、OpenAI のみに一本化（コード・設定・ドキュメントの整理）

### PR概要
- 変更内容
  - バックエンド: `src/backend/providers.py` から Azure 経路と `_AzureOpenAILLM` を削除。厳格モードの許容値を `openai` のみに整理。
  - 設定: `src/backend/config.py` から Azure 関連フィールドを削除。`llm_model` の説明から Azure 文言を除去。
  - サンプル環境: `env.example` から `AZURE_OPENAI_*` を削除。`LLM_PROVIDER` の選択肢を `openai | local` に統一。
  - ドキュメント: `README.md`・`UserManual.md`・`終了済みor参考ドキュメント/環境変数の意味.md` から Azure 記述を削除。`ロードマップ_4.md` も `openai/local` のみの表現に統一。
  - テスト: `tests/test_providers.py` の Azure 参照を削除。

- 互換性/影響
  - 破壊的変更: `LLM_PROVIDER=azure-openai` は無効化。`AZURE_OPENAI_*` は未使用。
  - 移行: `LLM_PROVIDER=openai` と `OPENAI_API_KEY` を設定してください。埋め込みは引き続き `EMBEDDING_PROVIDER=openai`（例: `text-embedding-3-small`）。

- 動作確認
  - `pytest` でグリーン。
  - バックエンド/フロントエンドの起動と主要APIの疎通確認済み。

- セキュリティ/運用
  - 秘密情報の追加なし。`.env` の既存 `AZURE_OPENAI_*` は無視されます。