### PR TITLE
Firestoreインデックスデプロイスクリプトの構文エラー修正

### DIFF
--- a/scripts/deploy_firestore_indexes.sh
+++ b/scripts/deploy_firestore_indexes.sh
@@ -55,6 +55,7 @@ if [[ ! -f "$INDEX_FILE" ]]; then
   exit 1
 fi
 
+# 利用するCLIに応じて適切なデプロイ手順を分岐させる。
 case "$TOOL" in
   gcloud)
     if ! command -v gcloud >/dev/null 2>&1; then
@@ -168,4 +169,4 @@ PY
     echo "[${SCRIPT_NAME}] --tool には gcloud または firebase を指定してください" >&2
     exit 1
     ;;
-endcase
+esac


### PR DESCRIPTION
## 概要
- `deploy_firestore_indexes.sh` の case 文終端を `esac` に修正し、実行時の構文エラーを解消
- CLI 分岐処理に説明コメントを追加し、スクリプトの意図を明確化

## テスト
- bash -n scripts/deploy_firestore_indexes.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922918bdc54832c8138f29ce4513d8f)