### PR TITLE
docs: DBのER図（Mermaid）を追加（SQLiteスキーマに基づく）

### DIFF
--- a/docs/db_er.md
+++ b/docs/db_er.md
@@ -1,0 +1,73 @@
+### DB ER 図（Mermaid）
+
+以下は本アプリ（SQLite）の主要テーブルとリレーションのER図です。
+
+```mermaid
+erDiagram
+    word_packs ||--o{ word_pack_examples : has
+    articles   ||--o{ article_word_packs : links
+    word_packs ||--o{ article_word_packs : linked_by
+
+    word_packs {
+        TEXT id PK
+        TEXT lemma
+        TEXT sense_title
+        TEXT data
+        TEXT created_at
+        TEXT updated_at
+    }
+
+    word_pack_examples {
+        INTEGER id PK
+        TEXT word_pack_id FK
+        TEXT category
+        INTEGER position
+        TEXT en
+        TEXT ja
+        TEXT grammar_ja
+        TEXT llm_model
+        TEXT llm_params
+        TEXT created_at
+    }
+
+    articles {
+        TEXT id PK
+        TEXT title_en
+        TEXT body_en
+        TEXT body_ja
+        TEXT notes_ja
+        TEXT llm_model
+        TEXT llm_params
+        TEXT generation_category
+        TEXT created_at
+        TEXT updated_at
+        TEXT generation_started_at
+        TEXT generation_completed_at
+        INTEGER generation_duration_ms
+    }
+
+    article_word_packs {
+        TEXT article_id FK
+        TEXT word_pack_id FK
+        TEXT lemma
+        TEXT status
+        TEXT created_at
+    }
+```
+
+補足:
+- `word_pack_examples.word_pack_id` は `word_packs.id` を参照（ON DELETE CASCADE）。
+- `article_word_packs.article_id` は `articles.id` を参照（ON DELETE CASCADE）。
+- `article_word_packs.word_pack_id` は `word_packs.id` を参照（ON DELETE CASCADE）。
+- `article_word_packs` の主キーは `(article_id, word_pack_id)` の複合主キー。
+- インデックス（実装由来）
+  - `idx_word_packs_lemma(lemma)`, `idx_word_packs_created_at(created_at)`
+  - `idx_wpex_pack(word_pack_id)`, `idx_wpex_pack_cat_pos(word_pack_id, category, position)`
+  - `idx_articles_created_at(created_at)`, `idx_articles_title(title_en)`
+  - `idx_article_wps_article(article_id)`, `idx_article_wps_lemma(lemma)`
+
+データ由来の値の例:
+- `word_pack_examples.category`: {"Dev","CS","LLM","Business","Common"}
+- `article_word_packs.status`: {"existing","created"}
+
+


### PR DESCRIPTION
I'll scan the backend models and storage layer to extract entities and relations for the ER diagram, then create a Mermaid ER diagram file under `docs/`.

[4 tools called]

I'll create a Mermaid ER diagram as `docs/db_er.md` describing the SQLite tables and relations inferred from `backend/store.py`.

[1 tool called]

I'll remove the composite PK annotation line inside the Mermaid entity to ensure Mermaid parses cleanly, then run a quick lint check on the edited file.

[1 tool called]

作成完了: SQLite の実体とリレーションを整理し、`docs/db_er.md` に Mermaid 形式のER図を追加しました。

### ドキュメント更新について
- README.md: ER 図へのリンクを追記するのが望ましい（任意）。例: “Docs/DB ER 図” セクション。
- UserManual.md: 一般ユーザー向け操作に変更なしのため更新不要。

### 追加ファイル
- `docs/db_er.md`: Mermaid ER 図（`word_packs`、`word_pack_examples`、`articles`、`article_word_packs` とその外部キー/インデックス/複合主キーの注記）

閲覧方法:
- GitHub 上の Markdown では Mermaid をそのまま表示できます。
- もしプレビューできない環境の場合は、Mermaid Live Editor に `docs/db_er.md` のコードブロックを貼り付けて確認してください。

ステータス: バックエンドのモデル/ストアを読み取り、主要テーブルと関係を抽出して `docs/db_er.md` を作成しました。

- 変更点
  - `docs/db_er.md` を新規追加し、ER 図（Mermaid）と補足（FK、インデックス、複合PK）を明記。

コミットメッセージ:
- 日本語: docs: DBのER図（Mermaid）を追加（SQLiteスキーマに基づく）
- 英語: docs: add DB ER diagram (Mermaid) based on SQLite schema

ブランチ名:
- feat/docs-db-er-diagram

新人向けメモ:
- このER図は `apps/backend/backend/store.py` で初期化されるSQLiteテーブル定義を元にしています。
  - 主要テーブル: `word_packs`（単語のコア情報JSONを保持）、`word_pack_examples`（例文の正規化テーブル）、`articles`（記事本文/生成メタ）、`article_word_packs`（記事と単語パックの多対多）
  - 重要な関係:
    - `word_packs` 1:N `word_pack_examples`（`word_pack_examples.word_pack_id` → `word_packs.id`）
    - `articles` N:M `word_packs`（中間 `article_word_packs`、複合PK `(article_id, word_pack_id)`）
  - 実際の外部キー・インデックスは `store.py` の `CREATE TABLE/INDEX` で有効化されています（`PRAGMA foreign_keys=ON`）。
- スキーマを変更した場合は、同ファイル（`docs/db_er.md`）の該当箇所（カラムや関係）を同期更新してください。README にもリンク追記/更新をお願いします。