### PR TITLE
Cloud Run デプロイスクリプトの gcloud ビルドオプション修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+Dockerfile.backend

--- a/scripts/deploy_cloud_run.sh
+++ b/scripts/deploy_cloud_run.sh
@@ -291,7 +291,9 @@ fi
 ensure_gcloud
 
 log "Submitting build to Cloud Build: $IMAGE_URI"
-BUILD_CMD=(gcloud builds submit --project "$PROJECT_ID" --tag "$IMAGE_URI" --file Dockerfile.backend --machine-type="$MACHINE_TYPE" --timeout="$BUILD_TIMEOUT")
+# gcloud builds submit は Dockerfile パス指定用の --file を受け付けないため、
+# リポジトリルートの Dockerfile（Dockerfile.backend へのシンボリックリンク）を利用する。
+BUILD_CMD=(gcloud builds submit --project "$PROJECT_ID" --tag "$IMAGE_URI" --machine-type="$MACHINE_TYPE" --timeout="$BUILD_TIMEOUT")
 if [[ ${#EXTRA_BUILD_ARGS[@]} -gt 0 ]]; then
   for build_arg in "${EXTRA_BUILD_ARGS[@]}"; do
     BUILD_CMD+=(--build-arg "$build_arg")


### PR DESCRIPTION
## 概要
- gcloud builds submit でサポートされない --file フラグを削除し、ルートの Dockerfile を参照するように修正しました
- Cloud Build から既存の Dockerfile.backend を利用できるよう、リポジトリ直下にシンボリックリンクの Dockerfile を追加しました

## テスト
- 実行せず（デプロイスクリプトの軽微な修正のみ）

Docs: No-Docs-Change: デプロイスクリプトのビルドフラグ調整のみでドキュメント更新不要と判断

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921f1cfd5d4832c83aa500c7a6104f7)