### PR TITLE
セキュリティヘッダの強化とFastAPIミドルウェア追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ cp env.example .env
 # SESSION_SECRET_KEY=Qv6G5zH1pN8wX4rT7yL2mC9dF0sJ3kV5bR1nP7tW4qY8uZ6  # 32文字以上の乱数文字列を必ず使用
 # SESSION_COOKIE_NAME=wp_session
 # SESSION_COOKIE_SECURE=true  # 本番(HTTPS)のみ true。開発(HTTP)は既定で false なので設定不要
+# SECURITY_HSTS_MAX_AGE_SECONDS=63072000  # HSTS の max-age（秒）
+# SECURITY_CSP_DEFAULT_SRC='self',https://cdn.jsdelivr.net  # CSP の default-src 許可リスト
+# SECURITY_CSP_CONNECT_SRC='self',https://api.example.com  # API fetch で許可する接続先
 # GOOGLE_CLOCK_SKEW_SECONDS=60  # Google IDトークン検証時に許容する時計ずれ（秒）
 ```
 
@@ -75,6 +78,8 @@ cp env.example .env
 `SESSION_SECRET_KEY` は 32 文字以上の十分に乱数性を持つ文字列を必ず指定してください。`change-me` など既知のプレースホルダーや短い値を設定すると、アプリケーション起動時に検証エラーとなり実行が停止します。外部に公開する環境では `openssl rand -base64 48` などで生成した値を `.env` へ保存し、リポジトリへコミットしない運用を徹底してください。
 
 `CORS_ALLOWED_ORIGINS` を設定すると、指定したオリジンからのみ資格情報付き CORS を許可します。ローカル開発では `http://127.0.0.1:5173,http://localhost:5173` を指定すると従来どおりフロントエンドと連携できます。未設定の場合はワイルドカード許可となりますが、`Access-Control-Allow-Credentials` は返さないためクッキー連携が無効化されます。
+
+バックエンドは `SecurityHeadersMiddleware` で HSTS / CSP / X-Frame-Options / X-Content-Type-Options / Referrer-Policy / Permissions-Policy を強制付与します。HTTPS 運用時に HSTS の寿命を調整したい場合は `SECURITY_HSTS_MAX_AGE_SECONDS` を設定し、`SECURITY_HSTS_INCLUDE_SUBDOMAINS=false` や `SECURITY_HSTS_PRELOAD=true` でディレクティブを切り替えてください。CSP のオリジンは `SECURITY_CSP_DEFAULT_SRC`・`SECURITY_CSP_CONNECT_SRC` にカンマ区切りで指定します。Swagger UI などで外部 CDN を利用する場合は `'self'`（引用符付き）に加えて `https://cdn.jsdelivr.net` などを列挙してください。
 
 フロントエンド側でも同じクライアントIDを参照できるように、`apps/frontend/.env` を作成して Vite の環境変数を指定してください。
 

--- a/UserManual.md
+++ b/UserManual.md
@@ -197,6 +197,10 @@
   - テスト/CI はモックのため不要
   - 本番は `STRICT_MODE=true` 推奨（開発では `false` 可）
 - 途中切れ対策に `LLM_MAX_TOKENS` を 1200–1800（推奨1500）
+- セキュリティヘッダ (`SecurityHeadersMiddleware`) の調整
+  - HTTPS 運用で HSTS の寿命を変えたい場合は `SECURITY_HSTS_MAX_AGE_SECONDS` を設定し、サブドメイン除外時は `SECURITY_HSTS_INCLUDE_SUBDOMAINS=false`
+  - `SECURITY_CSP_DEFAULT_SRC` と `SECURITY_CSP_CONNECT_SRC` にカンマ区切りで CSP オリジンを記述（`'self'` を含めたい場合は引用符ごと入力）
+  - Swagger UI など外部 CDN が必要な場合は `https://cdn.jsdelivr.net` などをリストへ追加する
 
 ### B-1-1. Google OAuth クライアントの作成手順
 1. [Google Cloud Console](https://console.cloud.google.com/) を開き、対象プロジェクトを作成または選択します。

--- a/env.example
+++ b/env.example
@@ -54,6 +54,16 @@ WORDPACK_DB_PATH=.data/wordpack.sqlite3
 # Per-IP / Per-User API rate limits (requests per minute)
 RATE_LIMIT_PER_MIN_IP=240
 RATE_LIMIT_PER_MIN_USER=240
+# Security headers
+# HSTS の max-age（秒）。HTTPS 運用では 1年以上 (63072000) を推奨。
+SECURITY_HSTS_MAX_AGE_SECONDS=63072000
+# includeSubDomains や preload を付与したくない場合は false に切り替え。
+# SECURITY_HSTS_INCLUDE_SUBDOMAINS=true
+# SECURITY_HSTS_PRELOAD=false
+# Content-Security-Policy の default-src / connect-src をカンマ区切りで指定。
+# 例: "'self',https://cdn.example.com"（引用符を含めて記述）
+# SECURITY_CSP_DEFAULT_SRC='self'
+# SECURITY_CSP_CONNECT_SRC='self'
 # Optional: Enable Sentry by setting DSN
 # SENTRY_DSN=
 

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+import sys
+
+from fastapi.testclient import TestClient
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1] / "apps" / "backend"
+if str(_BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_ROOT))
+
+from backend.config import settings
+from backend.main import create_app
+
+
+@contextmanager
+def override_settings(**overrides: object) -> Iterator[None]:
+    """Temporarily override backend settings for the duration of a test.
+
+    なぜ: `backend.config.settings` はモジュール読み込み時に確定するシングルトンのため、
+    テスト内で値を変更した場合は必ず元に戻さないと他ケースへ影響する。`with` 文で
+    一時的に差し替えて終了時に復元するヘルパーを用意し、改修者が安全に設定を操作
+    できるようにする。
+    """
+
+    original: dict[str, object] = {}
+    try:
+        for key, value in overrides.items():
+            original[key] = getattr(settings, key)
+            setattr(settings, key, value)
+        yield
+    finally:
+        for key, value in original.items():
+            setattr(settings, key, value)
+
+
+def test_security_headers_are_added_to_primary_endpoints() -> None:
+    """主要エンドポイントが想定したセキュリティヘッダを返却することを検証する。"""
+
+    custom_default = ("'self'", "https://cdn.example.com")
+    custom_connect = ("'self'", "https://api.example.com")
+    with override_settings(
+        security_hsts_max_age_seconds=10800,
+        security_hsts_preload=True,
+        security_csp_default_src=custom_default,
+        security_csp_connect_src=custom_connect,
+    ):
+        app = create_app()
+        with TestClient(app) as client:
+            for path in ("/healthz", "/api/config"):
+                response = client.get(path)
+                assert response.status_code == 200
+                headers = response.headers
+                assert (
+                    headers["Strict-Transport-Security"]
+                    == "max-age=10800; includeSubDomains; preload"
+                )
+                csp = headers["Content-Security-Policy"]
+                assert "default-src 'self' https://cdn.example.com" in csp
+                assert "connect-src 'self' https://api.example.com" in csp
+                assert "img-src 'self' https://cdn.example.com data:" in csp
+                assert "style-src 'self' https://cdn.example.com 'unsafe-inline'" in csp
+                assert "Permissions-Policy" in headers
+                assert headers["Permissions-Policy"] == (
+                    "camera=(), microphone=(), geolocation=()"
+                )
+                assert headers["X-Frame-Options"] == "DENY"
+                assert headers["X-Content-Type-Options"] == "nosniff"
+                assert headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+
+
+def test_rate_limited_response_keeps_security_headers() -> None:
+    """429 応答でもセキュリティヘッダが保持されることを確認する。"""
+
+    with override_settings(
+        rate_limit_per_min_ip=1,
+        rate_limit_per_min_user=1,
+        security_hsts_max_age_seconds=3600,
+        security_csp_default_src=("'self'",),
+        security_csp_connect_src=("'self'",),
+    ):
+        app = create_app()
+        with TestClient(app) as client:
+            first = client.get("/healthz")
+            assert first.status_code == 200
+
+            second = client.get("/healthz")
+            assert second.status_code == 429
+            headers = second.headers
+            assert headers["Strict-Transport-Security"] == "max-age=3600; includeSubDomains"
+            assert headers["Content-Security-Policy"].startswith("default-src 'self'")
+            assert headers["X-Frame-Options"] == "DENY"


### PR DESCRIPTION
1. `apps/backend/backend/middleware.py` に `SecurityHeadersMiddleware`（レスポンスへ HSTS / CSP / X-Frame-Options / X-Content-Type-Options / Referrer-Policy / Permissions-Policy を設定）を実装する。
2. CSP のオリジンや HSTS の max-age を `.env` 経由で調整できるよう `apps/backend/backend/config.py` に設定項目を追加する。
3. `apps/backend/backend/main.py` の `create_app` で新ミドルウェアを `RequestIDMiddleware` の外側に追加し、Stack 順序をコメントで明示する。
4. `tests` 配下に FastAPI クライアントテストを追加し、主要エンドポイントで各ヘッダが期待どおり返ることを検証する。
5. 新しい環境変数や運用手順があれば `README.md` と `UserManual.md` の該当セクションを更新する。

## 概要
- SecurityHeadersMiddleware を新設し、HSTS/CSP/Permissions-Policy などのレスポンスヘッダを一括付与
- HSTS の max-age や CSP 許可オリジンを環境変数から調整できるよう設定項目と .env サンプルを拡張
- ミドルウェア構成・ドキュメント・FastAPI クライアントテストを更新し、新ヘッダを主要エンドポイントで検証

## テスト
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691894f5f56c832ca04e290e9c2e3465)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `SecurityHeadersMiddleware` to attach HSTS/CSP and related headers to all responses, introduces env-configurable HSTS/CSP settings, integrates into middleware stack, updates `.env`/docs, and adds tests.
> 
> - **Backend**:
>   - **Middleware**: Add `SecurityHeadersMiddleware` to apply HSTS, CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy to all responses; placed outermost in stack.
>   - **Config**: New settings `security_hsts_max_age_seconds`, `security_hsts_include_subdomains`, `security_hsts_preload`, `security_csp_default_src`, `security_csp_connect_src` with normalizing validators.
>   - **Integration**: Wire middleware in `backend.main.create_app()`; comment updates on stack order.
> - **Env/Examples**:
>   - Extend `env.example` with `SECURITY_*` variables and guidance.
> - **Tests**:
>   - Add `tests/test_security_headers.py` to verify headers on `/healthz` and `/api/config`, and preservation on `429` rate-limited responses.
> - **Docs**:
>   - Update `README.md` and `UserManual.md` with configuration instructions for HSTS/CSP and middleware behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd4daa0f5d8ea318356425ba58aab4497d93beff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->