### PR TITLE
文章インポート生成フローのカテゴリ反映修正と通知表示改善

### DIFF
--- a/apps/frontend/src/NotificationsContext.tsx
+++ b/apps/frontend/src/NotificationsContext.tsx
@@ -10,12 +10,13 @@ export interface NotificationItem {
   createdAt: number;
   updatedAt: number;
   model?: string; // 任意: 使用モデル名（表示用）
+  category?: string; // 任意: 選択カテゴリ（表示用）
 }
 
 interface NotificationsContextValue {
   notifications: NotificationItem[];
-  add: (input: { title: string; message?: string; status?: NotificationStatus; id?: string; model?: string }) => string;
-  update: (id: string, patch: Partial<Pick<NotificationItem, 'title' | 'message' | 'status' | 'model'>>) => void;
+  add: (input: { title: string; message?: string; status?: NotificationStatus; id?: string; model?: string; category?: string }) => string;
+  update: (id: string, patch: Partial<Pick<NotificationItem, 'title' | 'message' | 'status' | 'model' | 'category'>>) => void;
   remove: (id: string) => void;
   clearAll: () => void;
 }
@@ -63,6 +64,7 @@ export const NotificationsProvider: React.FC<{ children: React.ReactNode } & { p
       createdAt: now,
       updatedAt: now,
       model: input.model,
+      category: input.category,
     };
     setNotifications((prev) => {
       const next = [...prev, item];

--- a/apps/frontend/src/components/NotificationsOverlay.tsx
+++ b/apps/frontend/src/components/NotificationsOverlay.tsx
@@ -36,6 +36,8 @@ export const NotificationsOverlay: React.FC = () => {
       {notifications.map((n) => {
         const elapsedMs = n.status === 'progress' ? nowMs - n.createdAt : n.updatedAt - n.createdAt;
         const timeLabel = n.status === 'progress' ? '経過' : '所要';
+        const detailParts = [n.model, n.category].filter((v): v is string => typeof v === 'string' && v.trim().length > 0);
+        const detailLabel = detailParts.length ? ` ( ${detailParts.join(', ')} )` : '';
         return (
         <div key={n.id} className="ntf-card" role="status" aria-label={`${n.title} - ${n.status}`}>
           <div className="ntf-icon" aria-hidden="true">
@@ -50,7 +52,7 @@ export const NotificationsOverlay: React.FC = () => {
           <div>
             <div className="ntf-title">{n.title}</div>
             {n.message ? <div className="ntf-msg">{n.message}</div> : null}
-            <div className="ntf-time">{timeLabel} {formatElapsed(elapsedMs)}{n.model ? ` (${n.model})` : ''}</div>
+            <div className="ntf-time">{timeLabel} {formatElapsed(elapsedMs)}{detailLabel}</div>
           </div>
           <button className="ntf-close" aria-label="閉じる" onClick={() => remove(n.id)}>✕</button>
         </div>

--- a/apps/frontend/src/lib/wordpack.ts
+++ b/apps/frontend/src/lib/wordpack.ts
@@ -10,8 +10,8 @@ export interface RegenerateSettings {
 }
 
 export interface NotificationsAdapter {
-  add: (input: { title: string; message?: string; status?: 'progress' | 'success' | 'error'; id?: string }) => string;
-  update: (id: string, patch: { title?: string; message?: string; status?: 'progress' | 'success' | 'error' }) => void;
+  add: (input: { title: string; message?: string; status?: 'progress' | 'success' | 'error'; id?: string; model?: string; category?: string }) => string;
+  update: (id: string, patch: { title?: string; message?: string; status?: 'progress' | 'success' | 'error'; model?: string; category?: string }) => void;
 }
 
 export interface RegenerateWordPackMessages {


### PR DESCRIPTION
## 概要
- 「生成＆インポート」ボタンで選択したカテゴリとモデルをAPIリクエストおよび通知に確実に反映するよう修正
- 通知カードにモデル名・カテゴリ名を表示できるよう通知コンテキストとオーバーレイを拡張
- カテゴリ選択がAPIリクエストへ渡されることを検証するフロントエンドテストを追加

## テスト
- npm --prefix apps/frontend test

------
https://chatgpt.com/codex/tasks/task_e_68ce776ff0b4832cb30d559ad5fa16a1