### PR TITLE
WordPackと例文に学習進捗カウンタを追加

### DIFF
--- a/apps/backend/backend/models/word.py
+++ b/apps/backend/backend/models/word.py
@@ -123,6 +123,16 @@ class Examples(BaseModel):
         category: Optional[ExampleCategory] = Field(default=None, description="例文カテゴリ（後方互換のため任意）")
         llm_model: Optional[str] = Field(default=None, description="例文生成に使用したLLMモデル名（任意）")
         llm_params: Optional[str] = Field(default=None, description="LLMパラメータ情報を連結した文字列（任意）")
+        checked_only_count: int = Field(
+            default=0,
+            ge=0,
+            description="この例文を確認しただけの回数（非負整数）",
+        )
+        learned_count: int = Field(
+            default=0,
+            ge=0,
+            description="この例文を学習完了と記録した回数（非負整数）",
+        )
 
     Dev: List[ExampleItem] = Field(default_factory=list)
     CS: List[ExampleItem] = Field(default_factory=list)
@@ -147,6 +157,16 @@ class ExampleListItem(BaseModel):
     grammar_ja: Optional[str] = None
     created_at: str
     word_pack_updated_at: Optional[str] = None
+    checked_only_count: int = Field(
+        default=0,
+        ge=0,
+        description="例文を確認しただけの回数（非負整数）",
+    )
+    learned_count: int = Field(
+        default=0,
+        ge=0,
+        description="例文を学習済みと記録した回数（非負整数）",
+    )
 
 
 class ExampleListResponse(BaseModel):
@@ -207,6 +227,16 @@ class WordPack(BaseModel):
     # 生成に使用したAIのメタ（任意）
     llm_model: Optional[str] = Field(default=None)
     llm_params: Optional[str] = Field(default=None)
+    checked_only_count: int = Field(
+        default=0,
+        ge=0,
+        description="WordPack全体を確認しただけの回数（非負整数）",
+    )
+    learned_count: int = Field(
+        default=0,
+        ge=0,
+        description="WordPack全体を学習した回数（非負整数）",
+    )
 
 
 class WordPackListItem(BaseModel):

--- a/apps/backend/backend/routers/word.py
+++ b/apps/backend/backend/routers/word.py
@@ -565,7 +565,19 @@ async def list_examples(
     )
 
     items: list[ExampleListItem] = []
-    for (rid, wp_id, lemma, cat, en, ja, grammar_ja, created_at, pack_updated_at) in items_raw:
+    for (
+        rid,
+        wp_id,
+        lemma,
+        cat,
+        en,
+        ja,
+        grammar_ja,
+        created_at,
+        pack_updated_at,
+        checked_only_count,
+        learned_count,
+    ) in items_raw:
         items.append(
             ExampleListItem(
                 id=rid,
@@ -577,6 +589,8 @@ async def list_examples(
                 grammar_ja=grammar_ja,
                 created_at=created_at,
                 word_pack_updated_at=pack_updated_at,
+                checked_only_count=checked_only_count,
+                learned_count=learned_count,
             )
         )
     return ExampleListResponse(items=items, total=total, limit=limit, offset=offset)


### PR DESCRIPTION
close #161 

## 概要
- WordPackおよび例文のPydanticモデルへ「確認しただけ」「学習した」回数を保持するフィールドを追加しました
- SQLiteテーブル定義と保存・取得ロジックを拡張し、新しい数値カラムを永続化できるようにしました
- 例文一覧APIが新カラムを返すようにし、例文追加処理でも非負整数として保存されるよう補正しました

## テスト
- pytest tests/test_api.py -k wordpack（カバレッジ閾値60%未達で失敗）

------
https://chatgpt.com/codex/tasks/task_e_68d2423f0950832caed189fd84859bcd