### PR TITLE
Google認証ログのハッシュ化とテスト強化

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ docker compose up --build
 - フロントエンドへアクセスすると、まず Google アカウントでのサインイン画面が表示されます。
 - 「Googleでログイン」ボタンは Google Identity Services の `GoogleLogin` コンポーネントを用いており、承認後に `credential`（ID トークン）を取得して `/api/auth/google` へ送信し、セッション Cookie を受け取ります。credential が欠落した場合は直ちにエラー帯を表示し、`/api/diagnostics/oauth-telemetry` へ状況を送信して原因調査に活用します。
 - バックエンド側で `ADMIN_EMAIL_ALLOWLIST` を設定している場合、リストに含まれないメールアドレスは検証後でも即座に 403 となり、構造化ログには `google_auth_denied` / `email_not_allowlisted` が記録されます。利用者を追加したい場合はリストへメールアドレスを追記して再起動してください。
+- バックエンドの構造化ログでは `google_auth_succeeded` を含むすべての Google 認証イベントで `email_hash`（および `display_name_hash`）が記録され、平文のメールアドレスや表示名は Cloud Logging へ送出されません。調査時はハッシュ値で突き合わせてください。
 - ポップアップは locale=ja で描画され、共有端末でも毎回アカウント選択ダイアログが表示されます。別アカウントでログインしたい場合は表示されたポップアップで希望のアカウントを選択してください。選択後の動作は従来どおり `/api/auth/google` の検証とセッションクッキー付与で完結します。
 - ヘッダー右側の「ログアウト」ボタン、または「設定」タブ下部の「ログアウト（Google セッションを終了）」ボタンから明示的にサインアウトできます。ログアウト時は `/api/auth/logout` へ通知した上でセッション Cookie を削除し、再びサインイン画面へ戻ります。
 - 既存のセッション Cookie が有効な状態でリロードした場合は、ローカルに保存されたユーザー情報を使って自動的に復元されます（Cookie が無効化されている場合は再ログインが必要です）。

--- a/docs/環境変数の意味.md
+++ b/docs/環境変数の意味.md
@@ -73,6 +73,7 @@
   - 空文字やコメントアウトのままの場合は許可リストが無効となり、従来どおりメールアドレス制限は掛かりません。
   - 値はカンマ区切りで指定し、余分な空白は自動的に除去されます。小文字へ正規化されるため、大文字小文字を意識する必要はありません。
   - 重複するメールアドレスは除外され、`google_auth_denied` ログには `allowlist_size` とハッシュ化されたメールアドレスが記録されます。
+  - 認証成功時の `google_auth_succeeded` も `email_hash` / `display_name_hash` として Cloud Logging に送信されるため、平文の識別子は残りません。
 - 設定例:
   - 管理者のみ許可: `ADMIN_EMAIL_ALLOWLIST=admin@example.com`
   - 複数名を許可: `ADMIN_EMAIL_ALLOWLIST=admin@example.com,owner@example.com`


### PR DESCRIPTION
## 概要
- Google認証成功ログをヘルパー経由でハッシュ化し、display_name も平文が残らないよう方針を明文化しました
- Cloud Logging でのハッシュ記録ポリシーを README.md と docs/環境変数の意味.md に追記しました
- `google_auth_succeeded` ログに平文が含まれないことを確認する結合テストを追加しました

## テスト
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a08be16c832c95b3a73cfc91851f)