### PR TITLE
例文一覧のページネーションでoffsetが一手遅れる不具合を修正

### DIFF
--- a/src/frontend/src/ExampleListPanel.test.tsx
+++ b/src/frontend/src/ExampleListPanel.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { App } from './App';
+import { vi } from 'vitest';
+
+describe('ExampleListPanel pagination offset behavior', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    // sessionStorage を汚染しないようにクリア
+    try { sessionStorage.clear(); } catch {}
+  });
+
+  function setupFetchMocks() {
+    const mock = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: any, init?: any) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      if (url.endsWith('/api/config') && (!init || (init && (!init.method || init.method === 'GET')))) {
+        return new Response(
+          JSON.stringify({ request_timeout_ms: 60000 }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+
+      if (url.startsWith('/api/word/examples?')) {
+        const u = new URL(url, 'http://localhost');
+        const limit = Number(u.searchParams.get('limit')) || 200;
+        const offset = Number(u.searchParams.get('offset')) || 0;
+        // ダミーデータ: total=450件とし、idは offset..offset+limit-1
+        const total = 450;
+        const items = Array.from({ length: Math.max(0, Math.min(limit, Math.max(0, total - offset))) }).map((_, i) => {
+          const id = offset + i + 1; // 1-based id for readability
+          return {
+            id,
+            word_pack_id: `wp:test:${Math.ceil(id / 5)}`,
+            lemma: `lemma${id}`,
+            category: (['Dev','CS','LLM','Business','Common'] as const)[id % 5],
+            en: `example en ${id}`,
+            ja: `例文 ja ${id}`,
+            grammar_ja: null,
+            created_at: new Date().toISOString(),
+            word_pack_updated_at: null,
+          };
+        });
+        return new Response(
+          JSON.stringify({ items, total, limit, offset }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+
+      return new Response('not found', { status: 404 });
+    });
+    return mock;
+  }
+
+  it('uses requested offset for Next/Prev and shows correct range', async () => {
+    setupFetchMocks();
+    render(<App />);
+
+    const user = userEvent.setup();
+
+    // 例文一覧タブへ
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: '例文一覧' }));
+    });
+
+    // 初期ロードのレンジ表記とボタン状態
+    await waitFor(() => expect(screen.getByText(/例文一覧/)).toBeInTheDocument());
+    // limit=200, total=450, offset=0 => 1-200 / 450件
+    const range1 = await screen.findByText(/1-200 \/ 450件/);
+    expect(range1).toBeInTheDocument();
+    const prevBtn = screen.getByRole('button', { name: '前へ' }) as HTMLButtonElement;
+    const nextBtn = screen.getByRole('button', { name: '次へ' }) as HTMLButtonElement;
+    expect(prevBtn).toBeDisabled();
+    expect(nextBtn).not.toBeDisabled();
+
+    // 次へ: offset=200 を使用
+    await act(async () => {
+      await user.click(nextBtn);
+    });
+    const range2 = await screen.findByText(/201-400 \/ 450件/);
+    expect(range2).toBeInTheDocument();
+    expect(prevBtn).not.toBeDisabled();
+    expect(nextBtn).not.toBeDisabled();
+
+    // 次へ（2回目）: offset=400 を使用し、400-450
+    await act(async () => {
+      await user.click(nextBtn);
+    });
+    const range3 = await screen.findByText(/401-450 \/ 450件/);
+    expect(range3).toBeInTheDocument();
+    // 最終ページでは次へが無効
+    expect(nextBtn).toBeDisabled();
+
+    // 前へ: offset=200 に戻る
+    await act(async () => {
+      await user.click(prevBtn);
+    });
+    const range4 = await screen.findByText(/201-400 \/ 450件/);
+    expect(range4).toBeInTheDocument();
+  }, 15000);
+});
+
+

--- a/src/frontend/src/ExampleListPanel.test.tsx
+++ b/src/frontend/src/ExampleListPanel.test.tsx
@@ -64,8 +64,8 @@ describe('ExampleListPanel pagination offset behavior', () => {
       await user.click(examplesTabBtn);
     });
 
-    // 初期ロードのレンジ表記とボタン状態
-    await waitFor(() => expect(screen.getByText(/例文一覧/)).toBeInTheDocument());
+    // 初期ロードのレンジ表記とボタン状態（見出しをheadingロールで特定）
+    await screen.findByRole('heading', { name: '例文一覧' });
     // limit=200, total=450, offset=0 => 1-200 / 450件
     const range1 = await screen.findByText(/1-200 \/ 450件/);
     expect(range1).toBeInTheDocument();

--- a/src/frontend/src/ExampleListPanel.test.tsx
+++ b/src/frontend/src/ExampleListPanel.test.tsx
@@ -58,9 +58,10 @@ describe('ExampleListPanel pagination offset behavior', () => {
 
     const user = userEvent.setup();
 
-    // 例文一覧タブへ
+    // 例文一覧タブへ（設定ロード完了を待ってボタンが出てからクリック）
+    const examplesTabBtn = await screen.findByRole('button', { name: '例文一覧' });
     await act(async () => {
-      await user.click(screen.getByRole('button', { name: '例文一覧' }));
+      await user.click(examplesTabBtn);
     });
 
     // 初期ロードのレンジ表記とボタン状態

--- a/src/frontend/src/components/ExampleListPanel.tsx
+++ b/src/frontend/src/components/ExampleListPanel.tsx
@@ -88,10 +88,10 @@ export const ExampleListPanel: React.FC = () => {
     return next;
   });
 
-  const buildQuery = () => {
+  const buildQuery = (o: number) => {
     const sp = new URLSearchParams();
     sp.set('limit', String(limit));
-    sp.set('offset', String(offset));
+    sp.set('offset', String(o));
     sp.set('order_by', sortKey);
     sp.set('order_dir', sortOrder);
     if (appliedSearch && appliedSearch.value) {
@@ -102,14 +102,14 @@ export const ExampleListPanel: React.FC = () => {
     return sp.toString();
   };
 
-  const load = async (newOffset: number = 0) => {
+  const load = async (newOffset: number = offset) => {
     abortRef.current?.abort();
     const ctrl = new AbortController();
     abortRef.current = ctrl;
     setLoading(true);
     setMsg(null);
     try {
-      const q = buildQuery();
+      const q = buildQuery(newOffset);
       const res = await fetchJson<ExampleListResponse>(`${settings.apiBase}/word/examples?${q}`, { signal: ctrl.signal });
       setItems(res.items);
       setTotal(res.total);


### PR DESCRIPTION
下記のレビューの妥当性を評価して、もし妥当であれば対応をお願いいたします。

[P1] Use requested offset when fetching examples

Pagination calls pass a newOffset (e.g. load(offset + limit) for Next) but the API request at load() always uses the component’s existing offset because buildQuery() builds the query string from that state and setOffset(newOffset) only runs after the fetch completes. As a result the first “Next/Prev” click reloads the current page and later clicks skip pages because the request offsets lag one step behind. Update the request query to use newOffset (or set the state before calling buildQuery) so that the API receives the correct offset.

ーーー

レビュー指摘を確認しました。APIに正しいoffsetを渡すため、`buildQuery`に引数を追加し、`load`から新しいoffsetを用いてクエリを生成するように修正します。続けてファイルを編集します。

[1 tool called]

今の変更が型/リンタに問題を起こしていないか確認します。

[1 tool called]

- まず結論: レビュー[P1]は妥当です。初回の「次へ/前へ」でAPIに誤ったoffsetが送られていました。`buildQuery()`が常に現在の`offset`ステートを参照し、`setOffset(newOffset)`がfetch後に遅れて反映されるためです。修正として、`buildQuery`に引数を追加し、`load`から`newOffset`をそのままAPIクエリへ渡すように変更しました。信頼度: 高。

- 対応内容:
  - `buildQuery(o: number)`に変更し、`offset`ではなく引数`o`を利用するように修正。
  - `load(newOffset: number = offset)`にし、API呼び出し時に`buildQuery(newOffset)`を使用。
  - これにより、ページネーションのクリックで即座に正しいページが取得され、ページ飛び・一手遅れが解消されます。

- 代替案:
  - `setOffset(newOffset)`を先に実行し、その後`buildQuery()`を呼ぶ方法もありますが、状態反映の非同期性や連打時の競合を考慮すると、今回のように引数で明示的に渡すほうが安全です。

- 回帰/影響範囲:
  - 既存の読み込み（フィルタ、ソート、検索適用）に影響はありません。
  - ページネーションUIの`前へ/次へ`が即時に正しいページを取得します。

- ドキュメント/テスト:
  - UI仕様/API契約に変更はないため、`README.md`/`UserManual.md`は更新不要（No-Docs-Change）。
  - フロントのページネーションのユニット/結合テストがあれば、offsetの遅延が起きないことを確認するケースを追加推奨。

- 失敗条件/反例チェック:
  - `load()`のデフォルト引数を`offset`にしたため、明示引数なしのリロードでも現状ページを正しく取得します。
  - 連打時は`AbortController`で前回リクエストを中断しており、競合のリスクは低いです。

コミットメッセージ（日本語）:
- fix(frontend): 例文一覧のページネーションでoffsetが一手遅れる不具合を修正

Commit message (English):
- fix(frontend): correct pagination offset usage to avoid one-step lag

ブランチ名（英語）:
- fix/example-list-pagination-offset

新人向け補足:
- Reactの状態更新（`setOffset`）は非同期で、直後の処理ではまだ古い値のままです。今回のようにAPIクエリ用に「今使いたい値（`newOffset`）」を明示的に関数引数で受け取り、その値でURLを生成することで、状態反映の遅延に依存しない安定した挙動になります。  
- 連続クリック時は`AbortController`で前のfetchをキャンセルするのが有効です。今回の実装は、リクエスト発行前に前回のコントローラをabortし、新しいコントローラを作成してからfetchしています。これにより、古いレスポンスの上書き事故を防げます。

ーーー

今からテストの追加・更新に着手します。まず既存のテストやユーティリティの実装を確認して、同じモック・セットアップ方針で`ExampleListPanel`のページネーションのオフセット挙動を検証するテストを追加します。

[7 tools called]

これから`ExampleListPanel`向けにページネーションのオフセットが正しくクエリに反映されることを検証するテストを新規追加します。追加後にリンタを確認します。

[1 tool called]

I'll create a new test file that mounts the app, mocks fetch for /api/word/examples with offset/limit, and verifies that clicking Next/Prev sends the correct offset in the request and updates the range label correctly.

[1 tool called]

テストファイルを追加しました。リンタを走らせて問題がないか確認します。

[2 tools called]

- いま、`ExampleListPanel`のページネーションの「次へ/前へ」操作で、表示レンジとボタンの有効/無効を含めた一連の挙動を検証するテストを追加しました。続けて、ボタン状態の確認まで通ったのでTODOの前者を完了にしました。

- 追加ファイル:
```src/frontend/src/ExampleListPanel.test.tsx
it('uses requested offset for Next/Prev and shows correct range', ...)
```
- ポイント:
  - `/api/word/examples`をモックし、`limit=200`, `total=450`, 可変`offset`に応じたアイテム配列とページレンジを返す実装。
  - 初回表示が `1-200 / 450件`、Next で `201-400 / 450件`、さらにNextで `401-450 / 450件`。最後のページで「次へ」無効化、Prevで戻れることを検証。

- ドキュメント更新:
  - 仕様やAPI契約の変更なし。`README.md`/`UserManual.md`は更新不要（No-Docs-Change）。

- 失敗条件/注意:
  - `sessionStorage`依存のUI状態はテスト前にクリアしています。
  - 非同期UI反映は`waitFor`/`findByText`で安定化。

この後の予定:
- もう一つのTODO（Prev/Nextの送信・ボタン制御検証）は今回のケースで満たせています。チェックオフします。

コミットメッセージ（日本語）:
- test(frontend): ExampleListPanelのページネーションoffset挙動のテストを追加

Commit message (English):
- test(frontend): add pagination offset behavior tests for ExampleListPanel

ブランチ名（英語）:
- test/example-list-pagination

新人向け補足:
- UIのページネーションは「表示レンジ」と「APIパラメータ（offset/limit）」の両方を検証するのが重要です。状態更新は非同期なので、直後にDOM断言せず`waitFor`/`findBy*`を使って、レンジ表示の更新を待ってから検証します。  
- `fetch`モックでは、リクエストURLのクエリから`offset/limit`を読み取り、レスポンスにそのまま反映することで、コンポーネントが正しい値を使っているかを”間接的”に検証できます。  
- セッションストレージやローカルストレージに依存するUIは、テスト間の汚染を避けるために`beforeEach`でクリアしておくのが安全です。