### PR TITLE
フロントエンド環境テンプレートの整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ cp env.example .env
 # SECURITY_CSP_DEFAULT_SRC='self',https://cdn.jsdelivr.net  # CSP の default-src 許可リスト
 # SECURITY_CSP_CONNECT_SRC='self',https://api.example.com  # API fetch で許可する接続先
 # GOOGLE_CLOCK_SKEW_SECONDS=60  # Google IDトークン検証時に許容する時計ずれ（秒）
+
+# Frontend（apps/frontend 配下の Vite プロジェクト）
+npm run prepare:frontend-env  # apps/frontend/.env が無い場合に .env.example をコピー
+# または `cp apps/frontend/.env.example apps/frontend/.env`
+# VITE_GOOGLE_CLIENT_ID=12345-abcdefgh.apps.googleusercontent.com
+# VITE_SESSION_COOKIE_NAME=wp_session
 ```
 
 ローカル開発（ENVIRONMENT=development など）では Secure 属性が既定で無効になり、HTTP サーバーでも `wp_session` Cookie が配信されます。本番で HTTPS を使う場合は `.env` または環境変数で `SESSION_COOKIE_SECURE=true` を指定してください。
@@ -105,17 +111,17 @@ cp env.example .env
 
 バックエンドは `SecurityHeadersMiddleware` で HSTS / CSP / X-Frame-Options / X-Content-Type-Options / Referrer-Policy / Permissions-Policy を強制付与します。HTTPS 運用時に HSTS の寿命を調整したい場合は `SECURITY_HSTS_MAX_AGE_SECONDS` を設定し、`SECURITY_HSTS_INCLUDE_SUBDOMAINS=false` や `SECURITY_HSTS_PRELOAD=true` でディレクティブを切り替えてください。CSP のオリジンは `SECURITY_CSP_DEFAULT_SRC`・`SECURITY_CSP_CONNECT_SRC` にカンマ区切りで指定します。Swagger UI などで外部 CDN を利用する場合は `'self'`（引用符付き）に加えて `https://cdn.jsdelivr.net` などを列挙してください。
 
-フロントエンド側でも同じクライアントIDを参照できるように、`apps/frontend/.env` を作成して Vite の環境変数を指定してください。
+フロントエンド側でも同じクライアントIDを参照できるように、`apps/frontend/.env.example` を `apps/frontend/.env` としてコピーしてください。ルートディレクトリで `npm run prepare:frontend-env` を実行するとテンプレートを自動で複製します（`.env` が存在する場合は上書きしません）。
 
 ```bash
-cd apps/frontend
-cp .env.example .env  # 無い場合は自作でOK
-echo "VITE_GOOGLE_CLIENT_ID=12345-abcdefgh.apps.googleusercontent.com" >> .env
+# ルートで実行
+npm run prepare:frontend-env
+# 既に .env がある場合や手動で書き換える場合は apps/frontend/.env.example を直接編集してください
 ```
 
-`VITE_GOOGLE_CLIENT_ID` はバックエンドの `GOOGLE_CLIENT_ID` と一致している必要があります。Google Console で発行した OAuth 2.0 Web クライアント ID を指定してください。
+`VITE_GOOGLE_CLIENT_ID` はバックエンドの `GOOGLE_CLIENT_ID` と一致している必要があります。Google Console で発行した OAuth 2.0 Web クライアント ID を指定してください。`AuthContext.tsx` では `VITE_SESSION_COOKIE_NAME` も参照するため、FastAPI 側の `SESSION_COOKIE_NAME` を変更した場合はフロントエンドの `.env` も合わせて更新します。
 
-バックエンド・フロントエンドのどちらも起動前に `.env` と `apps/frontend/.env` を用意し、`GOOGLE_CLIENT_ID`（必要に応じて `GOOGLE_ALLOWED_HD` や `ADMIN_EMAIL_ALLOWLIST`）、`SESSION_SECRET_KEY`、`VITE_GOOGLE_CLIENT_ID` を設定しておくと、初回起動から Google ログインが有効になります。
+バックエンド・フロントエンドのどちらも起動前に `.env` と `apps/frontend/.env` を用意し、`GOOGLE_CLIENT_ID`（必要に応じて `GOOGLE_ALLOWED_HD` や `ADMIN_EMAIL_ALLOWLIST`）、`SESSION_SECRET_KEY`、`VITE_GOOGLE_CLIENT_ID`、`VITE_SESSION_COOKIE_NAME` を設定しておくと、初回起動から Google ログインが有効になります。
 
 補足（時計ずれの吸収）  
 `GOOGLE_CLOCK_SKEW_SECONDS` を指定すると、Google の ID トークン検証で `iat`/`nbf`/`exp` の境界に対して指定秒数のゆとりを持たせます。既定は 60 秒で、Docker/WSL などの軽微な時計ずれによる “Token used too early” を回避できます（セキュリティ上の影響は軽微ですが、必要最小限の値にしてください）。

--- a/UserManual.md
+++ b/UserManual.md
@@ -202,6 +202,7 @@
   - HTTPS 運用で HSTS の寿命を変えたい場合は `SECURITY_HSTS_MAX_AGE_SECONDS` を設定し、サブドメイン除外時は `SECURITY_HSTS_INCLUDE_SUBDOMAINS=false`
   - `SECURITY_CSP_DEFAULT_SRC` と `SECURITY_CSP_CONNECT_SRC` にカンマ区切りで CSP オリジンを記述（`'self'` を含めたい場合は引用符ごと入力）
   - Swagger UI など外部 CDN が必要な場合は `https://cdn.jsdelivr.net` などをリストへ追加する
+- フロントエンド（`apps/frontend`）では `.env` を `apps/frontend/.env.example` からコピーしてください。リポジトリ直下で `npm run prepare:frontend-env` を実行すると、テンプレートが存在する場合のみ `.env` が自動作成され、既存ファイルは上書きされません。`VITE_GOOGLE_CLIENT_ID` と `VITE_SESSION_COOKIE_NAME` をバックエンドと同じ値に調整すると、`AuthContext.tsx` が正しいセッション Cookie を参照します。
 
 ### B-1-1. Google OAuth クライアントの作成手順
 1. [Google Cloud Console](https://console.cloud.google.com/) を開き、対象プロジェクトを作成または選択します。

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,4 +1,11 @@
-# Google OAuth 2.0 Web Client ID for WordPack frontend (must match backend GOOGLE_CLIENT_ID)
+# WordPack frontend (Vite) uses this template to populate apps/frontend/.env.
+# Copy it manually or run `npm run prepare:frontend-env` at the repository root
+# to duplicate the file before executing `npm run dev` / `npm run test`.
+
+# Google OAuth 2.0 Web Client ID. This MUST match backend GOOGLE_CLIENT_ID, and
+# should look like `12345-abcdefgh.apps.googleusercontent.com`.
 VITE_GOOGLE_CLIENT_ID=12345-abcdefgh.apps.googleusercontent.com
-# Optional: customize session cookie name if backend uses a different name
+
+# Session cookie name shared with the backend. Keep `wp_session` unless
+# SESSION_COOKIE_NAME in the FastAPI app uses a different value.
 VITE_SESSION_COOKIE_NAME=wp_session

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "smoke": "npm run smoke --prefix tests/ui/mcp-smoke"
+    "smoke": "npm run smoke --prefix tests/ui/mcp-smoke",
+    "prepare:frontend-env": "node ./scripts/prepare-frontend-env.mjs"
   }
 }

--- a/scripts/prepare-frontend-env.mjs
+++ b/scripts/prepare-frontend-env.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+import { promises as fs } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// Copies apps/frontend/.env.example to apps/frontend/.env when the latter is
+// missing so newcomers can bootstrap the Vite environment with one command.
+
+// This helper resolves repository-relative paths even when npm runs the script
+// from a nested working directory (e.g., via workspaces or prefix flags).
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const frontendDir = path.resolve(__dirname, '..', 'apps', 'frontend');
+const templatePath = path.join(frontendDir, '.env.example');
+const envPath = path.join(frontendDir, '.env');
+
+// fileExists inspects the given path and returns true when it can be read.
+async function fileExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// main orchestrates the copy flow and keeps log messages localized in Japanese
+// so contributors immediately understand what happened.
+async function main() {
+  const hasEnv = await fileExists(envPath);
+  if (hasEnv) {
+    console.log(`[prepare:frontend-env] ${path.relative(process.cwd(), envPath)} は既に存在するため処理をスキップしました。`);
+    return;
+  }
+
+  const hasTemplate = await fileExists(templatePath);
+  if (!hasTemplate) {
+    throw new Error(`テンプレート ${path.relative(process.cwd(), templatePath)} が見つかりません。先に apps/frontend/.env.example を作成してください。`);
+  }
+
+  await fs.copyFile(templatePath, envPath);
+  console.log(`[prepare:frontend-env] ${path.relative(process.cwd(), templatePath)} から ${path.relative(process.cwd(), envPath)} へコピーしました。`);
+}
+
+main().catch((error) => {
+  console.error('[prepare:frontend-env] 環境変数テンプレートのコピーに失敗しました:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
1. `apps/frontend/.env.example` を新規作成し、`VITE_GOOGLE_CLIENT_ID` や `VITE_SESSION_COOKIE_NAME`（`AuthContext.tsx` が参照）など Vite 変数のデフォルト値や説明コメントを記載する。
2. `README.md` の Google OAuth / フロントエンド設定節を更新し、テンプレートの存在とコピー手順を明記する。UserManual の開発者向けパートにも同様の追記を行う。
3. 追加したテンプレートをもとに `apps/frontend/.env` を生成する簡易スクリプト（例: `npm run prepare:frontend-env`）が必要であれば `package.json` にスクリプトを追加し README に使い方を記す。
4. 変更後は `npm run test`（フロントエンド）など影響するテストを実行し、環境変数の読み込みが壊れていないことを確認する。

## 概要
- Vite 用の環境変数テンプレート `.env.example` を拡充し、`npm run prepare:frontend-env` で `.env` を自動生成できるスクリプトを追加しました
- README と UserManual にテンプレートの存在とコピー手順、`VITE_SESSION_COOKIE_NAME` の設定ポイントを追記しました

## テスト
- npm run test (apps/frontend)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919e7efbc5c832cb8bceeb428c41166)