### PR TITLE
学習進捗エンドポイントのカウント整合性修正とテスト更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ __pycache__/
 
 # App runtime data
 .data/
+# Demo database snapshots (may contain sample user content)
+.data_demo/
 
 .cache/
 

--- a/apps/backend/backend/routers/word.py
+++ b/apps/backend/backend/routers/word.py
@@ -356,9 +356,14 @@ async def update_word_pack_study_progress(
 ) -> WordPackStudyProgressResponse:
     """WordPack単位の確認/学習済みカウントを更新する。"""
 
-    checked_increment = 1
-    learned_increment = 0
-    if req.kind == "learned":
+    # kind に応じて加算対象を明示的に切り替える。
+    # - checked: 確認のみ。checked_only_count を +1、learned_count は変化なし。
+    # - learned: 学習完了。learned_count のみ +1。checked_only_count は「確認止まり」の回数を維持する。
+    if req.kind == "checked":
+        checked_increment = 1
+        learned_increment = 0
+    else:  # req.kind == "learned" のみ通過（Pydantic Literal で保証）
+        checked_increment = 0
         learned_increment = 1
     result = store.update_word_pack_study_progress(
         word_pack_id, checked_increment, learned_increment
@@ -724,9 +729,12 @@ async def update_example_study_progress(
 ) -> ExampleStudyProgressResponse:
     """例文単位の確認/学習済みカウントを更新する。"""
 
-    checked_increment = 1
-    learned_increment = 0
-    if req.kind == "learned":
+    # WordPack と同様に、確認操作と学習完了を明確に分離する。
+    if req.kind == "checked":
+        checked_increment = 1
+        learned_increment = 0
+    else:
+        checked_increment = 0
         learned_increment = 1
     result = store.update_example_study_progress(
         example_id, checked_increment, learned_increment

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -252,15 +252,15 @@ def test_word_pack_study_progress_endpoint(client):
     assert r_checked.status_code == 200
     assert r_checked.json() == {"checked_only_count": 1, "learned_count": 0}
 
-    # 学習済みカウント（確認にも加算）
+    # 学習済みカウント（確認カウントは据え置き）
     r_learned = client.post(f"/api/word/packs/{pack_id}/study-progress", json={"kind": "learned"})
     assert r_learned.status_code == 200
-    assert r_learned.json() == {"checked_only_count": 2, "learned_count": 1}
+    assert r_learned.json() == {"checked_only_count": 1, "learned_count": 1}
 
     r_list2 = client.get("/api/word/packs")
     latest = next((it for it in r_list2.json().get("items", []) if it.get("id") == pack_id), None)
     assert latest
-    assert latest["checked_only_count"] == 2
+    assert latest["checked_only_count"] == 1
     assert latest["learned_count"] == 1
 
 
@@ -333,7 +333,7 @@ def test_example_study_progress_endpoint(client):
     r_learned = client.post(f"/api/word/examples/{example_id}/study-progress", json={"kind": "learned"})
     assert r_learned.status_code == 200
     body2 = r_learned.json()
-    assert body2["checked_only_count"] == 2
+    assert body2["checked_only_count"] == 1
     assert body2["learned_count"] == 1
 
 


### PR DESCRIPTION
## 概要
- WordPack と例文の学習進捗 API で "checked" と "learned" の加算先を明確に分離し、確認回数が学習完了時に増加しないよう修正しました
- 新しい挙動を API テストで固定し、期待値を更新しました
- サンプル用 SQLite データベースを Git 管理から除外するエントリを追加し、不要な漏洩を防ぎます

## テスト
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910903fcae4832c8fcc8c4113fb1488)