### PR TITLE
Firebase経由のヘッダ確認用デバッグエンドポイント追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,9 @@ npm run test
 - `POST /api/word/examples/bulk-delete` … 例文IDの配列を受け取り一括削除
 - `POST /api/word/examples/{id}/transcription-typing` … 指定IDの例文について、文字起こし練習で入力した文字数を検証・加算
 - `POST /api/tts` … OpenAI gpt-4o-mini-tts で読み上げた音声（audio/mpeg）をストリーミング返却
+- `GET /_debug/headers` … デバッグ用: FastAPI が受信した Host / X-Forwarded-* / URL / クライアント IP をそのまま JSON で返却。Firebase Hosting → Cloud Run 経由のヘッダ付け替え確認や、リバースプロキシ配下の疎通検証に利用できる（運用環境でも有効だが目立たないパスとして公開）。
+
+ローカルで `/api/config` と同じアプリに統合されていることを確認する場合は、`uvicorn backend.main:app --app-dir apps/backend --reload` で起動し、別ターミナルから `curl -H "Host: backend.internal" -H "X-Forwarded-Host: public.example.com" -H "X-Forwarded-Proto: https" http://127.0.0.1:8000/_debug/headers` を実行するとレスポンスに受信ヘッダが反映されます。
 
 ### WordPack 生成時の入力制約
 - 見出し語（`lemma`）は **英数字・半角スペース・ハイフン・アポストロフィのみ** で、1〜64文字。

--- a/apps/backend/backend/main.py
+++ b/apps/backend/backend/main.py
@@ -36,7 +36,7 @@ from .providers import ChromaClientFactory, shutdown_providers
 from .routers import article as article_router
 from .routers import auth as auth_router
 from .routers import config as cfg
-from .routers import diagnostics, health, tts, word
+from .routers import debug, diagnostics, health, tts, word
 
 
 _PROXY_MIDDLEWARE_PARAM = (
@@ -256,6 +256,7 @@ def create_app() -> FastAPI:
         prefix="/api/article",
         dependencies=protected_dependency,
     )
+    app.include_router(debug.router)
     app.include_router(diagnostics.router)
     app.include_router(health.router)
     app.include_router(cfg.router, prefix="/api")

--- a/apps/backend/backend/routers/debug.py
+++ b/apps/backend/backend/routers/debug.py
@@ -1,0 +1,35 @@
+"""Debug endpoints for quickly inspecting forwarded headers.
+
+このモジュールは Cloud Run/Firebase Hosting 経由で到達した際に、
+FastAPI がどの Host / X-Forwarded-* ヘッダを受け取っているかを
+即座に確認するための開発用 API を提供する。運用中に問題が発生した
+場合でも、/_debug/headers へアクセスするだけで実際の値を確認できる。
+"""
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter(prefix="/_debug", tags=["debug"])
+
+
+@router.get("/headers")
+async def inspect_forwarded_headers(request: Request) -> JSONResponse:
+    """Echo the effective host and forwarding headers for troubleshooting.
+
+    なぜ: Firebase Hosting -> Cloud Run の経路では複数のプロキシが介在し、
+    FastAPI から見える Host / X-Forwarded-* が想定どおりか判断しづらい。
+    このエンドポイントで受信ヘッダと URL/クライアント IP をそのまま
+    返すことで、設定漏れやプロキシ順序を素早く検証できる。
+    """
+
+    headers = request.headers
+    client_host = request.client.host if request.client else None
+    payload = {
+        "host": headers.get("host"),
+        "x_forwarded_host": headers.get("x-forwarded-host"),
+        "x_forwarded_proto": headers.get("x-forwarded-proto"),
+        "x_forwarded_for": headers.get("x-forwarded-for"),
+        "url": str(request.url),
+        "client_host": client_host,
+    }
+    return JSONResponse(payload)

--- a/tests/test_debug_headers.py
+++ b/tests/test_debug_headers.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def debug_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """/_debug 系のレスポンスを検証するための TestClient を提供する。
+
+    backend モジュールの配置（apps/backend 配下）を import path に追加したうえで、
+    セッション認証を無効化して最小限の設定で FastAPI アプリを初期化する。
+    """
+
+    backend_root = Path(__file__).resolve().parents[1] / "apps" / "backend"
+    if str(backend_root) not in sys.path:
+        sys.path.insert(0, str(backend_root))
+
+    monkeypatch.setenv("DISABLE_SESSION_AUTH", "true")
+    monkeypatch.setenv(
+        "SESSION_SECRET_KEY",
+        "T3sTIngSeSsIoNkEyForDebugHeaders123456",
+    )
+
+    from backend.main import create_app
+
+    app = create_app()
+    return TestClient(app)
+
+
+def test_debug_headers_echo_forwarding_information(debug_client: TestClient) -> None:
+    """X-Forwarded-* と URL/クライアント IP のエコー内容を確認する。"""
+
+    resp = debug_client.get(
+        "/_debug/headers",
+        headers={
+            "host": "backend.internal",
+            "x-forwarded-host": "public.example.com",
+            "x-forwarded-proto": "https",
+            "x-forwarded-for": "203.0.113.10",
+        },
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["host"] == "backend.internal"
+    assert body["x_forwarded_host"] == "public.example.com"
+    assert body["x_forwarded_proto"] == "https"
+    assert body["x_forwarded_for"] == "203.0.113.10"
+    assert body["url"] == "http://backend.internal/_debug/headers"
+    assert body["client_host"] == "testclient"
+
+
+def test_debug_headers_shares_same_application(debug_client: TestClient) -> None:
+    """/_debug/headers が /api 配下と同じアプリで提供されることを確認する。"""
+
+    cfg = debug_client.get("/api/config")
+    assert cfg.status_code == 200
+    assert "request_timeout_ms" in cfg.json()


### PR DESCRIPTION
## 概要
- FastAPI に `/_debug/headers` を追加し、Host と X-Forwarded-* を含む受信ヘッダや URL/クライアント IP を JSON で返すデバッグ用エンドポイントを用意しました。
- 既存のアプリ本体にルーターを組み込み、/api/config と同じインスタンスで確認できるようテストを追加しました。
- README にデバッグエンドポイントの用途とローカル確認手順を追記しました。

## テスト
- `python -m pytest`（一部の Google OAuth テストが `id_token` のダミー値検証で失敗する既知の状態）


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692311928658832c969f1bfa1d0901d6)