### PR TITLE
lemma新規作成時のみsense_titleを生成する改善

### DIFF
--- a/apps/backend/backend/store.py
+++ b/apps/backend/backend/store.py
@@ -530,7 +530,11 @@ class AppSQLiteStore:
         else:
             new_label = original_label or stored_label
         stripped_sense = str(sense_title or "").strip()
-        new_sense_title = stripped_sense or row["sense_title"]
+        stored_sense_title = str(row["sense_title"] or "")
+        if stored_sense_title:
+            new_sense_title = stored_sense_title
+        else:
+            new_sense_title = stripped_sense
         new_llm_model = llm_model if llm_model is not None else row["llm_model"]
         new_llm_params = llm_params if llm_params is not None else row["llm_params"]
         conn.execute(

--- a/tests/backend/test_store_lemma.py
+++ b/tests/backend/test_store_lemma.py
@@ -49,3 +49,34 @@ def test_upsert_preserves_original_label(tmp_path):
         assert row["sense_title"] == "Sense Title"
         assert row["llm_model"] == "gpt-x"
         assert row["llm_params"] == "{\"temperature\": 0.2}"
+
+
+def test_upsert_does_not_override_existing_sense_title(tmp_path):
+    db_path = tmp_path / "lemma-sense-title.sqlite3"
+    store = AppSQLiteStore(str(db_path))
+
+    now = datetime.now(UTC).isoformat()
+    with store._conn() as conn:  # pylint: disable=protected-access
+        store._upsert_lemma(  # pylint: disable=protected-access
+            conn,
+            label="Accelerate",
+            sense_title="初速を上げる",
+            llm_model=None,
+            llm_params=None,
+            now=now,
+        )
+
+        store._upsert_lemma(  # pylint: disable=protected-access
+            conn,
+            label="accelerate",
+            sense_title="速度を増す",
+            llm_model="gpt-5",
+            llm_params="{\"foo\": 1}",
+            now=now,
+        )
+
+        row = _row(conn)
+        assert row["label"] == "Accelerate"
+        assert row["sense_title"] == "初速を上げる"
+        assert row["llm_model"] == "gpt-5"
+        assert row["llm_params"] == "{\"foo\": 1}"


### PR DESCRIPTION
## 概要
- lemmaの既存レコードを再利用する際にsense_titleを上書きしないよう更新
- sense_titleが既に空でない場合は保持し、空の場合のみ新値を反映
- 新挙動を検証するテストを追加

## テスト
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d5783ca8ac832ca468315578c8ac83