### PR TITLE
Appプロバイダー構成の刷新とテスト調整

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -7,10 +7,6 @@ import { WordPackListPanel } from './components/WordPackListPanel';
 import { ExampleListPanel } from './components/ExampleListPanel';
 import { ArticleImportPanel } from './components/ArticleImportPanel';
 import { ArticleListPanel } from './components/ArticleListPanel';
-import { SettingsProvider } from './SettingsContext';
-import { ModalProvider } from './ModalContext';
-import { ConfirmDialogProvider } from './ConfirmDialogContext';
-import { NotificationsProvider } from './NotificationsContext';
 import { NotificationsOverlay } from './components/NotificationsOverlay';
 import { useSettings } from './SettingsContext';
 import { SIDEBAR_PORTAL_CONTAINER_ID } from './components/SidebarPortal';
@@ -524,17 +520,11 @@ export const App: React.FC = () => {
   );
 
   return (
-    <SettingsProvider>
-      <ModalProvider>
-        <ConfirmDialogProvider>
-          <NotificationsProvider>
-            <ThemeApplier />
-            {appContent}
-            <NotificationsOverlay />
-          </NotificationsProvider>
-        </ConfirmDialogProvider>
-      </ModalProvider>
-    </SettingsProvider>
+    <>
+      <ThemeApplier />
+      {appContent}
+      <NotificationsOverlay />
+    </>
   );
 };
 

--- a/apps/frontend/src/ArticleImportPanel.test.tsx
+++ b/apps/frontend/src/ArticleImportPanel.test.tsx
@@ -2,8 +2,8 @@ import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
-import { AuthProvider } from './AuthContext';
 import { App } from './App';
+import { AppProviders } from './main';
 
 describe('ArticleImportPanel model/params wiring (mocked fetch)', () => {
   beforeEach(() => {
@@ -26,9 +26,9 @@ describe('ArticleImportPanel model/params wiring (mocked fetch)', () => {
 
   const renderWithAuth = () =>
     render(
-      <AuthProvider clientId="test-client">
+      <AppProviders googleClientId="test-client">
         <App />
-      </AuthProvider>,
+      </AppProviders>,
     );
 
   function setupFetchMocks() {

--- a/apps/frontend/src/ArticleListPanel.test.tsx
+++ b/apps/frontend/src/ArticleListPanel.test.tsx
@@ -2,8 +2,8 @@ import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
-import { AuthProvider } from './AuthContext';
 import { App } from './App';
+import { AppProviders } from './main';
 
 describe('ArticleListPanel bulk delete', () => {
   beforeEach(() => {
@@ -27,9 +27,9 @@ describe('ArticleListPanel bulk delete', () => {
 
   const renderWithAuth = () =>
     render(
-      <AuthProvider clientId="test-client">
+      <AppProviders googleClientId="test-client">
         <App />
-      </AuthProvider>,
+      </AppProviders>,
     );
 
   function setupFetchMocks() {

--- a/apps/frontend/src/ExampleListPanel.test.tsx
+++ b/apps/frontend/src/ExampleListPanel.test.tsx
@@ -2,8 +2,8 @@ import { render, screen, act, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
-import { AuthProvider } from './AuthContext';
 import { App } from './App';
+import { AppProviders } from './main';
 
 describe('ExampleListPanel pagination offset behavior', () => {
   beforeEach(() => {
@@ -28,9 +28,9 @@ describe('ExampleListPanel pagination offset behavior', () => {
 
   const renderWithAuth = () =>
     render(
-      <AuthProvider clientId="test-client">
+      <AppProviders googleClientId="test-client">
         <App />
-      </AuthProvider>,
+      </AppProviders>,
     );
 
   const openTab = async (user: ReturnType<typeof userEvent.setup>, label: string) => {

--- a/apps/frontend/src/WordPackListPanel.actions-layout.test.tsx
+++ b/apps/frontend/src/WordPackListPanel.actions-layout.test.tsx
@@ -2,8 +2,8 @@ import { render, screen, waitFor, within, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
-import { AuthProvider } from './AuthContext';
 import { App } from './App';
+import { AppProviders } from './main';
 
 describe('WordPackListPanel card actions layout (two rows)', () => {
   beforeEach(() => {
@@ -29,9 +29,9 @@ describe('WordPackListPanel card actions layout (two rows)', () => {
 
   function renderWithAuth() {
     return render(
-      <AuthProvider clientId="test-client">
+      <AppProviders googleClientId="test-client">
         <App />
-      </AuthProvider>,
+      </AppProviders>,
     );
   }
 

--- a/apps/frontend/src/WordPackListPanel.bulk-delete.test.tsx
+++ b/apps/frontend/src/WordPackListPanel.bulk-delete.test.tsx
@@ -2,8 +2,8 @@ import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
-import { AuthProvider } from './AuthContext';
 import { App } from './App';
+import { AppProviders } from './main';
 
 describe('WordPackListPanel bulk delete', () => {
   beforeEach(() => {
@@ -29,9 +29,9 @@ describe('WordPackListPanel bulk delete', () => {
 
   function renderWithAuth() {
     return render(
-      <AuthProvider clientId="test-client">
+      <AppProviders googleClientId="test-client">
         <App />
-      </AuthProvider>,
+      </AppProviders>,
     );
   }
 

--- a/apps/frontend/src/WordPackListPanel.modal.test.tsx
+++ b/apps/frontend/src/WordPackListPanel.modal.test.tsx
@@ -2,8 +2,8 @@ import { render, screen, act, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
-import { AuthProvider } from './AuthContext';
 import { App } from './App';
+import { AppProviders } from './main';
 
 describe('WordPackListPanel modal preview', () => {
   beforeEach(() => {
@@ -31,9 +31,9 @@ describe('WordPackListPanel modal preview', () => {
 
   function renderWithAuth() {
     return render(
-      <AuthProvider clientId="test-client">
+      <AppProviders googleClientId="test-client">
         <App />
-      </AuthProvider>,
+      </AppProviders>,
     );
   }
 

--- a/apps/frontend/src/WordPackPanel.test.tsx
+++ b/apps/frontend/src/WordPackPanel.test.tsx
@@ -2,8 +2,8 @@ import { render, screen, act, waitFor, within, fireEvent } from '@testing-librar
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
-import { AuthProvider } from './AuthContext';
 import { App } from './App';
+import { AppProviders } from './main';
 
 describe('WordPackPanel E2E (mocked fetch)', () => {
   beforeEach(() => {
@@ -29,9 +29,9 @@ describe('WordPackPanel E2E (mocked fetch)', () => {
 
   function renderWithAuth() {
     return render(
-      <AuthProvider clientId="test-client">
+      <AppProviders googleClientId="test-client">
         <App />
-      </AuthProvider>,
+      </AppProviders>,
     );
   }
 

--- a/apps/frontend/src/__tests__/AuthContext.test.tsx
+++ b/apps/frontend/src/__tests__/AuthContext.test.tsx
@@ -2,6 +2,7 @@ import { render, waitFor, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 import { vi } from 'vitest';
+import type { MockedFunction } from 'vitest';
 import { AuthProvider, useAuth } from '../AuthContext';
 
 const googleProviderMock = vi.fn(({ children }: { children: React.ReactNode }) => <>{children}</>);
@@ -18,7 +19,7 @@ const MissingFlagProbe: React.FC = () => {
 describe('AuthProvider logging behaviour', () => {
   // 新規参画者向けメモ: 認証バイパス有効時のログレベル切り替えを固定するための回帰テスト。
   // バイパス環境では error を抑制し warn に切り替わることをここで保証する。
-  let fetchMock: vi.MockedFunction<typeof fetch>;
+  let fetchMock: MockedFunction<typeof fetch>;
 
   beforeEach(() => {
     fetchMock = vi.fn();
@@ -60,7 +61,7 @@ describe('AuthProvider logging behaviour', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
-    fetchMock.mockImplementation((input) => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input instanceof Request ? input.url : '';
       if (url.endsWith('/api/config')) {
         return Promise.resolve(
@@ -87,7 +88,7 @@ describe('AuthProvider logging behaviour', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
-    fetchMock.mockImplementation((input) => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input instanceof Request ? input.url : '';
       if (url.endsWith('/api/config')) {
         return Promise.resolve(

--- a/apps/frontend/src/env.d.ts
+++ b/apps/frontend/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -1,14 +1,51 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import type { ReactNode } from 'react';
 import { App } from './App';
 import { AuthProvider } from './AuthContext';
+import { SettingsProvider } from './SettingsContext';
+import { ModalProvider } from './ModalContext';
+import { ConfirmDialogProvider } from './ConfirmDialogContext';
+import { NotificationsProvider } from './NotificationsContext';
 
-const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID ?? '';
+const defaultGoogleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID ?? '';
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
-    <AuthProvider clientId={googleClientId}>
-      <App />
+interface AppProvidersProps {
+  children: ReactNode;
+  googleClientId?: string;
+}
+
+/**
+ * アプリ全体で共有するコンテキストをまとめてラップする。
+ * なぜ: 認証・設定・モーダル・通知などの横断的な状態を入口で集約し、
+ *       App コンポーネントを描画専用の責務へ限定するため。
+ */
+export const AppProviders: React.FC<AppProvidersProps> = ({
+  children,
+  googleClientId,
+}) => {
+  const resolvedClientId = googleClientId ?? defaultGoogleClientId;
+  return (
+    <AuthProvider clientId={resolvedClientId}>
+      <SettingsProvider>
+        <ModalProvider>
+          <ConfirmDialogProvider>
+            <NotificationsProvider>{children}</NotificationsProvider>
+          </ConfirmDialogProvider>
+        </ModalProvider>
+      </SettingsProvider>
     </AuthProvider>
-  </React.StrictMode>
-);
+  );
+};
+
+const container = document.getElementById('root');
+
+if (container) {
+  ReactDOM.createRoot(container).render(
+    <React.StrictMode>
+      <AppProviders>
+        <App />
+      </AppProviders>
+    </React.StrictMode>,
+  );
+}


### PR DESCRIPTION
## 概要
- App コンポーネントから Settings/Modal/ConfirmDialog/Notifications の各プロバイダーを外し、UI 描画専用コンポーネントへ整理しました
- main.tsx に AppProviders を追加し、AuthProvider 内部で他のコンテキストを順番にラップして <App /> を描画するようにしました
- フロントエンドのテスト群を AppProviders を利用した構成へ更新し、fetch モック型などの TypeScript 警告を解消しました

## テスト
- npm run test
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69105b13bd14832cb274469efca85868)