### PR TITLE
Cloud Trace ヘッダー連携でログ相関を強化

### DIFF
--- a/apps/backend/backend/config.py
+++ b/apps/backend/backend/config.py
@@ -57,6 +57,19 @@ class Settings(BaseSettings):
         default="development",
         description="Runtime environment / 実行環境",
     )
+    gcp_project_id: str | None = Field(
+        default=None,
+        description=(
+            "Google Cloud project ID used for trace correlation / "
+            "Cloud Logging のトレース関連付けに利用する GCP プロジェクト ID"
+        ),
+        validation_alias=AliasChoices(
+            "gcp_project_id",
+            "GCP_PROJECT_ID",
+            "GOOGLE_CLOUD_PROJECT",
+            "PROJECT_ID",
+        ),
+    )
     google_client_id: str = Field(
         default="",
         description="Google OAuth client ID / Googleサインイン用クライアントID",

--- a/env.example
+++ b/env.example
@@ -52,6 +52,8 @@ AUTO_SEED_ON_STARTUP=true
 WORDPACK_DB_PATH=.data/wordpack.sqlite3
 
 # Operations/Observability (PR4)
+# Cloud Logging/Trace correlation for Cloud Run
+# GCP_PROJECT_ID=
 # Per-IP / Per-User API rate limits (requests per minute)
 RATE_LIMIT_PER_MIN_IP=240
 RATE_LIMIT_PER_MIN_USER=240


### PR DESCRIPTION
## 概要
- X-Cloud-Trace-Context ヘッダーを解析して trace/spanId/trace_sampled を構造化ログへ付与し、Cloud Run リクエストログとの突合を可能にしました。
- structlog の processor にコンテキスト経由のトレースフィールドをマージする処理を追加し、リクエスト内の全ログを Cloud Trace と紐付けるようにしました。
- ヘッダー有無や設定未指定時のログフィールドを検証するユニットテストを追加し、環境変数テンプレートに GCP_PROJECT_ID を追記しました。

## テスト
- pytest tests/test_logging_json_format.py -o addopts=


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923d0e88b2c832c9fdc9be80704ab7b)