### PR TITLE
Google OAuth セッション認証の導入と保護 API の強化

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ npm install
 ```bash
 cp env.example .env
 # .env に OPENAI_API_KEY を設定
+# Google ログインを利用する場合は以下も設定（ドメイン制限は任意）
+# GOOGLE_CLIENT_ID=12345-abcdefgh.apps.googleusercontent.com
+# GOOGLE_ALLOWED_HD=example.com
+# SESSION_SECRET_KEY=change-me-to-random-value
+# SESSION_COOKIE_NAME=wp_session
+# SESSION_COOKIE_SECURE=false  # ローカルHTTPでCookieを試す場合のみ
 ```
 
 ### 起動

--- a/apps/backend/backend/auth.py
+++ b/apps/backend/backend/auth.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import HTTPException, Request, status
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+
+from .config import settings
+from .logging import logger
+from .store import store
+
+_SESSION_SALT = "wordpack.session"
+
+
+def _build_serializer() -> URLSafeTimedSerializer:
+    """Construct a serializer for signing and verifying session tokens."""
+
+    secret = settings.session_secret_key.strip()
+    if not secret:
+        raise RuntimeError("SESSION_SECRET_KEY is not configured")
+    return URLSafeTimedSerializer(secret, salt=_SESSION_SALT)
+
+
+def _session_max_age() -> int:
+    """Return the configured session lifetime in seconds."""
+
+    try:
+        max_age = int(getattr(settings, "session_max_age_seconds", 0))
+    except (TypeError, ValueError):  # pragma: no cover - defensive fallback
+        max_age = 0
+    return max(60, max_age or 60 * 60 * 24 * 14)
+
+
+def issue_session_token(google_sub: str) -> str:
+    """Generate a signed session token tied to the Google subject identifier."""
+
+    serializer = _build_serializer()
+    payload = {
+        "sid": uuid.uuid4().hex,
+        "sub": google_sub,
+        "issued_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
+    }
+    return serializer.dumps(payload)
+
+
+def verify_session_token(token: str) -> dict:
+    """Decode a signed session token and return the embedded payload."""
+
+    serializer = _build_serializer()
+    return serializer.loads(token, max_age=_session_max_age())
+
+
+async def get_current_user(request: Request) -> dict[str, str]:
+    """Validate session cookie and attach the authenticated user to the request state."""
+
+    cookie_name = settings.session_cookie_name or "wp_session"
+    raw_token = request.cookies.get(cookie_name)
+    if not raw_token:
+        logger.warning(
+            "session_validation_failed",
+            user_id=None,
+            reason="missing_cookie",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session cookie is missing",
+        )
+
+    try:
+        payload = verify_session_token(raw_token)
+    except SignatureExpired as exc:
+        logger.warning(
+            "session_validation_failed",
+            user_id=None,
+            reason="expired",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Session expired",
+        ) from exc
+    except BadSignature as exc:
+        logger.warning(
+            "session_validation_failed",
+            user_id=None,
+            reason="bad_signature",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid session token",
+        ) from exc
+    except RuntimeError as exc:
+        logger.error(
+            "session_validation_failed",
+            user_id=None,
+            reason="configuration_error",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Session configuration error",
+        ) from exc
+
+    sub = payload.get("sub") if isinstance(payload, dict) else None
+    if not sub:
+        logger.warning(
+            "session_validation_failed",
+            user_id=None,
+            reason="missing_sub",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid session payload",
+        )
+
+    user = store.get_user_by_google_sub(sub)
+    if user is None:
+        logger.warning(
+            "session_validation_failed",
+            user_id=sub,
+            reason="user_not_found",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+        )
+
+    request.state.user = user
+    request.state.user_id = sub
+    return user

--- a/apps/backend/backend/config.py
+++ b/apps/backend/backend/config.py
@@ -18,6 +18,30 @@ class Settings(BaseSettings):
         default="development",
         description="Runtime environment / 実行環境",
     )
+    google_client_id: str = Field(
+        default="",
+        description="Google OAuth client ID / Googleサインイン用クライアントID",
+    )
+    google_allowed_hd: str | None = Field(
+        default=None,
+        description="Optional allowed Google Workspace domain / 許可するGoogle Workspaceドメイン",
+    )
+    session_secret_key: str = Field(
+        default="",
+        description="Secret key for signing session cookies / セッションクッキー署名用シークレット",
+    )
+    session_cookie_name: str = Field(
+        default="wp_session",
+        description="Session cookie name / セッションクッキー名",
+    )
+    session_cookie_secure: bool = Field(
+        default=True,
+        description="Whether to mark session cookie as Secure / セッションクッキーにSecure属性を付与するか",
+    )
+    session_max_age_seconds: int = Field(
+        default=60 * 60 * 24 * 14,
+        description="Session lifetime in seconds / セッションの寿命（秒）",
+    )
     llm_provider: str = Field(
         default="openai",
         description="LLM service provider / 利用するLLMプロバイダ",

--- a/docs/環境変数の意味.md
+++ b/docs/環境変数の意味.md
@@ -21,6 +21,60 @@
 
 ---
 
+### 1.5) GOOGLE_CLIENT_ID / GOOGLE_ALLOWED_HD
+- 用途: Google サインインの ID トークン検証とドメイン制限。
+- 既定値: env.example=`GOOGLE_CLIENT_ID=`（空文字）, `# GOOGLE_ALLOWED_HD=`（未設定）。コード既定は `google_client_id=""`, `google_allowed_hd=None`。
+- 使われ方: Google から受け取った ID トークンを検証し、必要に応じて許可ドメインを照合します。
+```37:92:apps/backend/backend/routers/auth.py
+    if not settings.google_client_id:
+        ...
+    id_info = id_token.verify_oauth2_token(..., settings.google_client_id)
+    allowed_hd = (settings.google_allowed_hd or "").strip()
+    if allowed_hd and hosted_domain != allowed_hd:
+        raise HTTPException(status_code=HTTPStatus.FORBIDDEN, detail="Google account domain is not allowed")
+```
+- 未設定/誤設定:
+  - `GOOGLE_CLIENT_ID` が空のまま起動すると `/api/auth/google` が 500 を返却し、認証できません。
+  - `GOOGLE_ALLOWED_HD` を設定した場合は完全一致で照合されるため、Google Workspace ドメインと一致させる必要があります。
+- 設定例:
+  - 一般的な OAuth クライアント: `GOOGLE_CLIENT_ID=12345-abcdefgh.apps.googleusercontent.com`
+  - ドメイン制限を掛ける場合: `GOOGLE_ALLOWED_HD=example.com`
+
+---
+
+### 1.6) SESSION_SECRET_KEY / SESSION_COOKIE_NAME / SESSION_COOKIE_SECURE / SESSION_MAX_AGE_SECONDS
+- 用途: 署名付きセッショントークンの生成と検証、Cookie 名称・寿命の制御。
+- 既定値: env.example=`SESSION_SECRET_KEY=change-me`, `SESSION_COOKIE_NAME=wp_session`, `# SESSION_COOKIE_SECURE=true`, `# SESSION_MAX_AGE_SECONDS=1209600`。コード既定は `session_secret_key=""`, `session_cookie_name="wp_session"`, `session_cookie_secure=True`, `session_max_age_seconds=1209600`。
+- 使われ方: セッションシリアライザの初期化と HTTP 応答での Set-Cookie 設定に利用されます。
+```21:44:apps/backend/backend/auth.py
+def _build_serializer() -> URLSafeTimedSerializer:
+    secret = settings.session_secret_key.strip()
+    if not secret:
+        raise RuntimeError("SESSION_SECRET_KEY is not configured")
+    return URLSafeTimedSerializer(secret, salt=_SESSION_SALT)
+```
+```102:110:apps/backend/backend/routers/auth.py
+response.set_cookie(
+    key=settings.session_cookie_name or "wp_session",
+    value=session_token,
+    httponly=True,
+    secure=settings.session_cookie_secure,
+    samesite="lax",
+    max_age=_session_cookie_max_age(),
+)
+```
+- 未設定/誤設定:
+  - `SESSION_SECRET_KEY` が空の場合はログイン時に 500（configuration error）。実運用では十分な長さのランダム文字列を設定してください。
+  - `SESSION_COOKIE_SECURE` は既定で True。ローカル HTTP 開発で Cookie を送る必要がある場合は `.env` で `false` を指定します。
+  - `SESSION_MAX_AGE_SECONDS` は整数で指定。負数や文字列の場合は既定の 14 日間にフォールバックします。
+- 設定例:
+  - `SESSION_SECRET_KEY=base64-generated-secret`
+  - `SESSION_COOKIE_NAME=wp_session`
+  - 開発用途のみ: `SESSION_COOKIE_SECURE=false`
+  - 有効期限を 7 日に短縮: `SESSION_MAX_AGE_SECONDS=604800`
+
+---
+
 ### 2) LLM_PROVIDER, LLM_MODEL, LLM_TIMEOUT_MS, LLM_MAX_RETRIES, LLM_MAX_TOKENS
 - 用途:
   - `LLM_PROVIDER`: LLM クライアントの選択。`openai` | `local`

--- a/env.example
+++ b/env.example
@@ -2,6 +2,17 @@
 ENVIRONMENT=development
 STRICT_MODE=true
 
+# Google OAuth
+GOOGLE_CLIENT_ID=
+# Optional: Restrict sign-in to Google Workspace domain (example.com)
+# GOOGLE_ALLOWED_HD=
+
+# Session cookie (set strong secrets in production)
+SESSION_SECRET_KEY=change-me
+SESSION_COOKIE_NAME=wp_session
+# SESSION_COOKIE_SECURE=true
+# SESSION_MAX_AGE_SECONDS=1209600
+
 # LLM providers: openai | local
 LLM_PROVIDER=openai
 LLM_MODEL=gpt-4o-mini
@@ -18,7 +29,7 @@ EMBEDDING_MODEL=text-embedding-3-small
 # OpenAI
 OPENAI_API_KEY=
 
- 
+
 
 # Chroma (optional local persistence directory)
 CHROMA_PERSIST_DIR=.chroma

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ pydantic-settings
 pytest
 httpx
 pytest-cov
+google-auth
+itsdangerous
 langgraph
 chromadb
 cmudict

--- a/tests/backend/test_auth_google.py
+++ b/tests/backend/test_auth_google.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from http.cookies import SimpleCookie
+from pathlib import Path
+from typing import Callable
+
+from http.cookies import SimpleCookie
+from http.cookies import SimpleCookie
+from pathlib import Path
+from typing import Callable
+
+import pytest
+from fastapi.testclient import TestClient
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps" / "backend"))
+
+from backend.config import settings
+from backend.main import create_app
+from backend.store import AppSQLiteStore
+
+
+@pytest.fixture()
+def test_client(tmp_path, monkeypatch) -> TestClient:
+    """Create an isolated FastAPI test client with a dedicated SQLite store."""
+
+    db_path = tmp_path / "auth.sqlite3"
+    store_instance = AppSQLiteStore(str(db_path))
+
+    import backend.store as store_module
+    import backend.auth as auth_module
+    import backend.routers.auth as auth_router_module
+    import backend.routers.word as word_router_module
+    import backend.routers.article as article_router_module
+    monkeypatch.setattr(store_module, "store", store_instance)
+    monkeypatch.setattr(auth_module, "store", store_instance)
+    monkeypatch.setattr(auth_router_module, "store", store_instance)
+    monkeypatch.setattr(word_router_module, "store", store_instance)
+    monkeypatch.setattr(article_router_module, "store", store_instance)
+
+    monkeypatch.setattr(settings, "google_client_id", "test-client-id")
+    monkeypatch.setattr(settings, "google_allowed_hd", "example.com")
+    monkeypatch.setattr(settings, "session_secret_key", "super-secret-key")
+    monkeypatch.setattr(settings, "session_cookie_name", "wp_session_test")
+    monkeypatch.setattr(settings, "session_cookie_secure", False)
+    monkeypatch.setattr(settings, "session_max_age_seconds", 3600)
+    monkeypatch.setattr(settings, "strict_mode", False)
+
+    # Recreate the app after patching shared modules to ensure new dependencies are wired.
+    app = create_app()
+    return TestClient(app)
+
+
+def _stub_verifier(monkeypatch: pytest.MonkeyPatch, factory: Callable[[], dict[str, str]]) -> None:
+    from google.oauth2 import id_token
+
+    def _verify(token: str, request: object, audience: str) -> dict[str, str]:
+        assert audience == settings.google_client_id
+        return factory()
+
+    monkeypatch.setattr(id_token, "verify_oauth2_token", _verify)
+
+
+def test_google_auth_success_flow(test_client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Successful Google sign-in returns cookie and allows protected access."""
+
+    _stub_verifier(
+        monkeypatch,
+        lambda: {
+            "sub": "sub-123",
+            "email": "user@example.com",
+            "name": "Example User",
+            "hd": "example.com",
+        },
+    )
+
+    login_response = test_client.post("/api/auth/google", json={"id_token": "valid"})
+    assert login_response.status_code == 200
+    body = login_response.json()
+    assert body["user"]["google_sub"] == "sub-123"
+    assert "last_login_at" in body["user"]
+
+    cookie = SimpleCookie()
+    cookie.load(login_response.headers["set-cookie"])
+    assert settings.session_cookie_name in cookie
+
+    protected = test_client.get("/api/word/")
+    assert protected.status_code in {200, 501}
+    # Both 200 (non-strict) and 501 (strict placeholder) imply auth succeeded; ensure not 401.
+    assert protected.status_code != 401
+
+
+def test_google_auth_rejects_wrong_domain(
+    test_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Hosted domain mismatch should result in HTTP 403."""
+
+    _stub_verifier(
+        monkeypatch,
+        lambda: {
+            "sub": "sub-456",
+            "email": "user@other.com",
+            "name": "Other Domain",
+            "hd": "other.com",
+        },
+    )
+
+    resp = test_client.post("/api/auth/google", json={"id_token": "valid"})
+    assert resp.status_code == 403
+
+
+def test_google_auth_invalid_signature(
+    test_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Invalid token signature should produce HTTP 401."""
+
+    from google.oauth2 import id_token
+
+    def _raise(token: str, request: object, audience: str) -> dict[str, str]:
+        raise ValueError("bad signature")
+
+    monkeypatch.setattr(id_token, "verify_oauth2_token", _raise)
+
+    resp = test_client.post("/api/auth/google", json={"id_token": "invalid"})
+    assert resp.status_code == 401
+
+
+def test_protected_endpoint_requires_cookie(test_client: TestClient) -> None:
+    """Requests without a valid session cookie must fail with 401."""
+
+    # Ensure cookie jar is cleared before hitting protected endpoint
+    test_client.cookies.clear()
+    resp = test_client.get("/api/word/")
+    assert resp.status_code == 401


### PR DESCRIPTION
## 概要
- Google OAuth クライアント設定とセッショントークン署名キーを環境変数・設定に追加
- Google ログイン API とセッション検証依存を実装し、既存の保護 API に適用
- ユーザ永続化と認証テストを整備し、関連ドキュメントを更新

## テスト
- pytest tests/backend/test_auth_google.py -q --cov-fail-under=0

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f03f22e48832ca6a4270eee26fd25)