### PR TITLE
例文生成プロンプトのNotesを共通/カテゴリ別に分離し最適化

### DIFF
--- a/tests/test_examples_prompt.py
+++ b/tests/test_examples_prompt.py
@@ -1,0 +1,59 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# Ensure `src` is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from backend.flows.word_pack import WordPackFlow  # noqa: E402
+from backend.models.word import ExampleCategory  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "category, present, absent",
+    [
+        (
+            ExampleCategory.Dev,
+            ["- Dev: ソフトウェア開発の文脈。"],
+            ["- CS:", "- LLM:", "- Business:", "- Common:", "ビジネス英語ではなく"],
+        ),
+        (
+            ExampleCategory.CS,
+            ["- CS: 計算機科学の学術文脈。"],
+            ["- Dev:", "- LLM:", "- Business:", "- Common:", "ビジネス英語ではなく"],
+        ),
+        (
+            ExampleCategory.LLM,
+            ["- LLM: 機械学習/LLM 文脈。"],
+            ["- Dev:", "- CS:", "- Business:", "- Common:", "ビジネス英語ではなく"],
+        ),
+        (
+            ExampleCategory.Business,
+            ["- Business: ビジネス文脈"],
+            ["- Dev:", "- CS:", "- LLM:", "- Common:", "ビジネス英語ではなく"],
+        ),
+        (
+            ExampleCategory.Common,
+            ["- Common: 日常会話", "ビジネス英語ではなく"],
+            ["- Dev:", "- CS:", "- LLM:", "- Business:"],
+        ),
+    ],
+)
+def test_examples_prompt_is_category_specific(category, present, absent):
+    flow = WordPackFlow(llm=None)
+    prompt = flow._build_examples_prompt("converge", category, 2)
+
+    # Common parts are always included
+    assert "You are a lexicographer." in prompt
+    assert "\"examples\"" in prompt
+    assert "Override: examples must be exactly 2 items." in prompt
+
+    # Category-specific presence/absence
+    for token in present:
+        assert token in prompt, f"expected to include: {token}"
+    for token in absent:
+        assert token not in prompt, f"expected to exclude: {token}"
+
+


### PR DESCRIPTION
close #68

- 主ミッション（例文生成プロンプトのカテゴリ別最適化＆スリム化）
  - 現在、例文生成用のプロンプト内には（特にNotesの内容）、カテゴリ特化の要件が混在する形で書かれています。
  - 現状の課題: 例文生成Graphで入力されるプロンプトはカテゴリごとでこの共通のNotesが含まれるため、該当外のカテゴリの記述は入力トークンとしてノイズかつムダものとなってしまっています。
  - このNotes部分を文字列変数として分割定義し、各カテゴリごとに送信プロンプト内に適切に適用されて送信されるようにしたいです。
- その外にも改善余地が見つかれば対応をお願いします。

---

---

今から関連ファイルの有無や配置を確認し、プロンプト生成部のNotes分割とカテゴリ別適用の実装方針に合わせて編集に入ります。まずはドキュメントやテストの存在も併せて調べます。

[5 tools called]

今からTODOを作成し、`word_pack.py`の`_build_examples_prompt`のNotesをカテゴリ別に分割し、テストとドキュメントを更新します。続けて該当ファイルを開いて正確に編集します。

[1 tool called]

今から `word_pack.py`, `README.md`, `UserManual.md` を開いて現在の内容を読み、該当箇所の正確な編集計画を確定します。

[3 tools called]

今から`word_pack.py`のプロンプト生成ロジックをカテゴリ別ノートに分割し、不要なノイズを除去するための編集を行います。続けて、テストとドキュメント更新も行います。

[3 tools called]

今からテストファイルのパスや既存のimport方法を確認して、同じスタイルで新しい単体テストを追加します。

[7 tools called]

- 例文プロンプトのNotesを共通/カテゴリ別に分割し、カテゴリ特化の記述だけを送るように修正しました。続けて、プロンプト長をログ出力する軽量ログも加えました。テストとドキュメントも更新済みです。

変更点
- backend: `src/backend/flows/word_pack.py`
  - 新規関数 `\_examples_common_notes_text()` を追加（共通Notes）
  - 新規関数 `\_examples_category_notes_text(category)` を追加（カテゴリ固有Notes）
  - `\_build_examples_prompt()` をリファクタし、共通Notes＋対象カテゴリNotesのみを連結して送信
  - プロンプト長の簡易ログ `wordpack_examples_prompt_built` を追加
- tests: `tests/test_examples_prompt.py`
  - カテゴリごとに「対象カテゴリの記述は含む」「他カテゴリの記述は含まない」を検証
- docs:
  - `README.md` に「例文生成プロンプトの最適化（新）」を追記
  - `UserManual.md` に実装メモ「例文生成プロンプト最適化（カテゴリ別Notesの分離）」を追記

動作・品質
- 既存のAPI/UIには非破壊。`ExampleCategory` による生成分岐だけが影響し、不要トークンの削減とノイズ除去が期待できます。
- linterは問題なし。テストはカテゴリ別の適用/非適用を確認します。

ブランチ名
- feature/split-examples-notes-by-category

コミットメッセージ
- 日本語: 例文生成プロンプトのNotesを共通/カテゴリ別に分離し最適化。テストとドキュメントを更新
- English: Split example-prompt Notes into common and per-category parts; optimize prompts. Add tests and docs

新人向け補足
- 目的: LLMへのプロンプトから不要な記述を省き、カテゴリ固有の指示だけを渡すことで入力トークンを削減し、生成結果の一貫性を高めるためです。
- 実装の要点:
  - `\_examples_common_notes_text()` でどのカテゴリにも共通な注意点を定義。
  - `\_examples_category_notes_text(category)` でカテゴリ固有の注意点を返す。`Common` は追加の口語トーン規定を含む。
  - `\_build_examples_prompt()` で `header + 共通Notes + カテゴリNotes + enforce + tail` を連結し、他カテゴリ記述を含めない。
  - ログ `wordpack_examples_prompt_built` は、LLMへ渡す全文ではなく長さ等のメタのみを出力。Langfuseの全文記録は別設定で制御。
- テストの観点:
  - カテゴリ別に「含めるべき文言」「含めない文言」をパラメタライズしてチェック。これで回帰的にノイズ混入を検出できます。
- 影響範囲:
  - 例文生成のプロンプトのみ。返却スキーマやフロントは無変更。
  - 将来カテゴリ追加時は `\_examples_category_notes_text()` のマップへの追記を忘れないように。