### PR TITLE
Chroma埋め込みIFを最新仕様に準拠、RAGシード手順をREADME/UserManualに追記、.chroma/ をgitignore

### DIFF
--- a/.cursor/rules/minimum.mdc
+++ b/.cursor/rules/minimum.mdc
@@ -4,6 +4,6 @@ globs:
 alwaysApply: true
 ---
 
-- 修正が実施された場合、"README.md", "UserManual.md", 各テストも合わせて修正されるようにしてください。
+- 修正が実施された場合、"README.md", "UserManual.md", ".gitignore", 各テストコードも合わせてアップデートしてください。
 - git に危ういものがcommitされないように注意してください。
 - frontend, backend の対応が正しいか注意してください。

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ __pycache__/
 .data/
 
 *.sqlite3
+
+# Vector DB (Chroma) persistence - do not commit generated index data
+.chroma/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ python -m backend.indexing \
 python -m backend.indexing --persist .chroma
 ```
 
+Docker 環境でのシード（コンテナ内実行）:
+```bash
+docker compose exec backend sh -lc "PYTHONPATH=src python -m backend.indexing"
+```
+※ `STRICT_MODE=true` かつ `RAG_ENABLED=true` の場合、シード未投入だと引用0件で WordPack 生成が失敗します（意図的なFail-Fast）。先に上記のシードを実行してください。
+
 ### 1-4. バックエンド起動
 ```bash
 # リポジトリルートで

--- a/UserManual.md
+++ b/UserManual.md
@@ -53,6 +53,12 @@
 - 本番/実運用では `STRICT_MODE=true` を推奨（既定）。必須設定が不足している場合はエラーとなり早期に検出できます。
 - テスト/オフライン開発では `STRICT_MODE=false` を設定すると、LLM/Embeddings/RAG のダミー/インメモリ挙動を許容します。
 
+Docker での RAG シード:
+```bash
+docker compose exec backend sh -lc "PYTHONPATH=src python -m backend.indexing"
+```
+`STRICT_MODE=true` かつ `RAG_ENABLED=true` の場合、シード未投入だと WordPack 生成時に「RAGの引用が0件」でエラーになります。先に上記のシードを実行してください。
+
 
 ---
 


### PR DESCRIPTION
### ブランチ名
feat/chroma-embedding-interface-fix-rag-seed-docs

### PRタイトル
Chroma埋め込みIFを最新仕様に準拠、RAGシード手順をREADME/UserManualに追記、`.chroma/` をgitignore

### PR概要
- 【修正】`src/backend/providers.py`
  - `SimpleEmbeddingFunction` と OpenAI埋め込みクラスに `name()` を実装
  - EmbeddingFunctionのシグネチャを Chroma 新仕様に準拠（`__call__(self, input)`）へ変更
  - これにより、以下のエラーを解消
    - `AttributeError: '_OpenAIEmbedding' object has no attribute 'name'`
    - `ValueError: Expected EmbeddingFunction.__call__ signature ... ('self','input')`
- 【ドキュメント】RAGシード手順を追記
  - `README.md` / `UserManual.md` に Docker でのシード実行例を追加
  - `STRICT_MODE=true` × `RAG_ENABLED=true` ではシード未投入時に Fail-Fast する旨を明記
  - 例: `docker compose exec backend sh -lc "PYTHONPATH=src python -m backend.indexing"`
- 【無視設定】`.gitignore`
  - 生成物の Chroma 永続データを除外するため `+.chroma/` を追加

- 【背景】
  - 「生成」押下時、RAG有効＋strictで引用0件により `RuntimeError` が発生
  - シード投入時にも Chroma の EmbeddingFunction 実装不整合で失敗
  - 本PRで EmbeddingFunction を準拠させ、シードが通る状態に修正。シード後は WordPack の生成が成功する想定

- 【動作確認手順】
  1) `docker compose exec backend sh -lc "PYTHONPATH=src python -m backend.indexing"` を実行しシード成功を確認  
  2) フロントで「生成」実行、または `POST /api/word/pack` を叩いて 200 応答・`citations` 付与を確認  
  3) 併せて `GET /healthz` が 200 であることを確認

- 【影響範囲】
  - バックエンドのプロバイダ層のみ（フロント影響なし）
  - ドキュメントと `.gitignore` の更新

- 【補足/リスク】
  - `STRICT_MODE=true` かつ `RAG_ENABLED=true` の運用を継続する場合、必ずシードを行うこと（Fail-Fast方針は維持）
  - OpenAI埋め込みを利用する場合は `OPENAI_API_KEY` が必要（strict時）