### PR TITLE
文字起こし練習カウンタAPIの追加と例文スキーマ更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ npm run test
 ## REST API（抜粋）
 - `POST /api/word/pack` … WordPack を生成して語義タイトル・語義・例文・語源・学習カード要点を返却
 - `POST /api/word/examples/bulk-delete` … 例文IDの配列を受け取り一括削除
+- `POST /api/word/examples/{id}/transcription-typing` … 指定IDの例文について、文字起こし練習で入力した文字数を検証・加算
 - `POST /api/tts` … OpenAI gpt-4o-mini-tts で読み上げた音声（audio/mpeg）をストリーミング返却
 
 ## ディレクトリ

--- a/apps/backend/backend/models/word.py
+++ b/apps/backend/backend/models/word.py
@@ -177,6 +177,11 @@ class Examples(BaseModel):
             ge=0,
             description="この例文を学習完了と記録した回数（非負整数）",
         )
+        transcription_typing_count: int = Field(
+            default=0,
+            ge=0,
+            description="文字起こしトレーニングで入力された延べ文字数（非負整数）",
+        )
 
     Dev: list[ExampleItem] = Field(default_factory=list)
     CS: list[ExampleItem] = Field(default_factory=list)
@@ -211,6 +216,11 @@ class ExampleListItem(BaseModel):
         ge=0,
         description="例文を学習済みと記録した回数（非負整数）",
     )
+    transcription_typing_count: int = Field(
+        default=0,
+        ge=0,
+        description="例文の文字起こし練習で積み上がった入力文字数",
+    )
 
 
 class ExampleListResponse(BaseModel):
@@ -218,6 +228,21 @@ class ExampleListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+
+
+class ExampleTranscriptionTypingRequest(BaseModel):
+    input_length: int = Field(
+        ge=1,
+        le=2000,
+        description="文字起こしで入力された文字数（1〜2000の範囲）",
+    )
+
+
+class ExampleTranscriptionTypingResponse(BaseModel):
+    transcription_typing_count: int = Field(
+        ge=0,
+        description="更新後の文字起こし入力累積文字数",
+    )
 
 
 class ExamplesBulkDeleteRequest(BaseModel):

--- a/apps/backend/backend/store/__init__.py
+++ b/apps/backend/backend/store/__init__.py
@@ -173,7 +173,7 @@ class AppSQLiteStore:
         search_mode: str = "contains",
         category: str | None = None,
     ) -> list[
-        tuple[int, str, str, str, str, str, str | None, str, str | None, int, int]
+        tuple[int, str, str, str, str, str, str | None, str, str | None, int, int, int]
     ]:
         return self.examples.list_examples(
             limit=limit,
@@ -184,6 +184,13 @@ class AppSQLiteStore:
             search_mode=search_mode,
             category=category,
         )
+
+    def update_example_transcription_typing(
+        self, example_id: int, input_length: int
+    ) -> int | None:
+        """例文の文字起こし練習カウンタを更新するラッパー。"""
+
+        return self.examples.update_example_transcription_typing(example_id, input_length)
 
     # --- Articles ---
     def save_article(self, article_id: str, **kwargs: Any) -> None:

--- a/apps/backend/backend/store/wordpacks.py
+++ b/apps/backend/backend/store/wordpacks.py
@@ -136,13 +136,14 @@ class WordPackStore:
                         llm_params,
                         checked_count,
                         learned_count,
+                        transcription_typing_count,
                     ) in iter_example_rows(examples):
                         conn.execute(
                             """
                             INSERT INTO word_pack_examples(
                                 word_pack_id, category, position, en, ja, grammar_ja, llm_model, llm_params,
-                                checked_only_count, learned_count, created_at
-                            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+                                checked_only_count, learned_count, transcription_typing_count, created_at
+                            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
                             """,
                             (
                                 word_pack_id,
@@ -155,6 +156,7 @@ class WordPackStore:
                                 llm_params,
                                 checked_count,
                                 learned_count,
+                                transcription_typing_count,
                                 now,
                             ),
                         )
@@ -507,7 +509,8 @@ class WordPackStore:
                 llm_model,
                 llm_params,
                 checked_only_count,
-                learned_count
+                learned_count,
+                transcription_typing_count
             FROM word_pack_examples
             WHERE word_pack_id = ?
             ORDER BY category ASC, position ASC, id ASC;
@@ -537,6 +540,9 @@ class WordPackStore:
                 r["checked_only_count"]
             )
             item["learned_count"] = normalize_non_negative_int(r["learned_count"])
+            item["transcription_typing_count"] = normalize_non_negative_int(
+                r["transcription_typing_count"]
+            )
             examples.setdefault(cat, []).append(item)
         for cat in EXAMPLE_CATEGORIES:
             examples.setdefault(cat, [])


### PR DESCRIPTION
1. `apps/backend/backend/store/examples.py` の `ensure_tables` に `transcription_typing_count INTEGER NOT NULL DEFAULT 0` を追加し、既存テーブルへ `ALTER TABLE`（存在確認は `PRAGMA table_info`）する分岐を用意する。
2. 同ファイルに `update_example_transcription_typing`（例文IDと入力長を受け、差分が±10以内か検証・加算）を新設し、`append_examples`/`iter_example_rows`/`list_examples` のクエリと返却値へ `transcription_typing_count` を組み込む。
3. `apps/backend/backend/store/wordpacks.py` の `_merge_core_with_examples` で `transcription_typing_count` を JSON へ戻す処理を追加する。
4. `apps/backend/backend/models/word.py` の `ExampleListItem` と `WordPack` 内例文モデルに `transcription_typing_count: int = 0` を定義し、`ExampleListResponse` 作成箇所を更新する。
5. `apps/backend/backend/store/__init__.py` に新メソッドをラップ追加し、`apps/backend/backend/routers/word.py` へ `POST /api/word/examples/{id}/transcription-typing` を実装（入力長バリデーション、404/422 応答、更新後カウント返却）。
6. `tests/test_api.py` に API 正常系/桁外入力の異常系テストを追加し、既存テストの例文レスポンス検証へ新フィールドをアサートする。

## 概要
- word_pack_examples テーブルへ transcription_typing_count 列を追加し、既存データも移行
- 例文リスト/WordPack 応答へ文字起こしカウンタを含め、加算 API を新設
- API テストを更新し、新規エンドポイントの正常系・異常系を検証

## テスト
- `pytest tests/test_api.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691824e0ce98832c8e043c26cc059102)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 7366d8c6e7a5958e9b8f0eef0809ac8935f48a8c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->