### PR TITLE
Cloud Run向け環境テンプレートとデプロイ手順の整備

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ bin-release/
 !.env.example
 # Cloud Run デプロイ用の秘密情報は必ずローカルファイル (.env.deploy など) に閉じ込める
 .env.deploy
+!env.deploy.example
 configs/cloud-run/*.secrets
 google-oauth-client-secret.json
 client_secret_*.json

--- a/README.md
+++ b/README.md
@@ -153,7 +153,14 @@ docker compose up --build
 - `apps/frontend/docker-entrypoint.sh` が起動時に依存を確認し、`node_modules/@react-oauth/google` が不足している場合は自動で `npm install` を実行します。このため、新しいフロントエンド依存を追加してもコンテナの再ビルドは不要です。
 
 ### Cloud Run へのデプロイ
-`scripts/deploy_cloud_run.sh` が Cloud Run 用イメージのビルドからデプロイまでを自動化します。`.env.deploy`（もしくは `--env-file` で指定したファイル）に本番環境の設定をまとめ、`SESSION_SECRET_KEY` / `CORS_ALLOWED_ORIGINS` / `TRUSTED_PROXY_IPS` / `ALLOWED_HOSTS` を必ず明示してください。
+`scripts/deploy_cloud_run.sh` が Cloud Run 用イメージのビルドからデプロイまでを自動化します。まずはテンプレートを複製して、本番用の `.env.deploy` を作成してください。
+
+```bash
+cp env.deploy.example .env.deploy
+# コピー後に PROJECT_ID などを本番値へ置き換える
+```
+
+`.env.deploy`（もしくは `--env-file` で指定したファイル）に本番環境の設定をまとめ、`SESSION_SECRET_KEY` / `CORS_ALLOWED_ORIGINS` / `TRUSTED_PROXY_IPS` / `ALLOWED_HOSTS` を必ず明示します。`SESSION_SECRET_KEY` は `./scripts/deploy_cloud_run.sh --generate-secret` を付けて実行すると不足時に `openssl rand -base64 <length>` で安全な値へ自動補完できます。
 
 ```env
 # .env.deploy の例
@@ -162,7 +169,7 @@ PROJECT_ID=my-prod-project
 REGION=asia-northeast1
 CLOUD_RUN_SERVICE=wordpack-backend
 ARTIFACT_REPOSITORY=wordpack/backend
-SESSION_SECRET_KEY=<openssl rand -base64 48 の結果>
+SESSION_SECRET_KEY=<後述の --generate-secret か openssl rand -base64 48 で生成>
 CORS_ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
 TRUSTED_PROXY_IPS=35.191.0.0/16,130.211.0.0/22
 ALLOWED_HOSTS=app-xxxx.a.run.app,api.example.com
@@ -170,7 +177,7 @@ GOOGLE_CLIENT_ID=123456.apps.googleusercontent.com
 OPENAI_API_KEY=sk-xxxxx
 ```
 
-準備ができたら次のコマンドでデプロイします（`--generate-secret` を付けると不足時に `openssl rand -base64 <length>` で自動生成されます）。
+準備ができたら次のコマンドでデプロイします。テンプレートをコピーした直後で `SESSION_SECRET_KEY` が空の場合は、`--generate-secret` を付けることで不足分を `openssl rand -base64 <length>` で自動生成できます。
 
 ```bash
 ./scripts/deploy_cloud_run.sh \

--- a/UserManual.md
+++ b/UserManual.md
@@ -287,7 +287,7 @@
 - LLM 機能有効時でも内部スレッドは共有プールで制御（長時間運用でのスレッド増加なし）
 
 #### B-5-1. Cloud Run への自動デプロイ
-- `scripts/deploy_cloud_run.sh` が Cloud Build → Cloud Run Deploy を一括で実行します。`.env.deploy`（または `--env-file` で指定するファイル）に `ENVIRONMENT=production` と `SESSION_SECRET_KEY` / `CORS_ALLOWED_ORIGINS` / `TRUSTED_PROXY_IPS` / `ALLOWED_HOSTS` を記載してください。`PROJECT_ID` / `REGION` を同じファイルに含めるとコマンド引数を短縮できます。
+- `scripts/deploy_cloud_run.sh` が Cloud Build → Cloud Run Deploy を一括で実行します。最初に `cp env.deploy.example .env.deploy` でテンプレートを複製し、`PROJECT_ID` や `REGION`、ドメイン情報を本番値へ置き換えてください。`.env.deploy`（または `--env-file` で指定するファイル）に `ENVIRONMENT=production` と `SESSION_SECRET_KEY` / `CORS_ALLOWED_ORIGINS` / `TRUSTED_PROXY_IPS` / `ALLOWED_HOSTS` を記載してください。`PROJECT_ID` / `REGION` を同じファイルに含めるとコマンド引数を短縮できます。
 - 実行例:
   ```bash
   ./scripts/deploy_cloud_run.sh \
@@ -297,7 +297,7 @@
     --artifact-repo wordpack/backend \
     --generate-secret
   ```
-  - `--generate-secret` は `SESSION_SECRET_KEY` が未設定のときに `openssl rand -base64 <length>` で安全な乱数を生成します。既存値を維持したい場合は `.env.deploy` にあらかじめ貼り付けておけば上書きされません。
+  - `--generate-secret` は `SESSION_SECRET_KEY` が未設定のときに `openssl rand -base64 <length>` で安全な乱数を生成します。テンプレートをコピーしただけで未記入の場合でも、このオプションを付ければ安全な値が自動で補完されます。既存値を維持したい場合は `.env.deploy` にあらかじめ貼り付けておけば上書きされません。
   - `--dry-run` を付けると設定のロード（`python -m apps.backend.backend.config`）までを実行し、gcloud コマンドをスキップします。CI では `configs/cloud-run/ci.env` を入力にして dry-run を常時実行し、必須設定の欠落をブロックしています。
   - `--image-tag`（既定: `git rev-parse --short HEAD`）、`--build-arg KEY=VALUE`、`--machine-type`、`--timeout` などで Cloud Build のパラメータを細かく制御できます。`--artifact-repo` で Artifact Registry のリポジトリを差し替え可能です。
 - `make deploy-cloud-run PROJECT_ID=... REGION=...` を利用すれば、Makefile から同じスクリプトを呼び出せます。GitHub Actions の `Cloud Run config guard` ジョブでも `scripts/deploy_cloud_run.sh --dry-run` を実行しており、`shellcheck` でスクリプトの静的解析も同ジョブで通過させます。ローカルでスクリプトを更新した場合は `shellcheck scripts/deploy_cloud_run.sh` を必ず実行してください。

--- a/env.deploy.example
+++ b/env.deploy.example
@@ -1,0 +1,28 @@
+# Cloud Run 用の本番設定テンプレートです。以下の値はすべてダミーなので、
+# `cp env.deploy.example .env.deploy` で複製したあと、実際の GCP プロジェクト情報やドメインに置き換えてください。
+# `SESSION_SECRET_KEY` は `./scripts/deploy_cloud_run.sh --generate-secret` で安全な乱数へ自動補完できます。
+
+# --- Cloud Run / Artifact Registry の基本情報 ---
+ENVIRONMENT=production
+PROJECT_ID=replace-with-your-prod-project
+REGION=asia-northeast1
+CLOUD_RUN_SERVICE=wordpack-backend
+ARTIFACT_REPOSITORY=wordpack/backend
+
+# --- アプリケーションの認証/セキュリティ設定 ---
+# Google OAuth クライアント ID。Cloud Console で発行した Web クライアントを設定してください。
+GOOGLE_CLIENT_ID=1234567890-prod.apps.googleusercontent.com
+# 任意: Google Workspace のドメイン制限を行う場合に設定します。不要なら空のままで問題ありません。
+GOOGLE_ALLOWED_HD=example.com
+# フロントエンドのアクセス元をカンマ区切りで列挙します。HTTPS 本番ドメインを指定してください。
+CORS_ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
+# Cloud Load Balancing/プロキシで信頼する CIDR をカンマ区切りで記載します。
+TRUSTED_PROXY_IPS=35.191.0.0/16,130.211.0.0/22
+# Cloud Run サービス URL や独自ドメインなど、API を公開するホスト名を列挙します。
+ALLOWED_HOSTS=app-xxxx.a.run.app,api.example.com
+# セッションクッキー署名用シークレット。`--generate-secret` や openssl で作成後に貼り付けてください。
+SESSION_SECRET_KEY=replace-this-with-a-secure-random-string
+
+# --- API キー / モデル設定 ---
+# OpenAI など LLM の API キー。CI 用ダミー値はコミットせず、本番値をローカルで設定してください。
+OPENAI_API_KEY=replace-with-real-openai-api-key


### PR DESCRIPTION
1. ルート直下に `env.deploy.example` を新規作成し、`ENVIRONMENT=production` や `PROJECT_ID` など README のサンプルと `configs/cloud-run/ci.env` の必須キーを網羅したテンプレートを配置する（セキュリティ上のダミー値とコメント付きで、コピー後に置き換えるべき項目を明示）。
2. README の Cloud Run 手順と UserManual の B-5-1 セクションを更新し、`cp env.deploy.example .env.deploy` でテンプレートを複製する流れと、`SESSION_SECRET_KEY` を `--generate-secret` で補完できることをあわせて説明する。
3. `.gitignore` に既にある `.env.deploy` エントリを再確認し、テンプレートファイルだけが追跡対象になるよう `!env.deploy.example` を追加して誤コミットを防ぐ（必要なら既存の ignore ルールも整理）。

## 概要
- Cloud Run 向けの `env.deploy.example` テンプレートを追加し、本番用の必須キーとコメントを整理しました。
- README / UserManual の Cloud Run セクションにテンプレートの複製手順と `--generate-secret` による `SESSION_SECRET_KEY` 自動生成の説明を追記しました。
- `.gitignore` に `!env.deploy.example` を追加し、テンプレートのみを追跡できるようにしました。

## テスト
- ドキュメント更新のみのため未実施


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a105cd24c832c9e57d3d85e865810)