### PR TITLE
閲覧ユーザーのAI機能制限を実装

### DIFF
--- a/apps/backend/backend/config.py
+++ b/apps/backend/backend/config.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -125,6 +127,11 @@ class Settings(BaseSettings):
     strict_mode: bool = Field(
         default=True,
         description="Fail fast on missing/invalid configuration (disable only for tests)",
+    )
+
+    user_role: Literal["admin", "viewer"] = Field(
+        default="admin",
+        description="Current user role / 現在のユーザーロール (admin|viewer)",
     )
 
     # Pydantic v2 settings config

--- a/apps/backend/backend/permissions.py
+++ b/apps/backend/backend/permissions.py
@@ -1,0 +1,14 @@
+"""Simple authorization helpers for feature gating."""
+
+from fastapi import HTTPException
+
+from .config import settings
+
+
+def ensure_ai_access() -> None:
+    """Raise 403 when AI features are disabled for the current user role."""
+    if settings.user_role == "viewer":
+        raise HTTPException(
+            status_code=403,
+            detail="AI features are disabled for viewer role",
+        )

--- a/apps/backend/backend/routers/article.py
+++ b/apps/backend/backend/routers/article.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, Field
 from ..flows.category_generate_import import CategoryGenerateAndImportFlow
 import anyio
 from functools import partial
+from ..permissions import ensure_ai_access
 
 
 router = APIRouter(tags=["article"])
@@ -184,6 +185,7 @@ def _post_filter_lemmas(raw: list[str]) -> list[str]:
     "/import", response_model=ArticleDetailResponse, response_model_exclude_none=True
 )
 async def import_article(req: ArticleImportRequest) -> ArticleDetailResponse:
+    ensure_ai_access()
     flow = ArticleImportFlow()
     # ルータ層は薄く、Langfuse の親スパンを貼ってフローを呼び出す
     from ..observability import request_trace
@@ -313,6 +315,7 @@ async def generate_and_import_examples(
     """選択カテゴリに関連する語を1つ生成し、空のWordPackを作成、
     当該カテゴリの例文を2件生成して保存し、それぞれを文章インポートに渡して記事化する。
     """
+    ensure_ai_access()
     flow = CategoryGenerateAndImportFlow(
         model=getattr(req, "model", None),
         temperature=getattr(req, "temperature", None),

--- a/apps/backend/backend/routers/config.py
+++ b/apps/backend/backend/routers/config.py
@@ -16,4 +16,5 @@ def get_runtime_config() -> dict[str, object]:
     return {
         "request_timeout_ms": settings.llm_timeout_ms,
         "llm_model": settings.llm_model,
+        "user_role": settings.user_role,
     }

--- a/apps/backend/backend/routers/tts.py
+++ b/apps/backend/backend/routers/tts.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, constr
 
 from ..config import settings
 from ..logging import logger
+from ..permissions import ensure_ai_access
 
 try:
     from openai import (  # type: ignore
@@ -106,6 +107,7 @@ def _map_openai_exception(exc: Exception) -> tuple[int, str, str]:
 @router.post("", response_class=StreamingResponse)
 def synth(req: TTSIn, request: Request) -> StreamingResponse:
     """Synthesize speech using OpenAI TTS and stream MP3 audio to the client."""
+    ensure_ai_access()
     t0 = time.perf_counter()
     request_id = _loggable_request_id(request)
     text_chars = len(req.text)

--- a/apps/backend/backend/routers/word.py
+++ b/apps/backend/backend/routers/word.py
@@ -12,6 +12,7 @@ from ..config import settings
 from ..flows.word_pack import WordPackFlow
 from ..providers import get_llm_provider
 from ..logging import logger
+from ..permissions import ensure_ai_access
 from ..models.word import (
     WordPack,
     ExampleCategory,
@@ -62,6 +63,7 @@ async def create_empty_word_pack(req: WordPackCreateRequest) -> dict:
     - sense_title は日本語の短い見出しを優先（LLM）。失敗時のフォールバックは choose_sense_title。
     - 保存ID（wp:{lemma}:{短縮uuid}）を返す
     """
+    ensure_ai_access()
     lemma = req.lemma.strip()
     if not lemma:
         raise HTTPException(status_code=400, detail="lemma is required")
@@ -149,6 +151,7 @@ async def generate_word_pack(req: WordPackRequest) -> WordPack:
     情報は空値で返す。
     生成されたWordPackは自動的にデータベースに保存される。
     """
+    ensure_ai_access()
     # 近傍検索クライアントは使用しない
     chroma_client = None
     # リクエストでモデル/パラメータが指定されていればオーバーライド
@@ -404,6 +407,7 @@ async def regenerate_word_pack(
     word_pack_id: str, req: WordPackRegenerateRequest
 ) -> WordPack:
     """既存のWordPackを再生成する。"""
+    ensure_ai_access()
     # 既存のWordPackを取得してlemmaを取得
     result = store.get_word_pack(word_pack_id)
     if result is None:
@@ -564,6 +568,7 @@ async def generate_examples_for_word_pack(
 
     既存の例文データはプロンプトに含めず、入力トークンを削減する。
     """
+    ensure_ai_access()
     result = store.get_word_pack(word_pack_id)
     if result is None:
         raise HTTPException(status_code=404, detail="WordPack not found")

--- a/apps/frontend/src/SettingsContext.tsx
+++ b/apps/frontend/src/SettingsContext.tsx
@@ -12,6 +12,7 @@ export interface Settings {
   reasoningEffort?: 'minimal' | 'low' | 'medium' | 'high';
   textVerbosity?: 'low' | 'medium' | 'high';
   theme: 'light' | 'dark';
+  userRole: 'admin' | 'viewer';
 }
 
 interface SettingsValue {
@@ -50,6 +51,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
       reasoningEffort: 'minimal',
       textVerbosity: 'medium',
       theme: savedTheme === 'light' ? 'light' : 'dark',
+      userRole: 'admin',
     };
   });
   const [status, setStatus] = useState<SettingsStatus>('loading');
@@ -74,7 +76,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
           const hint = bodyText ? ` body=${bodyText}` : '';
           throw new Error(`Failed to load /api/config: ${res.status}${hint}`);
         }
-        const json = (await res.json()) as { request_timeout_ms?: number; llm_model?: string };
+        const json = (await res.json()) as { request_timeout_ms?: number; llm_model?: string; user_role?: string };
         const ms = json.request_timeout_ms;
         if (!aborted && typeof ms === 'number' && Number.isFinite(ms)) {
           setSettings((prev) => ({ ...prev, requestTimeoutMs: ms }));
@@ -82,6 +84,10 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         const m = (json as any).llm_model;
         if (!aborted && typeof m === 'string' && m) {
           setSettings((prev) => ({ ...prev, model: prev.model || m }));
+        }
+        const role = (json as any).user_role;
+        if (!aborted && (role === 'admin' || role === 'viewer')) {
+          setSettings((prev) => ({ ...prev, userRole: role }));
         }
         if (!aborted) {
           setStatus('ready');

--- a/apps/frontend/src/components/TTSButton.tsx
+++ b/apps/frontend/src/components/TTSButton.tsx
@@ -11,9 +11,11 @@ type Props = {
 export function TTSButton({ text, className, voice = 'alloy', style }: Props) {
   const [loading, setLoading] = useState(false);
   let contextApiBase: string | undefined;
+  let contextUserRole: 'admin' | 'viewer' = 'admin';
   try {
     const { settings } = useSettings();
     contextApiBase = settings.apiBase;
+    contextUserRole = settings.userRole;
   } catch (err) {
     contextApiBase = undefined;
   }
@@ -23,8 +25,15 @@ export function TTSButton({ text, className, voice = 'alloy', style }: Props) {
     return `${normalized}/tts`;
   }, [contextApiBase]);
 
+  const aiDisabled = contextUserRole === 'viewer';
+  const buttonDisabled = aiDisabled || loading || !text?.trim();
+  const combinedStyle = {
+    ...style,
+    ...(aiDisabled ? { opacity: 0.5, cursor: 'not-allowed' } : {}),
+  } satisfies CSSProperties;
+
   const speak = async () => {
-    if (loading) return;
+    if (aiDisabled || loading) return;
     const trimmed = text?.trim();
     if (!trimmed) return;
     if (typeof window === 'undefined' || typeof Audio === 'undefined') {
@@ -64,10 +73,11 @@ export function TTSButton({ text, className, voice = 'alloy', style }: Props) {
     <button
       type="button"
       onClick={speak}
-      disabled={loading || !text?.trim()}
+      disabled={buttonDisabled}
       className={className}
       data-testid="speak-btn"
-      style={style}
+      style={combinedStyle}
+      title={aiDisabled ? '閲覧ユーザーは音声機能を利用できません' : undefined}
     >
       {loading ? '読み上げ中…' : '音声'}
     </button>

--- a/docs/環境変数の意味.md
+++ b/docs/環境変数の意味.md
@@ -21,6 +21,37 @@
 
 ---
 
+### 1.5) USER_ROLE
+- 用途: 管理者（`admin`）と閲覧専用ユーザー（`viewer`）を切り替える。`viewer` の場合、LLM/TTS など API キーを必要とする機能をバックエンドが 403 で遮断し、フロントエンドも対応UIをグレーアウトして無効化する。
+- 既定値: env.example=`admin` / コード既定=`"admin"`
+- 使われ方:
+```83:90:apps/backend/backend/config.py
+    user_role: Literal["admin", "viewer"] = Field(
+        default="admin",
+        description="Current user role / 現在のユーザーロール (admin|viewer)",
+    )
+```
+```12:29:apps/backend/backend/permissions.py
+def ensure_ai_access() -> None:
+    """Raise 403 when AI features are disabled for the current user role."""
+    if settings.user_role == "viewer":
+        raise HTTPException(
+            status_code=403,
+            detail="AI features are disabled for viewer role",
+        )
+```
+```29:49:apps/frontend/src/components/ArticleImportPanel.tsx
+  const aiFeaturesDisabled = settings.userRole === 'viewer';
+  const aiUnavailableMessage = '閲覧ユーザーはAI生成機能を利用できません';
+  const aiDisabledStyle: CSSProperties | undefined = aiFeaturesDisabled
+    ? { opacity: 0.5, cursor: 'not-allowed' }
+    : undefined;
+```
+- 未設定/誤設定: 未設定・その他の値は `admin` として扱われ、従来通りの操作が可能。
+- 設定例: 閲覧専用環境では `.env` に `USER_ROLE=viewer` を指定し、生成系機能を無効化する。
+
+---
+
 ### 2) LLM_PROVIDER, LLM_MODEL, LLM_TIMEOUT_MS, LLM_MAX_RETRIES, LLM_MAX_TOKENS
 - 用途:
   - `LLM_PROVIDER`: LLM クライアントの選択。`openai` | `local`

--- a/env.example
+++ b/env.example
@@ -2,6 +2,9 @@
 ENVIRONMENT=development
 STRICT_MODE=true
 
+# User role: admin has full access, viewer disables AI-powered features
+USER_ROLE=admin
+
 # LLM providers: openai | local
 LLM_PROVIDER=openai
 LLM_MODEL=gpt-4o-mini


### PR DESCRIPTION
## 概要
- Settings.user_role を追加し、env.example やドキュメントを更新してユーザーロールを構成できるようにしました
- バックエンドに ensure_ai_access を導入し、記事生成・WordPack生成・TTS エンドポイントを閲覧専用ロールで 403 にするよう変更しました
- /api/config で user_role を返却し、フロントエンド設定へ同期して UI から LLM/TTS 操作をグレーアウトするようにしました
- ArticleImportPanel, WordPackPanel, WordPackListPanel, TTSButton などで閲覧ユーザー時のガードと無効化表示を実装しました

## テスト
- `npx vitest run src/components/TTSButton.test.tsx src/components/ArticleImportPanel.test.tsx src/components/WordPackPanel.test.tsx src/WordPackListPanel.actions-layout.test.tsx`
- `npx vitest run src/WordPackPanel.test.tsx`
- `npx vitest run src/ArticleImportPanel.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68dbde2279a8832caed682c5241ba27f