### PR TITLE
Makefileのrelease-cloud-runターゲットのレシピ整備

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ release-cloud-run: ENV_FILE ?= .env.deploy
 # release-cloud-run: Firestore インデックス同期 → Cloud Run dry-run → 本番デプロイを一括で行い、
 # `.env.deploy` などの env ファイル存在チェックと dry-run 成功を必須条件にしています。
 release-cloud-run:
-@set -euo pipefail; \
+	@set -euo pipefail; \
+	# 一連のリリース処理で必須パラメータや前提ファイルの欠落を早期に検出する。
 	PROJECT_ID_VALUE="$(PROJECT_ID)"; \
 	REGION_VALUE="$(REGION)"; \
 	ENV_FILE_PATH="$(ENV_FILE)"; \


### PR DESCRIPTION
## 概要
- release-cloud-runターゲットのレシピ行をタブインデントに修正し、makeエラーが出ないよう整備しました。
- リリース処理の前提チェックに関するコメントを追加し、意図を明確化しました。

## テスト
- make -n deploy-firestore-indexes PROJECT_ID=test
- make -n release-cloud-run PROJECT_ID=test REGION=us-central1 ENV_FILE=.env.deploy （ENVファイル未作成のため存在チェックで失敗することを確認）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69234f6276d4832c872e012732f9b85d)