### PR TITLE
例文詳細モーダルに文字起こしタイピング機能を追加

### DIFF
--- a/apps/frontend/src/components/ExampleDetailModal.tsx
+++ b/apps/frontend/src/components/ExampleDetailModal.tsx
@@ -16,6 +16,7 @@ export interface ExampleItemData {
   word_pack_updated_at?: string | null;
   checked_only_count?: number;
   learned_count?: number;
+  transcription_typing_count?: number;
 }
 
 interface ExampleDetailModalProps {
@@ -28,21 +29,45 @@ interface ExampleDetailModalProps {
     checked_only_count: number;
     learned_count: number;
   }) => void;
+  onTranscriptionTypingRecorded?: (payload: {
+    id: number;
+    word_pack_id: string;
+    transcription_typing_count: number;
+  }) => void;
 }
 
-export const ExampleDetailModal: React.FC<ExampleDetailModalProps> = ({ isOpen, onClose, item, onStudyProgressRecorded }) => {
+export const ExampleDetailModal: React.FC<ExampleDetailModalProps> = ({
+  isOpen,
+  onClose,
+  item,
+  onStudyProgressRecorded,
+  onTranscriptionTypingRecorded,
+}) => {
   const { settings } = useSettings();
   const [progressUpdating, setProgressUpdating] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
-  const [localCounts, setLocalCounts] = useState<{ checked: number; learned: number }>({ checked: 0, learned: 0 });
+  const [localCounts, setLocalCounts] = useState<{ checked: number; learned: number; transcriptionTyping: number }>({
+    checked: 0,
+    learned: 0,
+    transcriptionTyping: 0,
+  });
+  const [transcriptionFormVisible, setTranscriptionFormVisible] = useState(false);
+  const [transcriptionInput, setTranscriptionInput] = useState('');
+  const [transcriptionUpdating, setTranscriptionUpdating] = useState(false);
+  const [transcriptionFeedback, setTranscriptionFeedback] = useState<string | null>(null);
 
   useEffect(() => {
     if (!item) return;
     setLocalCounts({
       checked: item.checked_only_count ?? 0,
       learned: item.learned_count ?? 0,
+      transcriptionTyping: item.transcription_typing_count ?? 0,
     });
     setFeedback(null);
+    setTranscriptionFeedback(null);
+    setTranscriptionFormVisible(false);
+    setTranscriptionInput('');
+    setTranscriptionUpdating(false);
   }, [item]);
 
   const recordProgress = async (kind: 'checked' | 'learned') => {
@@ -77,6 +102,55 @@ export const ExampleDetailModal: React.FC<ExampleDetailModalProps> = ({ isOpen, 
       setProgressUpdating(false);
     }
   };
+
+  // 入力フォームの表示/非表示はトグルのみで制御し、直前の入力値を保持する
+  const toggleTranscriptionForm = () => {
+    setTranscriptionFormVisible((visible) => !visible);
+  };
+
+  // 文字起こしタイピングの送信処理。APIと連携しローカル状態および親へ反映させる。
+  const recordTranscriptionTyping = async () => {
+    if (!item) return;
+    if (!settings.apiBase) {
+      setTranscriptionFeedback('APIベースURLが未設定です');
+      return;
+    }
+    setTranscriptionUpdating(true);
+    setTranscriptionFeedback(null);
+    try {
+      const res = await fetchJson<{
+        id: number;
+        word_pack_id: string;
+        transcription_typing_count: number;
+      }>(`${settings.apiBase}/word/examples/${item.id}/transcription-typing`, {
+        method: 'POST',
+        body: { content: transcriptionInput },
+      });
+      setLocalCounts((prev) => ({
+        checked: prev.checked,
+        learned: prev.learned,
+        transcriptionTyping: res.transcription_typing_count,
+      }));
+      try {
+        onTranscriptionTypingRecorded?.({
+          id: res.id,
+          word_pack_id: res.word_pack_id,
+          transcription_typing_count: res.transcription_typing_count,
+        });
+      } catch {}
+      setTranscriptionFeedback('タイピング記録を保存しました');
+    } catch (e) {
+      const m = e instanceof ApiError ? e.message : '文字起こしタイピングの記録に失敗しました';
+      setTranscriptionFeedback(m);
+    } finally {
+      setTranscriptionUpdating(false);
+    }
+  };
+
+  const transcriptionLengthDiff = transcriptionInput.length - (item?.en.length ?? 0);
+  const isTranscriptionWithinRange = Math.abs(transcriptionLengthDiff) <= 10; // ±10文字差以内なら許容する
+  const transcriptionRecordDisabled =
+    transcriptionUpdating || !isTranscriptionWithinRange || transcriptionInput.trim().length === 0;
 
   if (!isOpen || !item) return null;
   return (
@@ -153,6 +227,75 @@ export const ExampleDetailModal: React.FC<ExampleDetailModalProps> = ({ isOpen, 
               >
                 {feedback}
               </span>
+            ) : null}
+          </div>
+          <div style={{ display: 'grid', gap: '0.5rem' }}>
+            <button
+              type="button"
+              onClick={toggleTranscriptionForm}
+              style={{
+                padding: '0.3rem 0.6rem',
+                borderRadius: 6,
+                border: '1px solid #64b5f6',
+                backgroundColor: transcriptionFormVisible ? '#e3f2fd' : '#f5faff',
+                color: '#1e88e5',
+                textAlign: 'left',
+              }}
+            >
+              文字起こしタイピング ({localCounts.transcriptionTyping})
+            </button>
+            {transcriptionFormVisible ? (
+              <div style={{ display: 'grid', gap: '0.5rem' }}>
+                <label style={{ display: 'grid', gap: '0.25rem' }}>
+                  <span style={{ fontWeight: 600 }}>英文を入力してください</span>
+                  <textarea
+                    value={transcriptionInput}
+                    onChange={(event) => setTranscriptionInput(event.target.value)}
+                    rows={5}
+                    style={{
+                      borderRadius: 6,
+                      border: '1px solid #90caf9',
+                      padding: '0.5rem',
+                      fontFamily: 'inherit',
+                    }}
+                    aria-label="文字起こしタイピング入力"
+                  />
+                </label>
+                <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+                  <button
+                    type="button"
+                    onClick={recordTranscriptionTyping}
+                    disabled={transcriptionRecordDisabled}
+                    style={{
+                      padding: '0.3rem 0.6rem',
+                      borderRadius: 6,
+                      border: '1px solid #64b5f6',
+                      backgroundColor: transcriptionRecordDisabled ? '#e3f2fd' : '#bbdefb',
+                      color: '#0d47a1',
+                    }}
+                  >
+                    タイピング記録
+                  </button>
+                  <span style={{ fontSize: '0.8em', color: isTranscriptionWithinRange ? '#2e7d32' : '#c62828' }}>
+                    入力文字数差: {transcriptionLengthDiff}
+                  </span>
+                  {transcriptionFeedback ? (
+                    <span
+                      role="status"
+                      aria-live="polite"
+                      style={{
+                        fontSize: '0.8em',
+                        color:
+                          transcriptionFeedback.includes('失敗') || transcriptionFeedback.includes('未設定')
+                            ? '#c62828'
+                            : '#2e7d32',
+                      }}
+                    >
+                      {transcriptionFeedback}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
             ) : null}
           </div>
         </div>


### PR DESCRIPTION
1. `apps/frontend/src/components/ExampleDetailModal.tsx` の `ExampleItemData` に `transcription_typing_count?: number` を追加し、初期化時に 0 でローカル状態へ取り込む。
2. モーダル内へ「文字起こしタイピング」トグルボタンを配置し、押下時に入力フォーム（多行テキスト）と `タイピング記録` ボタンを展開する。
3. 入力文字列と `item.en` の長さ差を計算し、±10 以内のみ `タイピング記録` を有効化するバリデーションを実装（境界条件のコメントを明記）。
4. 新 API `POST /word/examples/{id}/transcription-typing` を `fetchJson` で呼び出し、成功時にモーダル内のカウントとステータス表示を更新し、親コンポーネントへ `onTranscriptionTypingRecorded` コールバックで伝搬する。
5. 失敗時のメッセージや二重送信防止の `disabled` 制御を既存学習記録ロジックにならって整備する。
6. `apps/frontend/src/components/ExampleDetailModal.test.tsx` にフォーム展開・長さ制約・API 送信ハンドラ呼び出しを検証するテストを追加し、モックで差分を覆う。

## 概要
- ExampleItemData に文字起こしタイピング回数を保持するフィールドとコールバックを追加
- モーダル内に文字起こしタイピングのトグル・入力フォーム・API連携を実装し、成功時にはローカル状態と親コンポーネントへ反映
- 入力長の許容差判定と送信時の状態/エラーハンドリングを追加
- 上記挙動を確認するテストケースを拡張

## 動作確認
- npm test -- ExampleDetailModal

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69182cfe1e80832c9e8dab57d69196df)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a transcription typing feature to `ExampleDetailModal` with API POST, validation, state updates, and corresponding tests.
> 
> - **Frontend (`apps/frontend/src/components/ExampleDetailModal.tsx`)**:
>   - Extend `ExampleItemData` with `transcription_typing_count` and add `onTranscriptionTypingRecorded` callback prop.
>   - Add UI for transcription typing: toggle button, textarea input, character-difference indicator, and submit button.
>   - Implement POST to ``/word/examples/:id/transcription-typing`` via `fetchJson`, updating local counts and notifying parent; success/error feedback and loading states included.
>   - Initialize/reset related local state on `item` change and enforce ±10 char length tolerance before enabling submit.
> - **Tests (`apps/frontend/src/components/ExampleDetailModal.test.tsx`)**:
>   - Add tests for toggling the transcription form, length tolerance gating, API submission, local count update, success feedback, and parent callback invocation (with mocked fetcher and settings).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e27eebc7d63b5315efc0f8c0e1e5dbf33e50d197. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->