### PR TITLE
WordPack概要ウインドウで語義タイトルが更新されない不具合を修正

### DIFF
--- a/apps/frontend/src/WordPackPanel.test.tsx
+++ b/apps/frontend/src/WordPackPanel.test.tsx
@@ -13,6 +13,12 @@ describe('WordPackPanel E2E (mocked fetch)', () => {
   function setupFetchMocks() {
     const mock = vi.spyOn(global, 'fetch').mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : (input as URL).toString();
+      if (url.includes('/api/word/lemma/Paths')) {
+        return new Response(
+          JSON.stringify({ found: true, id: 'wp:Paths:lemma', lemma: 'Paths', sense_title: '語義タイトルなし' }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
       if (url.endsWith('/api/word/packs') && init?.method === 'POST') {
         const body = init?.body ? JSON.parse(init.body as string) : {};
         const lemma = body.lemma || 'test';
@@ -275,6 +281,12 @@ describe('WordPackPanel E2E (mocked fetch)', () => {
       expect(urls.some((u) => u.includes('/api/word/lemma/Paths'))).toBe(true);
     });
     const windowRegion = await screen.findByRole('complementary', { name: 'Paths のWordPack概要' });
+    await waitFor(() => {
+      const subtitle = windowRegion.querySelector('.lemma-window-subtitle');
+      expect(subtitle).toBeTruthy();
+      expect(subtitle).toHaveTextContent('Paths概説');
+      expect(subtitle).not.toHaveTextContent('語義タイトルなし');
+    });
     expect(within(windowRegion).getAllByText(/Paths概説/).length).toBeGreaterThan(0);
 
     const minimizeButton = within(windowRegion).getByRole('button', { name: '最小化' });

--- a/apps/frontend/src/components/WordPackPanel.tsx
+++ b/apps/frontend/src/components/WordPackPanel.tsx
@@ -213,6 +213,7 @@ export const WordPackPanel: React.FC<Props> = ({ focusRef, selectedWordPackId, o
           return {
             ...prev,
             status: 'ready',
+          senseTitle: (detail.sense_title || prev.senseTitle) ?? null,
             data: normalizeWordPack(detail),
             errorMessage: null,
           };


### PR DESCRIPTION
[20 tools called]

結論: WordPack概要ウインドウのサブタイトルを詳細レスポンスで再同期する実装と、その挙動を固定化するテストを追加しました。信頼度: 高。

- **ドキュメント**: 挙動仕様や操作手順に差分はなく、`README.md`/`UserManual.md` の更新は不要と判断しました。  
- **テスト**: `npm test -- src/WordPackPanel.test.tsx` を実行し、新規シナリオを含め全テストが成功しています。

根拠・操作・結果:
- 原因: Lemma検索APIから受け取った旧プレースホルダ `"語義タイトルなし"` を `LemmaExplorerWindow` state が保持し続け、詳細取得後の `WordPack.sense_title` を反映していませんでした。
- 対応: 詳細取得成功時に `senseTitle` を `detail.sense_title` で上書き。
```214:218:apps/frontend/src/components/WordPackPanel.tsx
        return {
          ...prev,
          status: 'ready',
          senseTitle: (detail.sense_title || prev.senseTitle) ?? null,
          data: normalizeWordPack(detail),
```
- 追加テスト: Lemma検索が旧プレースホルダを返し、詳細で正しいタイトルが届くケースをモックして UI が更新されることを検証。
```284:290:apps/frontend/src/WordPackPanel.test.tsx
    await waitFor(() => {
      const subtitle = windowRegion.querySelector('.lemma-window-subtitle');
      expect(subtitle).toBeTruthy();
      expect(subtitle).toHaveTextContent('Paths概説');
      expect(subtitle).not.toHaveTextContent('語義タイトルなし');
    });
```
- 結果: プレースホルダは表示されず、実際の語義タイトルが確実にヘッダーへ反映されます。

代替案: バックエンド側で Lemma検索結果の `sense_title` を最新化するマイグレーションや再計算を実施する方法もありますが、フロントで即座に同期する今回の解は最小変更で副作用が少ないです。  
失敗条件: 詳細レスポンスが `sense_title` を含まない場合はプレースホルダが残る可能性があります。現在のAPI契約では常に返却される想定ですが、異常時の監視が必要です。  
残リスク: Lemma検索キャッシュ内に旧値が残存していても、詳細取得成功後に上書きされるため実害は解消済み。バックエンドDBのプレースホルダは後日掃除を検討できます。

次の一手: 必要であれば Lemma検索APIやDBマイグレーションで旧プレースホルダを置換し、ログ監視で同現象が再発しないか確認してください。

コミットメッセージ案:  
- 日本語: `WordPack概要ウインドウで語義タイトルが更新されない不具合を修正`  
- 英語: `Fix lemma explorer subtitle not refreshing after detail fetch`  
推奨ブランチ名: `fix/lemma-explorer-sense-title-refresh`

新人向け解説: LemmaExplorerWindow は① Lemma検索API → ② WordPack詳細API の順にデータを取得します。旧実装では①の結果（語義タイトルが空/プレースホルダのまま）を state に保存し、②で最新データが来ても更新していませんでした。そのため古い `"語義タイトルなし"` がヘッダーに残っていました。今回、②のレスポンスを受け取った際に `senseTitle` を確実に置き換えるようにし、テストで「検索がプレースホルダを返しても詳細取得後は正しいタイトルへ切り替わる」ことを検証しました。これで既存DBにプレースホルダが残っていても UI は最新情報を表示します。