### PR TITLE
allowed_hosts設定の正規化と初期ログ整備

### DIFF
--- a/apps/backend/backend/main.py
+++ b/apps/backend/backend/main.py
@@ -184,6 +184,11 @@ def _maybe_add_timeout_middleware(app: FastAPI) -> None:
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application instance."""
     configure_logging()
+    logger.info(
+        "ALLOWED_HOSTS init raw=%r parsed=%r",
+        settings.allowed_hosts_raw,
+        settings.allowed_hosts,
+    )
     app = FastAPI(title="WordPack API", version="0.3.1")
 
     configured_proxies = [value for value in settings.trusted_proxy_ips if value]


### PR DESCRIPTION
## Summary
- allowed_hosts_rawを追加し、カンマ区切り入力から正規化したリストを提供するプロパティを定義
- FastAPI 初期化時に許可ホストの生値とパース結果を構造化ログで一度だけ出力
- ForwardedHostTrustedHostMiddleware へパース済みリストを渡すようにし、設定ミスを防止

## Testing
- 未実施（not run）

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69235416ba10832c886f707b9af0b491)