### PR TITLE
Firestore の lemma 検索を最適化しモックテストを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ npm run prepare:frontend-env  # apps/frontend/.env が無い場合に .env.examp
 `ENVIRONMENT=production` のときバックエンドは Cloud Firestore へ永続化します。Google Cloud のサービスアカウント資格情報（`GOOGLE_APPLICATION_CREDENTIALS` など）を必ず設定し、Firestore プロジェクトで `users` / `word_packs` / `examples` などのコレクション作成権限を付与してください。その他の環境では従来どおりローカル SQLite ファイル（`WORDPACK_DB_PATH`）が利用されます。
 
 #### Firestore のインデックス要件
-Firestore に保存する主要コレクションは `firestore.indexes.json` で複合インデックスを一括管理しています。`word_packs`（`created_at` 降順 + `__name__`）、`examples`（`word_pack_id`/`category` フィルタ + `position` / `example_id` の組み合わせ）を固定することで、バックエンドのページネーションと `Aggregation Query` の `count()` が常に安定します。JSON ファイルはそのまま Cloud Firestore / エミュレータ / Firebase CLI で流用できるようにしてあるため、手作業で Web Console に登録する必要はありません。
+Firestore に保存する主要コレクションは `firestore.indexes.json` で複合インデックスを一括管理しています。`word_packs`（`created_at` 降順 + `__name__`）、`examples`（`word_pack_id`/`category` フィルタ + `position` / `example_id` の組み合わせ）を固定することで、バックエンドのページネーションと `Aggregation Query` の `count()` が常に安定します。`lemma_label_lower` への等価フィルタと `updated_at` 降順の `order_by` を組み合わせるクエリ用のインデックスも追加済みで、lemma 重複チェック時に最新 1 件だけを取得します。JSON ファイルはそのまま Cloud Firestore / エミュレータ / Firebase CLI で流用できるようにしてあるため、手作業で Web Console に登録する必要はありません。
 `examples` ではページングと検索のために `created_at` / `pack_updated_at` / `search_en` / `search_en_reversed` / `search_terms` を組み合わせた追加インデックスを定義し、`order_by` + `start_after` + `limit` の組み合わせで常に 50 件までしか読み出さないようにしています（`offset` はカーソル取得のみに使用）。`search_en` は小文字化、`search_en_reversed` は逆順文字列、`search_terms` は 1〜3 文字の N-gram とトークン配列で、`prefix`/`suffix`/`contains` の各検索モードをサーバー側で絞り込みます。
 
 | 操作 | コマンド | 補足 |

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -9,6 +9,15 @@
       ]
     },
     {
+      "collectionGroup": "word_packs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "lemma_label_lower", "order": "ASCENDING" },
+        { "fieldPath": "updated_at", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "examples",
       "queryScope": "COLLECTION",
       "fields": [

--- a/tests/backend/test_flow_firestore_store_mock.py
+++ b/tests/backend/test_flow_firestore_store_mock.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+# ルート（apps/backend 配下）を解決するためのパス追加。
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+sys.path.insert(0, str(PROJECT_ROOT / "apps" / "backend"))
+
+from backend.flows import article_import as article_module
+from backend.flows import category_generate_import as category_module
+from backend.flows.article_import import ArticleImportFlow
+from backend.flows.category_generate_import import CategoryGenerateAndImportFlow
+from backend.models.word import ExampleCategory
+from backend.store.firestore_store import AppFirestoreStore
+from tests.firestore_fakes import FakeFirestoreClient
+
+
+@pytest.fixture()
+def firestore_store() -> AppFirestoreStore:
+    """Firestore クライアントモックを介したストアを各テストに配布する。"""
+
+    store = AppFirestoreStore(client=FakeFirestoreClient())
+    store.wordpacks._word_packs.reset_query_log()
+    return store
+
+
+def test_category_flow_operates_with_firestore_store(
+    firestore_store: AppFirestoreStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Firestore ストアを差し替えてもカテゴリー生成フローが完走することを検証する。"""
+
+    monkeypatch.setattr(category_module, "store", firestore_store)
+    monkeypatch.setattr(article_module, "store", firestore_store)
+
+    dummy_llm = SimpleNamespace(complete=lambda prompt: "{}")
+    monkeypatch.setattr(category_module, "get_llm_provider", lambda **_: dummy_llm)
+
+    article_stub = SimpleNamespace(run=lambda req: SimpleNamespace(id="article-from-stub"))
+    monkeypatch.setattr(category_module, "ArticleImportFlow", lambda: article_stub)
+
+    class DummyCategoryFlow(CategoryGenerateAndImportFlow):
+        """LLM 依存部を固定化したテスト専用フロー。"""
+
+        def _choose_new_lemma(self, category: ExampleCategory) -> str:  # type: ignore[override]
+            return "StreamSafe"
+
+        def _generate_two_examples(  # type: ignore[override]
+            self, lemma: str, category: ExampleCategory
+        ) -> list[dict]:
+            return [
+                {"en": f"{lemma} example 1", "ja": "例1", "grammar_ja": "解説1"},
+                {"en": f"{lemma} example 2", "ja": "例2", "grammar_ja": "解説2"},
+            ]
+
+    flow = DummyCategoryFlow()
+
+    firestore_store.wordpacks._word_packs.reset_query_log()
+    result = flow.run(ExampleCategory.Dev)
+
+    assert result["lemma"] == "StreamSafe"
+    assert firestore_store.list_examples(limit=10)
+
+    log = firestore_store.wordpacks._word_packs.query_log
+    assert any(("lemma_label_lower", "==", "streamsafe") in entry["filters"] for entry in log)
+
+
+def test_article_import_flow_links_with_firestore_store(
+    firestore_store: AppFirestoreStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ArticleImportFlow が Firestore ストア越しに WordPack を紐付けられることを確認する。"""
+
+    monkeypatch.setattr(article_module, "store", firestore_store)
+
+    firestore_store.save_word_pack(
+        "wp-existing",
+        "Latency",
+        json.dumps({"lemma": "Latency", "examples": {}}, ensure_ascii=False),
+    )
+    firestore_store.wordpacks._word_packs.reset_query_log()
+
+    class MinimalArticleImportFlow(ArticleImportFlow):
+        """LLM を呼ばず、WordPack 紐付け部分のみを通す軽量フロー。"""
+
+        def run(self, request: object) -> dict:  # type: ignore[override]
+            lemmas = ["Latency", "Throughput"]
+            links: list[tuple[str, str]] = []
+            for lemma in lemmas:
+                wp_id = article_module.store.find_word_pack_id_by_lemma(lemma)
+                status = "existing"
+                if wp_id is None:
+                    wp_id = f"wp:{lemma}:demo"
+                    payload = {"lemma": lemma, "sense_title": lemma, "examples": {}}
+                    article_module.store.save_word_pack(
+                        wp_id, lemma, json.dumps(payload, ensure_ascii=False)
+                    )
+                    status = "created"
+                links.append((wp_id, status))
+            return {"links": links}
+
+    flow = MinimalArticleImportFlow()
+    response = flow.run(SimpleNamespace(text="dummy"))
+
+    assert response["links"][0][1] == "existing"
+    assert response["links"][1][1] == "created"
+
+    log = firestore_store.wordpacks._word_packs.query_log
+    assert len(log) >= 2
+    assert all(entry.get("limit") == 1 for entry in log if entry.get("filters"))

--- a/tests/firestore_fakes.py
+++ b/tests/firestore_fakes.py
@@ -1,0 +1,277 @@
+"""Firestore をテストで再現するための簡易フェイク実装。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from google.cloud import firestore
+
+
+class FakeDocumentSnapshot:
+    def __init__(self, collection: str, doc_id: str, data: dict[str, Any] | None, client: "FakeFirestoreClient") -> None:
+        self._collection = collection
+        self.id = doc_id
+        self._data = data
+        self._client = client
+
+    @property
+    def exists(self) -> bool:
+        return self._data is not None
+
+    def to_dict(self) -> dict[str, Any] | None:
+        return None if self._data is None else dict(self._data)
+
+    @property
+    def reference(self) -> "FakeDocumentReference":
+        return FakeDocumentReference(self._client, self._collection, self.id)
+
+
+class FakeDocumentReference:
+    def __init__(self, client: "FakeFirestoreClient", collection: str, doc_id: str) -> None:
+        self._client = client
+        self._collection = collection
+        self.id = doc_id
+
+    def set(self, data: dict[str, Any], merge: bool = False) -> None:
+        bucket = self._client._data.setdefault(self._collection, {})
+        if merge and self.id in bucket:
+            bucket[self.id].update(data)
+        else:
+            bucket[self.id] = dict(data)
+
+    def update(self, data: dict[str, Any]) -> None:
+        bucket = self._client._data.setdefault(self._collection, {})
+        if self.id not in bucket:
+            raise KeyError(f"document {self._collection}/{self.id} not found")
+        bucket[self.id].update(data)
+
+    def get(self, transaction: "FakeTransaction" | None = None) -> FakeDocumentSnapshot:
+        bucket = self._client._data.setdefault(self._collection, {})
+        payload = dict(bucket[self.id]) if self.id in bucket else None
+        return FakeDocumentSnapshot(self._collection, self.id, payload, self._client)
+
+    def delete(self) -> None:
+        bucket = self._client._data.setdefault(self._collection, {})
+        bucket.pop(self.id, None)
+
+
+class FakeCollectionReference:
+    def __init__(self, client: "FakeFirestoreClient", name: str) -> None:
+        self._client = client
+        self._name = name
+        self._count_calls = 0
+        self._query_log: list[dict[str, Any]] = []
+
+    def document(self, doc_id: str) -> FakeDocumentReference:
+        return FakeDocumentReference(self._client, self._name, doc_id)
+
+    def _all_snapshots(self) -> list[FakeDocumentSnapshot]:
+        bucket = self._client._data.setdefault(self._name, {})
+        return [
+            FakeDocumentSnapshot(self._name, doc_id, dict(data), self._client)
+            for doc_id, data in bucket.items()
+        ]
+
+    def stream(self):  # pragma: no cover - simple iterator
+        docs = self._all_snapshots()
+        self._record_query([], len(docs))
+        for snapshot in docs:
+            yield snapshot
+
+    def order_by(self, field_path: str, direction=firestore.Query.ASCENDING):
+        return FakeQuery(self).order_by(field_path, direction)
+
+    def where(self, field_path: str, op_string: str, value: Any):
+        return FakeQuery(self).where(field_path, op_string, value)
+
+    def count(self, alias: str | None = None) -> "FakeAggregationQuery":
+        self._count_calls += 1
+        return FakeAggregationQuery(FakeQuery(self), alias or "count")
+
+    @property
+    def count_calls(self) -> int:
+        return self._count_calls
+
+    def _record_query(
+        self, filters: list[tuple[str, str, Any]], size: int, limit: int | None = None
+    ) -> None:  # pragma: no cover - bookkeeping helper
+        self._query_log.append({"filters": list(filters), "size": size, "limit": limit})
+
+    def reset_query_log(self) -> None:
+        self._query_log.clear()
+
+    @property
+    def query_log(self) -> list[dict[str, Any]]:
+        return list(self._query_log)
+
+
+class FakeQuery:
+    def __init__(
+        self,
+        collection: FakeCollectionReference,
+        *,
+        orderings: list[tuple[str, bool]] | None = None,
+        filters: list[tuple[str, str, Any]] | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+        start_after_id: str | None = None,
+    ) -> None:
+        self._collection = collection
+        self._orderings: list[tuple[str, bool]] = list(orderings or [])
+        self._filters: list[tuple[str, str, Any]] = list(filters or [])
+        self._limit: int | None = limit
+        self._offset = offset
+        self._start_after_id = start_after_id
+
+    def _clone(self, **kwargs: Any) -> "FakeQuery":
+        """Return a shallow copy with updated attributes."""
+
+        params = {
+            "collection": self._collection,
+            "orderings": kwargs.pop("orderings", self._orderings),
+            "filters": kwargs.pop("filters", self._filters),
+            "limit": kwargs.pop("limit", self._limit),
+            "offset": kwargs.pop("offset", self._offset),
+            "start_after_id": kwargs.pop("start_after_id", self._start_after_id),
+        }
+        params.update(kwargs)
+        return FakeQuery(**params)
+
+    def order_by(self, field_path: str, direction=firestore.Query.ASCENDING) -> "FakeQuery":
+        updated = list(self._orderings)
+        updated.append((field_path, direction == firestore.Query.DESCENDING))
+        return self._clone(orderings=updated)
+
+    def where(self, field_path: str, op_string: str, value: Any) -> "FakeQuery":
+        updated = list(self._filters)
+        updated.append((field_path, op_string, value))
+        return self._clone(filters=updated)
+
+    def limit(self, value: int) -> "FakeQuery":
+        return self._clone(limit=max(0, int(value)))
+
+    def offset(self, value: int) -> "FakeQuery":
+        return self._clone(offset=max(0, int(value)))
+
+    def start_after(self, snapshot: FakeDocumentSnapshot) -> "FakeQuery":
+        return self._clone(start_after_id=snapshot.id)
+
+    def _matching_snapshots(self) -> list[FakeDocumentSnapshot]:
+        docs = self._collection._all_snapshots()
+        for field_path, op_string, expected in self._filters:
+            docs = [
+                doc
+                for doc in docs
+                if self._matches_filter(doc, field_path, op_string, expected)
+            ]
+        for field_path, descending in reversed(self._orderings):
+            docs.sort(
+                key=lambda snap, fp=field_path: self._order_value(snap, fp),
+                reverse=descending,
+            )
+        if self._start_after_id:
+            ids = [snap.id for snap in docs]
+            if self._start_after_id in ids:
+                start_index = ids.index(self._start_after_id) + 1
+                docs = docs[start_index:]
+        if self._offset:
+            docs = docs[self._offset :]
+        if self._limit is not None:
+            docs = docs[: self._limit]
+        return docs
+
+    def stream(self):  # pragma: no cover - passthrough iterator
+        results = self._matching_snapshots()
+        self._collection._record_query(self._filters, len(results), self._limit)
+        for snapshot in results:
+            yield snapshot
+
+    def count(self, alias: str | None = None) -> "FakeAggregationQuery":
+        self._collection._count_calls += 1
+        return FakeAggregationQuery(self, alias or "count")
+
+    def _matches_filter(
+        self,
+        snapshot: FakeDocumentSnapshot,
+        field_path: str,
+        op_string: str,
+        expected: Any,
+    ) -> bool:
+        data = snapshot.to_dict() or {}
+        actual = data.get(field_path)
+        if op_string == "==":
+            return actual == expected
+        if op_string == "array_contains":
+            try:
+                return expected in (actual or [])
+            except TypeError:
+                return False
+        if op_string == ">=":
+            return actual >= expected
+        if op_string == "<=":
+            return actual <= expected
+        if op_string == ">":
+            return actual > expected
+        if op_string == "<":
+            return actual < expected
+        raise NotImplementedError(f"unsupported operator: {op_string}")
+
+    def _order_value(self, snapshot: FakeDocumentSnapshot, field_path: str) -> Any:
+        data = snapshot.to_dict() or {}
+        if field_path == "__name__":
+            return snapshot.id
+        value = data.get(field_path)
+        if isinstance(value, (int, float)):
+            return value
+        return str(value or "")
+
+
+class FakeAggregationQuery:
+    def __init__(self, query: FakeQuery, alias: str) -> None:
+        self._query = query
+        self._alias = alias
+
+    def stream(self, *args: Any, **kwargs: Any):  # pragma: no cover - simple iterator
+        total = len(self._query._matching_snapshots())
+        yield FakeAggregationResult(self._alias, total)
+
+    def get(self, *args: Any, **kwargs: Any) -> list["FakeAggregationResult"]:
+        return list(self.stream(*args, **kwargs))
+
+
+class FakeAggregationResult:
+    def __init__(self, alias: str, value: int) -> None:
+        self.alias = alias
+        self.value = value
+        self.aggregate_fields = {alias: value}
+
+    def __getitem__(self, key: str) -> int:
+        return self.aggregate_fields[key]
+
+
+class FakeTransaction:
+    def __init__(self, client: "FakeFirestoreClient") -> None:
+        self._client = client
+
+    def get(self, doc_ref: FakeDocumentReference) -> FakeDocumentSnapshot:
+        return doc_ref.get()
+
+    def set(self, doc_ref: FakeDocumentReference, data: dict[str, Any], merge: bool = False) -> None:
+        doc_ref.set(data, merge=merge)
+
+    def update(self, doc_ref: FakeDocumentReference, data: dict[str, Any]) -> None:
+        doc_ref.update(data)
+
+    def commit(self) -> None:  # pragma: no cover - no-op
+        return None
+
+
+class FakeFirestoreClient:
+    def __init__(self) -> None:
+        self._data: dict[str, dict[str, dict[str, Any]]] = {}
+
+    def collection(self, name: str) -> FakeCollectionReference:
+        return FakeCollectionReference(self, name)
+
+    def transaction(self) -> FakeTransaction:
+        return FakeTransaction(self)


### PR DESCRIPTION
## 概要
- Firestore の lemma 検索をフィルタ＋更新日時降順クエリに変更し、複合インデックスを追加
- Stream を使わない検索実装に合わせてフェイク Firestore を拡張し、単体・結合テストを追加
- README に新インデックスの適用手順を追記

## テスト
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b3c2c8744832cbf583a01265a53c1)