### PR TITLE
Firestore依存のバージョン固定と再インストール確認

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ pytest
 httpx
 pytest-cov
 google-auth
-google-cloud-firestore
+# Firestore backend を安定運用するため v2 系へ明示固定
+google-cloud-firestore>=2.11.0,<3.0.0
 itsdangerous
 langgraph
 chromadb


### PR DESCRIPTION
## 概要
- Cloud Firestore クライアントを v2 系へ固定し、コメントで意図を明示して CI で確実に導入されるようにしました
- 依存追加後に `pip install -r requirements.txt` を実行してキャッシュを破棄し、google-cloud-core などの必須トランジティブ依存が解決されることを確認しました

## テスト
- `pip install -r requirements.txt`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919622d1a50832c9c65ed08bc516103)