### PR TITLE
Word lookup APIを実装しstrict対応とテストを整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ npm run test
 
 ## REST API（抜粋）
 - `POST /api/word/pack` … WordPack を生成して語義タイトル・語義・例文・語源・学習カード要点を返却
+- `GET /api/word?lemma=...` … lemma を指定して最新の WordPack から定義と例文を返却（見つからなければ自動生成）
 - `POST /api/word/examples/bulk-delete` … 例文IDの配列を受け取り一括削除
 - `POST /api/word/examples/{id}/transcription-typing` … 指定IDの例文について、文字起こし練習で入力した文字数を検証・加算
 - `POST /api/tts` … OpenAI gpt-4o-mini-tts で読み上げた音声（audio/mpeg）をストリーミング返却

--- a/UserManual.md
+++ b/UserManual.md
@@ -264,6 +264,7 @@
 
 ### B-3. API 一覧（現状）
 - `POST /api/word/pack` … WordPack 生成（語義/共起/対比/例文/語源/学習カード要点/発音RP + `citations`/`confidence`、`pronunciation_enabled`,`regenerate_scope` 対応）
+- `GET /api/word?lemma=...` … lemma から保存済み WordPack を検索し、定義と例文を返却（未存在時は生成して保存）
 - 追加（保存済み WordPack 関連）:
   - `DELETE /api/word/packs/{id}/examples/{category}/{index}` … 例文の個別削除
 - `POST /api/tts` … OpenAI gpt-4o-mini-tts を使い、`text`/`voice` を受け取って `audio/mpeg` ストリームを返却


### PR DESCRIPTION
## 概要
- GET /api/word エンドポイントを実装し、ストア検索と Flow による生成を統合、strict_mode を含む例外マッピングを追加しました。
- 定義と例文を返すレスポンススキーマを整備し、保存済みデータ・新規生成の双方で一貫した整形を行うようにしました。
- API 契約に合わせてテストを拡充し、lemma バリデーションに沿う形で既存テストデータを修正、関連ドキュメントを更新しました。

## テスト
- pytest tests/test_api.py tests/backend/test_store_wordpack_lookup.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b5a0cb9a8832ca262c4a67d91527b)