### PR TITLE
語源情報のフォールバックと永続化の検証を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ firebase-debug.log
 !env.deploy.example
 configs/cloud-run/*.env.local
 configs/cloud-run/*.secrets
+apps/backend/.env
+apps/backend/.env.*
 google-oauth-client-secret.json
 client_secret_*.json
 firestore-service-account*.json

--- a/apps/backend/backend/routers/word.py
+++ b/apps/backend/backend/routers/word.py
@@ -15,6 +15,7 @@ from ..id_factory import generate_word_pack_id
 from ..providers import get_llm_provider
 from ..logging import logger
 from ..models.word import (
+    DEFAULT_ETYMOLOGY_PLACEHOLDER,
     WordPack,
     ExampleCategory,
     ExampleListItem,
@@ -528,7 +529,7 @@ async def create_empty_word_pack(req: WordPackCreateRequest) -> dict:
         },
         contrast=[],
         examples={"Dev": [], "CS": [], "LLM": [], "Business": [], "Common": []},
-        etymology={"note": "-", "confidence": "low"},
+        etymology={"note": DEFAULT_ETYMOLOGY_PLACEHOLDER, "confidence": "low"},
         study_card="",
         citations=[],
         confidence="low",

--- a/tests/backend/test_auth_google.py
+++ b/tests/backend/test_auth_google.py
@@ -113,8 +113,8 @@ def test_google_auth_success_flow(
     assert settings.session_cookie_name in cookie
 
     protected = test_client.get("/api/word/")
-    assert protected.status_code in {200, 501}
-    # Both 200 (non-strict) and 501 (strict placeholder) imply auth succeeded; ensure not 401.
+    assert protected.status_code in {200, 422, 501}
+    # 422 はクエリ必須パラメータが欠けているだけで、認証は通っていることを示す。
     assert protected.status_code != 401
 
     log_entries = _structlog_events(caplog, "google_auth_succeeded")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -882,6 +882,7 @@ def test_word_pack_persistence(client):
     assert "senses" in retrieved_pack
     assert "citations" in retrieved_pack
     assert "confidence" in retrieved_pack
+    assert retrieved_pack.get("etymology", {}).get("note")
     
     # 4. WordPackを再生成
     resp = client.post(f"/api/word/packs/{pack_id}/regenerate", json={

--- a/tests/test_etymology_generation.py
+++ b/tests/test_etymology_generation.py
@@ -1,0 +1,58 @@
+"""語源情報の生成ロジックを検証するユニットテスト。"""
+
+import sys
+from pathlib import Path
+
+backend_root = Path(__file__).resolve().parents[1] / "apps" / "backend"
+if str(backend_root) not in sys.path:
+    sys.path.insert(0, str(backend_root))
+
+from backend.flows.word_pack import RegenerateScope, WordPackFlow
+from backend.models.common import ConfidenceLevel
+from backend.models.word import Pronunciation
+
+
+def test_synthesize_fills_etymology_when_missing(monkeypatch):
+    """LLM 出力に語源が無い場合でもフォールバックが入ることを確認する。"""
+
+    flow = WordPackFlow(llm=None)
+
+    # 発音生成が外部辞書に依存しないようにシンプルなダミーへ差し替え。
+    monkeypatch.setattr(
+        flow,
+        "_generate_pronunciation",
+        lambda lemma: Pronunciation(
+            ipa_GA=None,
+            ipa_RP=None,
+            syllables=None,
+            stress_index=None,
+            linking_notes=[],
+        ),
+        raising=False,
+    )
+
+    flow._last_llm_data = {  # type: ignore[attr-defined]
+        "senses": [{"id": "s1", "gloss_ja": "意味", "patterns": []}],
+        # etymology キーをあえて欠落させ、フォールバックが働くことを検証
+        "collocations": {
+            "general": {"verb_object": [], "adj_noun": [], "prep_noun": []},
+            "academic": {"verb_object": [], "adj_noun": [], "prep_noun": []},
+        },
+        "examples": {"Dev": [], "CS": [], "LLM": [], "Business": [], "Common": []},
+        "study_card": "カード",
+    }
+
+    pack = flow._synthesize(  # type: ignore[attr-defined]
+        "originless",
+        pronunciation_enabled=False,
+        regenerate_scope=RegenerateScope.all,
+        citations=[],
+    )
+
+    assert isinstance(pack.etymology.note, str) and pack.etymology.note.strip()
+    assert pack.etymology.confidence in {
+        ConfidenceLevel.low,
+        ConfidenceLevel.medium,
+        ConfidenceLevel.high,
+    }
+


### PR DESCRIPTION
## 概要
- WordPack 生成フローで語源メモを辞書ソースとプレースホルダーで補完し、空値を返さないようにしました。
- etymology フィールドのプレースホルダーをモデルと API 例に反映し、永続化経路を通るユニットテストを追加しました。
- Google 認証後の疎通テストを現行のバリデーション挙動に合わせ、バックエンド用の .env を誤ってコミットしないよう .gitignore を強化しました。

## テスト
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b62f06c18832c98fb41a30d1fa319)