### PR TITLE
OpenAI TTSによる音声読み上げ機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - 発音情報（IPA/音節/強勢）の付与
 - 例文（Dev/CS/LLM/Business/Common）の追加・削除
 - 文章インポートと関連 WordPack の紐付け
+- OpenAI gpt-4o-mini-tts を用いた例文の音声読み上げ
 
 ## クイックスタート
 
@@ -64,6 +65,10 @@ pytest
 cd apps/frontend
 npm run test
 ```
+
+## REST API（抜粋）
+- `POST /api/word/pack` … WordPack を生成して語義や例文、語源、学習カード要点を返却
+- `POST /api/tts` … OpenAI gpt-4o-mini-tts で読み上げた音声（audio/mpeg）をストリーミング返却
 
 ## ディレクトリ
 ```

--- a/UserManual.md
+++ b/UserManual.md
@@ -51,6 +51,7 @@
   - 絞り込み: カテゴリ（Dev/CS/LLM/Business/Common）
 - 操作:
   - 「訳表示」ボタン: 原文の下に日本語訳を展開/畳む
+  - 「音声読み上げ」ボタン: OpenAI gpt-4o-mini-tts で原文を音声再生（音量は端末で調整）
   - 項目クリック: 詳細モーダル（原文/日本語訳/解説）を表示
 
 
@@ -66,6 +67,7 @@
 - 例文表示:
   - カテゴリ例: Dev/CS/LLM/Business/Common（必要数が足りない場合は空欄のまま）
   - 各例文は「英 / 訳 / 解説」をカード型で縦に表示
+  - 各カード下部の「音声読み上げ」ボタンで原文をその場で再生（OpenAI gpt-4o-mini-tts を使用）
 - 語義表示（各 sense 単位）:
   - 見出し語義/定義/ニュアンス/典型パターン/類義・反義/レジスター/注意点
 
@@ -181,6 +183,7 @@
 - `POST /api/word/pack` … WordPack 生成（語義/共起/対比/例文/語源/学習カード要点/発音RP + `citations`/`confidence`、`pronunciation_enabled`,`regenerate_scope` 対応）
 - 追加（保存済み WordPack 関連）:
   - `DELETE /api/word/packs/{id}/examples/{category}/{index}` … 例文の個別削除
+- `POST /api/tts` … OpenAI gpt-4o-mini-tts を使い、`text`/`voice` を受け取って `audio/mpeg` ストリームを返却
 
 ### B-4. 保存済み WordPack の内部構造（実装メモ）
 - 例文は DB で別テーブルに正規化。部分読み込み/部分削除が高速

--- a/apps/backend/backend/main.py
+++ b/apps/backend/backend/main.py
@@ -28,7 +28,7 @@ from .observability import request_trace
 from .providers import ChromaClientFactory, shutdown_providers
 from .routers import article as article_router
 from .routers import config as cfg
-from .routers import health, word
+from .routers import health, tts, word
 
 
 async def access_log_and_metrics(
@@ -160,6 +160,7 @@ def create_app() -> FastAPI:
     app.include_router(article_router.router, prefix="/api/article")
     app.include_router(health.router)
     app.include_router(cfg.router, prefix="/api")
+    app.include_router(tts.router)
 
     app.add_event_handler("shutdown", _on_shutdown)
     app.add_event_handler("startup", _on_startup_seed)

--- a/apps/backend/backend/routers/tts.py
+++ b/apps/backend/backend/routers/tts.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import os
+from typing import Iterator
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, constr
+
+try:
+    from openai import OpenAI  # type: ignore
+except Exception:  # pragma: no cover - openai SDK が無い環境では初期化しない
+    OpenAI = None  # type: ignore[assignment]
+
+
+router = APIRouter(prefix="/api/tts", tags=["tts"])
+
+
+def _init_client() -> OpenAI | None:  # type: ignore[valid-type]
+    if OpenAI is None:  # pragma: no cover - SDK 未導入環境
+        return None
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return None
+    return OpenAI(api_key=api_key)
+
+
+def _iter_audio_bytes(response: object) -> Iterator[bytes]:
+    if hasattr(response, "iter_bytes"):
+        yield from response.iter_bytes()  # type: ignore[misc]
+    else:  # pragma: no cover - 想定外フォーマット
+        raise RuntimeError("streaming response does not provide iter_bytes")
+
+
+client = _init_client()
+
+
+class TTSIn(BaseModel):
+    text: constr(min_length=1)
+    voice: str = "alloy"
+
+
+@router.post("", response_class=StreamingResponse)
+def synth(req: TTSIn) -> StreamingResponse:
+    if client is None:
+        raise HTTPException(status_code=500, detail="OpenAI client is not configured")
+
+    try:
+        def stream() -> Iterator[bytes]:
+            with client.audio.speech.with_streaming_response.create(  # type: ignore[union-attr]
+                model="gpt-4o-mini-tts",
+                voice=req.voice,
+                input=req.text,
+            ) as resp:
+                yield from _iter_audio_bytes(resp)
+
+        return StreamingResponse(stream(), media_type="audio/mpeg")
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - SDK からの例外をそのまま伝播
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/apps/frontend/src/components/TTSButton.test.tsx
+++ b/apps/frontend/src/components/TTSButton.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { TTSButton } from './TTSButton';
+
+describe('TTSButton', () => {
+  const originalFetch = global.fetch;
+  const originalAudio = (global as any).Audio;
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  const originalAlert = window.alert;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+    if (originalAudio) {
+      (global as any).Audio = originalAudio;
+    } else {
+      delete (global as any).Audio;
+    }
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+    window.alert = originalAlert;
+  });
+
+  it('fetches audio and plays it', async () => {
+    const playMock = vi.fn().mockResolvedValue(undefined);
+    const audioInstances: Array<{ onended: (() => void) | null }> = [];
+    const audioCtor = vi.fn().mockImplementation(() => {
+      const instance = {
+        play: playMock,
+        onended: null as (() => void) | null,
+        onerror: null as (() => void) | null,
+      };
+      audioInstances.push(instance);
+      return instance;
+    });
+    (global as any).Audio = audioCtor;
+    URL.createObjectURL = vi.fn().mockReturnValue('blob:mock-url');
+    URL.revokeObjectURL = vi.fn();
+    const fetchMock = vi.fn().mockResolvedValue(new Response('audio-data', { status: 200 }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<TTSButton text="Hello" />);
+    const user = userEvent.setup();
+    const button = screen.getByRole('button', { name: '音声読み上げ' });
+    await user.click(button);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/tts', expect.objectContaining({ method: 'POST' }));
+    await waitFor(() => expect(playMock).toHaveBeenCalled());
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    audioInstances[0].onended?.();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+
+  it('alerts when fetch fails', async () => {
+    (global as any).Audio = vi.fn().mockImplementation(() => ({ play: vi.fn().mockResolvedValue(undefined), onended: null, onerror: null }));
+    URL.createObjectURL = vi.fn().mockReturnValue('blob:mock');
+    URL.revokeObjectURL = vi.fn();
+    const fetchMock = vi.fn().mockResolvedValue(new Response('error', { status: 500 }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const alertMock = vi.fn();
+    window.alert = alertMock;
+    const consoleMock = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<TTSButton text="Hello" />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: '音声読み上げ' }));
+
+    await waitFor(() => expect(alertMock).toHaveBeenCalledWith('音声の取得に失敗しました'));
+    expect(consoleMock).toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/components/TTSButton.tsx
+++ b/apps/frontend/src/components/TTSButton.tsx
@@ -1,0 +1,62 @@
+import { type CSSProperties, useState } from 'react';
+
+type Props = {
+  text: string;
+  className?: string;
+  voice?: string;
+  style?: CSSProperties;
+};
+
+export function TTSButton({ text, className, voice = 'alloy', style }: Props) {
+  const [loading, setLoading] = useState(false);
+
+  const speak = async () => {
+    if (loading) return;
+    const trimmed = text?.trim();
+    if (!trimmed) return;
+    if (typeof window === 'undefined' || typeof Audio === 'undefined') {
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch('/api/tts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: trimmed, voice }),
+      });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const audio = new Audio(url);
+      audio.onended = () => {
+        URL.revokeObjectURL(url);
+      };
+      audio.onerror = () => {
+        URL.revokeObjectURL(url);
+      };
+      await audio.play();
+    } catch (err) {
+      console.error('[TTS] failed to fetch audio', err);
+      if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+        window.alert('音声の取得に失敗しました');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={speak}
+      disabled={loading || !text?.trim()}
+      className={className}
+      data-testid="speak-btn"
+      style={style}
+    >
+      {loading ? '読み上げ中…' : '音声読み上げ'}
+    </button>
+  );
+}

--- a/apps/frontend/src/components/WordPackPanel.tsx
+++ b/apps/frontend/src/components/WordPackPanel.tsx
@@ -7,6 +7,7 @@ import { LoadingIndicator } from './LoadingIndicator';
 import { useNotifications } from '../NotificationsContext';
 import { Modal } from './Modal';
 import { formatDateJst } from '../lib/date';
+import { TTSButton } from './TTSButton';
 
 interface Props {
   focusRef: React.RefObject<HTMLElement>;
@@ -661,34 +662,41 @@ export const WordPackPanel: React.FC<Props> = ({ focusRef, selectedWordPackId, o
                       {ex.grammar_ja ? (
                         <div className="ex-grammar"><span className="ex-label">解説</span> {ex.grammar_ja}</div>
                       ) : null}
-                      {currentWordPackId ? (
-                        <div style={{ marginTop: 6, display: 'inline-flex', gap: 6, flexWrap: 'wrap' }}>
-                          <button
-                            onClick={() => deleteExample(k, i)}
-                            disabled={loading}
-                            aria-label={`delete-example-${k}-${i}`}
-                            style={{ fontSize: '0.85em', color: '#d32f2f', border: '1px solid #d32f2f', background: 'white', padding: '0.1rem 0.4rem', borderRadius: 4 }}
-                          >
-                            削除
-                          </button>
-                          <button
-                            onClick={() => importArticleFromExample(k, i)}
-                            disabled={loading}
-                            aria-label={`import-article-from-example-${k}-${i}`}
-                            style={{ fontSize: '0.85em', color: '#1565c0', border: '1px solid #1565c0', background: 'white', padding: '0.1rem 0.4rem', borderRadius: 4 }}
-                          >
-                            文章インポート
-                          </button>
-                          <button
-                            onClick={() => copyExampleText(k, i)}
-                            disabled={loading}
-                            aria-label={`copy-example-${k}-${i}`}
-                            style={{ fontSize: '0.85em', color: '#2e7d32', border: '1px solid #2e7d32', background: 'white', padding: '0.1rem 0.4rem', borderRadius: 4 }}
-                          >
-                            コピー
-                          </button>
-                        </div>
-                      ) : null}
+                      <div style={{ marginTop: 6, display: 'inline-flex', gap: 6, flexWrap: 'wrap' }}>
+                        <TTSButton
+                          text={ex.en}
+                          voice="alloy"
+                          style={{ fontSize: '0.85em', color: '#6a1b9a', border: '1px solid #6a1b9a', background: 'white', padding: '0.1rem 0.4rem', borderRadius: 4 }}
+                        />
+                        {currentWordPackId ? (
+                          <>
+                            <button
+                              onClick={() => deleteExample(k, i)}
+                              disabled={loading}
+                              aria-label={`delete-example-${k}-${i}`}
+                              style={{ fontSize: '0.85em', color: '#d32f2f', border: '1px solid #d32f2f', background: 'white', padding: '0.1rem 0.4rem', borderRadius: 4 }}
+                            >
+                              削除
+                            </button>
+                            <button
+                              onClick={() => importArticleFromExample(k, i)}
+                              disabled={loading}
+                              aria-label={`import-article-from-example-${k}-${i}`}
+                              style={{ fontSize: '0.85em', color: '#1565c0', border: '1px solid #1565c0', background: 'white', padding: '0.1rem 0.4rem', borderRadius: 4 }}
+                            >
+                              文章インポート
+                            </button>
+                            <button
+                              onClick={() => copyExampleText(k, i)}
+                              disabled={loading}
+                              aria-label={`copy-example-${k}-${i}`}
+                              style={{ fontSize: '0.85em', color: '#2e7d32', border: '1px solid #2e7d32', background: 'white', padding: '0.1rem 0.4rem', borderRadius: 4 }}
+                            >
+                              コピー
+                            </button>
+                          </>
+                        ) : null}
+                      </div>
                     </article>
                   ))}
                 </div>

--- a/tests/test_tts_router.py
+++ b/tests/test_tts_router.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Iterator
+
+from fastapi.testclient import TestClient
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1] / "apps" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from backend.main import create_app
+from backend.routers import tts
+
+
+class _DummyStream:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    def __enter__(self) -> "_DummyStream":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    def iter_bytes(self) -> Iterator[bytes]:
+        yield from self._chunks
+
+
+class _DummyClient:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self.audio = type(
+            "_Audio",
+            (),
+            {
+                "speech": type(
+                    "_Speech",
+                    (),
+                    {
+                        "with_streaming_response": type(
+                            "_WithStreaming",
+                            (),
+                            {"create": staticmethod(lambda **_: _DummyStream(chunks))},
+                        )()
+                    },
+                )()
+            },
+        )()
+
+
+def test_tts_synth_streams_audio(monkeypatch) -> None:
+    original_client = tts.client
+    dummy_client = _DummyClient([b"foo", b"bar"])
+    tts.client = dummy_client  # type: ignore[assignment]
+    try:
+        app = create_app()
+        with TestClient(app) as client:
+            response = client.post("/api/tts", json={"text": "Hello", "voice": "verse"})
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("audio/mpeg")
+        assert response.content == b"foobar"
+    finally:
+        tts.client = original_client  # type: ignore[assignment]
+
+
+def test_tts_synth_unconfigured(monkeypatch) -> None:
+    original_client = tts.client
+    tts.client = None  # type: ignore[assignment]
+    try:
+        app = create_app()
+        with TestClient(app) as client:
+            response = client.post("/api/tts", json={"text": "Hi"})
+        assert response.status_code == 500
+        assert response.json()["detail"].startswith("OpenAI client is not configured")
+    finally:
+        tts.client = original_client  # type: ignore[assignment]


### PR DESCRIPTION
## 概要
- gpt-4o-mini-tts を利用する FastAPI エンドポイント `/api/tts` を新設し、音声ストリーミングを提供
- フロントエンドに音声読み上げボタンと再生処理を実装し、WordPack の例文カードから呼び出せるように調整
- バックエンド・フロントエンドのテストを追加し、README と UserManual を更新

## テスト
- pytest
- npm run test

Docs: updated (README|UserManual)

------
https://chatgpt.com/codex/tasks/task_e_68cfa0ab712c832c8ac31faf205d6452