### PR TITLE
Chromium フォールバックと共有ライブラリ不足時のスキップ制御を改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ __pycache__/
 # App runtime data
 .data/
 
+.cache/
+
 *.sqlite3
 
 # Vector DB (Chroma) persistence - do not commit generated index data

--- a/README.md
+++ b/README.md
@@ -123,4 +123,4 @@ docs/                   # 詳細ドキュメント
 ## 追加ドキュメント
 - 詳細な API・フロー・モデルは `docs/flows.md`, `docs/models.md`, `docs/環境変数の意味.md` を参照してください。
 - ユーザー向け操作は `UserManual.md` を参照してください。
-- GitHub Actions の CI では Chrome DevTools MCP を利用した UI スモークテスト（`UI smoke test (Chrome DevTools MCP)` ジョブ）が自動実行されます。ローカルで同じシナリオを再現する方法は `docs/testing/chrome-devtools-mcp-ui-testing.md` を参照してください（Node.js 22 + `tests/ui/mcp-smoke/run-smoke.mjs` を用いた再現手順を含みます）。
+- GitHub Actions の CI では Chrome DevTools MCP を利用した UI スモークテスト（`UI smoke test (Chrome DevTools MCP)` ジョブ）が自動実行されます。ローカルで同じシナリオを再現する方法は `docs/testing/chrome-devtools-mcp-ui-testing.md` を参照してください（Node.js 22 を用い、ルートディレクトリで `npm run smoke` または `tests/ui/mcp-smoke/run-smoke.mjs` を実行する手順を含みます）。Chrome 未インストール環境でも安定版 Chrome の自動取得を試み、許可されない場合は OSS Chromium へのフォールバックを順番に実施します。いずれもダウンロードできなかった場合は `CHROME_EXECUTABLE` で既存バイナリを指定しない限りローカル実行のみスキップする挙動です。

--- a/apps/frontend/src/__tests__/AuthContext.test.tsx
+++ b/apps/frontend/src/__tests__/AuthContext.test.tsx
@@ -1,0 +1,88 @@
+import { render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { vi } from 'vitest';
+import { AuthProvider } from '../AuthContext';
+
+vi.mock('@react-oauth/google', () => ({
+  GoogleOAuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('AuthProvider logging behaviour', () => {
+  // 新規参画者向けメモ: 認証バイパス有効時のログレベル切り替えを固定するための回帰テスト。
+  // バイパス環境では error を抑制し warn に切り替わることをここで保証する。
+  let fetchMock: vi.MockedFunction<typeof fetch>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    (globalThis as unknown as { fetch: typeof fetch }).fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const renderProvider = () => {
+    render(
+      <AuthProvider clientId="">
+        <div data-testid="auth-provider-child" />
+      </AuthProvider>,
+    );
+  };
+
+  it('prefers console.warn when bypass mode supplies a development credential', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    fetchMock.mockImplementation((input) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : '';
+      if (url.endsWith('/api/config')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ session_auth_disabled: true }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }));
+    });
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('VITE_GOOGLE_CLIENT_ID is not set; Google login will not work.'),
+      );
+    });
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to console.error when bypass is not available', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    fetchMock.mockImplementation((input) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : '';
+      if (url.endsWith('/api/config')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({}), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }));
+    });
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        'VITE_GOOGLE_CLIENT_ID is not set; Google login will not work.',
+      );
+    });
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Authentication bypass is active; continuing with development fallback.'),
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "wordpack-monorepo-tools",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "smoke": "npm run smoke --prefix tests/ui/mcp-smoke"
+  }
+}

--- a/tests/ui/mcp-smoke/package-lock.json
+++ b/tests/ui/mcp-smoke/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.18.2",
+        "@puppeteer/browsers": "^2.4.0",
         "chrome-devtools-mcp": "^0.4.0"
       },
       "engines": {

--- a/tests/ui/mcp-smoke/package.json
+++ b/tests/ui/mcp-smoke/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.18.2",
+    "@puppeteer/browsers": "^2.4.0",
     "chrome-devtools-mcp": "^0.4.0"
   }
 }


### PR DESCRIPTION
## 概要
- Chrome の自動ダウンロードが 403 で失敗した場合に OSS Chromium を段階的に取得するフォールバックを追加しました
- Chromium 起動時に共有ライブラリ不足で即時終了した際はローカル環境のみスキップし、解決策を警告ログに表示するようにしました
- README と Chrome DevTools MCP 手順書へ新しいフォールバック順序とスキップ条件を反映しました

## テスト
- npm run smoke（Chromium ダウンロード後に共有ライブラリ不足を検出して警告スキップ、終了コード0を確認）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f61996d84832c9b056f35ce8a773d)