### PR TITLE
Google認証失敗ログの詳細化とテスト整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ docker compose up --build
 ### トラブルシューティング
 - **ID トークンが取得できない**: ログイン画面に「ID トークンを取得できませんでした。ブラウザを更新して再試行してください。」と表示された場合は、ブラウザを更新してから再度サインインしてください。それでも解消しない場合は Google OAuth のクライアント ID や承認済みオリジン設定を確認し、バックエンドのターミナルへ出力される `google_login_missing_id_token` ログで `google_client_id` や `error_category` を突き合わせて原因を特定します。テレメトリは `/api/diagnostics/oauth-telemetry` で受信した値をマスクした形で保存されるため、生のトークン値は記録されません。
 
+#### Google 認証失敗時のログキー
+- `event`: 常に `google_auth_failed` または `google_auth_denied` が設定されます。
+- `reason`: 失敗理由。`invalid_token`（署名検証エラー）、`missing_claims`（`sub`/`email` が欠落）や `domain_mismatch`（許可ドメイン不一致）など。
+- `error`: Google SDK から受け取った例外メッセージの `repr`。署名不正などの詳細を確認できます。
+- `missing_claims`: 欠落していたクレームの配列。例: `['email']`。
+- `hosted_domain`: ID トークンに含まれていた `hd`（`hostedDomain`）値。
+- `allowed_domain`: 設定ファイル（`GOOGLE_ALLOWED_HD`）で許可しているドメイン。`None` の場合はドメイン制限が無効。
+- `email_hash`: メールアドレスを小文字化し SHA-256 でハッシュ化した先頭12文字。個人情報を露出させずに該当アカウントを突き合わせる目的で使用します。
+
 ## テスト
 - Backend（Python）
 ```bash


### PR DESCRIPTION
1. `apps/backend/backend/routers/auth.py` の `except ValueError as exc:` 節で `logger.warning(..., error=repr(exc))` を追加し、Google SDK のメッセージを記録する。PII を含む `id_info` 全体は出力しない。
2. `missing_claims` や `domain_mismatch` の分岐では、欠落していたクレーム名 (`missing_claims=['sub','email']` 等) や受信した `hosted_domain`／許可ドメインをログに含める。メールアドレスなどはハッシュ化して記録する。
3. 新しいログフィールドに合わせて `tests/test_api.py` などの既存テストを更新し、ログキャプチャで期待キーが含まれるかを確認する。必要に応じて新しい単体テストを追加する。
4. ログ項目が増えるため README.md の運用/トラブルシューティング節に「Google 認証失敗時のログキー」の一覧を追記し、SRE が参照できるようにする。

---

Summary

authenticate_with_google を拡張し、Google SDK 例外の error、不足クレーム一覧、受信/許可ドメイン、ハッシュ化したメールアドレスなどを警告ログに含めるとともに、PII を安全に扱う _hash_for_log ヘルパーを追加しました。

Google 認証テストで構造化ログを解析する補助関数を実装し、ドメイン不一致・署名不正・必須クレーム欠落の各ケースで新しいログキーが出力されることを検証するテストを整備しました。

API 統合テスト群に Structlog 抽出ヘルパーと stderr フォールバック処理を追加し、Google 認証失敗時ログに invalid_token 理由と例外情報が含まれることを確認する新テストを追加、既存フィクスチャではセッション認証を無効化して動作を安定化させました。

README のトラブルシューティングに Google 認証失敗時のログキー一覧を追記し、SRE が参照すべき項目を整理しました。

---


## 概要
- Google 認証失敗時のログに error・missing_claims・ドメイン情報などのキーを追加し、メールアドレスはハッシュ化して記録するよう更新
- ログ出力内容を検証するユニットテストを追加し、構造化ログが caplog/capfd で取得できるよう補助関数を実装
- README のトラブルシューティング節に Google 認証失敗時のログキー一覧を追記

## テスト
- pytest tests/backend/test_auth_google.py tests/test_api.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691012450fe8832cb7747eb690e8f674)