### PR TITLE
ADMIN_EMAIL_ALLOWLIST の環境変数パースを安定化

### DIFF
--- a/apps/backend/backend/config.py
+++ b/apps/backend/backend/config.py
@@ -85,7 +85,10 @@ class Settings(BaseSettings):
             "Google ID トークン検証時に許容する時計ずれ（秒）"
         ),
     )
-    admin_email_allowlist: tuple[str, ...] = Field(
+    # NoDecode を付与し、カンマ区切りの文字列を JSON と誤解釈しないようにする。
+    # なぜ: Cloud Run などの環境変数では配列を JSON 形式で渡しづらく、
+    #       README でもカンマ区切りで指定する手順を案内しているため。
+    admin_email_allowlist: Annotated[tuple[str, ...], NoDecode] = Field(
         default=(),
         description=(
             "Email addresses allowed to sign in when restrict mode is enabled / "

--- a/tests/backend/test_config_admin_email_allowlist.py
+++ b/tests/backend/test_config_admin_email_allowlist.py
@@ -53,3 +53,18 @@ def test_non_production_can_skip_allowlist(environment: str) -> None:
     config = Settings(environment=environment, _env_file=None)
 
     assert config.admin_email_allowlist == ()
+
+
+def test_allowlist_accepts_comma_separated_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """カンマ区切りで指定した環境変数を JSON と誤解釈せずに読み込める。"""
+
+    monkeypatch.setenv("ADMIN_EMAIL_ALLOWLIST", "Admin@example.com,owner@example.com")
+
+    config = Settings(
+        environment="production",
+        allowed_hosts=(_CLOUD_RUN_HOST,),
+        session_secret_key=_SAFE_SECRET,
+        _env_file=None,
+    )
+
+    assert config.admin_email_allowlist == ("admin@example.com", "owner@example.com")


### PR DESCRIPTION
## 概要
- ADMIN_EMAIL_ALLOWLIST に NoDecode を付け、カンマ区切り指定を JSON と誤解釈しないように修正しました。
- 環境変数からの読み込みで正規化された許可リストを得られることを確認するテストを追加しました。

## テスト
- pytest -q tests/backend/test_config_admin_email_allowlist.py --cov=apps/backend/backend/config.py --cov-fail-under=0


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923ec903414832c83db6dcb7146a731)