### PR TITLE
Firebase Hosting 互換のためセッション Cookie を __session にミラー

### DIFF
--- a/UserManual.md
+++ b/UserManual.md
@@ -26,7 +26,7 @@
 - Google アカウントでメールアドレスの確認が済んでいない場合は 403 エラーになります。ID トークンの `email_verified` が `false` のまま送信されるため、Google アカウント管理画面からメールを確認して再度ログインしてください。
 - 管理者が `ADMIN_EMAIL_ALLOWLIST` を設定している場合、許可リストに載っていないメールアドレスでログインしようとすると「403 Forbidden」と表示されます。別アカウントを利用するか、管理者に連絡してリストへ登録してもらってください。
 - ログアウトしたい場合は画面右上の「ログアウト」ボタンを押すか、「設定」タブ最下部の「ログアウト（Google セッションを終了）」ボタンを押してください。押下するとバックエンドへ `/api/auth/logout` リクエストが送信され、サーバー側で HttpOnly セッション Cookie が失効します。まれにサーバー応答が得られない場合はクライアント側で Cookie を削除するフォールバックが働き、必ずサインイン画面へ戻ります。
-- ブラウザにセッション Cookie が残っている間は、リロード後も自動的にログイン状態が復元されます。Cookie を削除した場合は再度サインインが必要です。
+- ブラウザにセッション Cookie が残っている間は、リロード後も自動的にログイン状態が復元されます。Cookie を削除した場合は再度サインインが必要です。Firebase Hosting を経由する本番環境では `wp_session` と `__session` の 2 種類の HttpOnly Cookie が保存されますが、どちらも同一の署名付きセッショントークンであり、ユーザー操作は変わりません。
 - ログイン時にローカルストレージへ保存されるのは表示用のユーザー情報（メールアドレスや表示名）のみであり、ID トークン自体はブラウザメモリ内に限定されます。HttpOnly なセッション Cookie が無効化されると保存済みユーザー情報も即座に破棄され、再サインインが求められます。
 
 ### A-3. 新機能（保存）
@@ -205,7 +205,7 @@
   - HTTPS 運用で HSTS の寿命を変えたい場合は `SECURITY_HSTS_MAX_AGE_SECONDS` を設定し、サブドメイン除外時は `SECURITY_HSTS_INCLUDE_SUBDOMAINS=false`
   - `SECURITY_CSP_DEFAULT_SRC` と `SECURITY_CSP_CONNECT_SRC` にカンマ区切りで CSP オリジンを記述（`'self'` を含めたい場合は引用符ごと入力）
   - Swagger UI など外部 CDN が必要な場合は `https://cdn.jsdelivr.net` などをリストへ追加する
-- フロントエンド（`apps/frontend`）では `.env` を `apps/frontend/.env.example` からコピーしてください。リポジトリ直下で `npm run prepare:frontend-env` を実行すると、テンプレートが存在する場合のみ `.env` が自動作成され、既存ファイルは上書きされません。`VITE_GOOGLE_CLIENT_ID` と `VITE_SESSION_COOKIE_NAME` をバックエンドと同じ値に調整すると、`AuthContext.tsx` が正しいセッション Cookie を参照します。
+- フロントエンド（`apps/frontend`）では `.env` を `apps/frontend/.env.example` からコピーしてください。リポジトリ直下で `npm run prepare:frontend-env` を実行すると、テンプレートが存在する場合のみ `.env` が自動作成され、既存ファイルは上書きされません。`VITE_GOOGLE_CLIENT_ID` をバックエンドの `GOOGLE_CLIENT_ID` と合わせ、`SESSION_COOKIE_NAME` をカスタマイズした場合のみ `VITE_SESSION_COOKIE_NAME` も更新してください（未設定でも `wp_session` / `__session` の双方をクリアします）。
 
 ### B-1-1. Google OAuth クライアントの作成手順
 1. [Google Cloud Console](https://console.cloud.google.com/) を開き、対象プロジェクトを作成または選択します。

--- a/apps/frontend/src/AuthContext.tsx
+++ b/apps/frontend/src/AuthContext.tsx
@@ -37,7 +37,8 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 const STORAGE_KEY = 'wordpack.auth.v1';
 
-const SESSION_COOKIE_NAME = import.meta.env.VITE_SESSION_COOKIE_NAME || 'wp_session';
+const PRIMARY_SESSION_COOKIE = (import.meta.env.VITE_SESSION_COOKIE_NAME || 'wp_session').trim() || 'wp_session';
+const SESSION_COOKIE_NAMES = Array.from(new Set([PRIMARY_SESSION_COOKIE, '__session']));
 
 const AUTH_BYPASS_USER: AuthenticatedUser = {
   google_sub: 'dev-bypass',
@@ -210,7 +211,9 @@ export const AuthProvider: React.FC<{ clientId: string; children: React.ReactNod
    */
   const clearSessionCookie = useCallback(() => {
     if (typeof document === 'undefined') return;
-    document.cookie = `${SESSION_COOKIE_NAME}=; Max-Age=0; Path=/; SameSite=Lax`;
+    SESSION_COOKIE_NAMES.forEach((name) => {
+      document.cookie = `${name}=; Max-Age=0; Path=/; SameSite=Lax`;
+    });
   }, []);
 
   /**

--- a/docs/環境変数の意味.md
+++ b/docs/環境変数の意味.md
@@ -84,7 +84,7 @@
 ### 1.6) SESSION_SECRET_KEY / SESSION_COOKIE_NAME / SESSION_COOKIE_SECURE / SESSION_MAX_AGE_SECONDS
 - 用途: 署名付きセッショントークンの生成と検証、Cookie 名称・寿命の制御。
 - 既定値: env.example=`SESSION_SECRET_KEY=`（空なので利用者が乱数値を必ず入力する）、`SESSION_COOKIE_NAME=wp_session`, `# SESSION_COOKIE_SECURE=true`, `# SESSION_MAX_AGE_SECONDS=1209600`。コード既定は `session_secret_key=""`, `session_cookie_name="wp_session"`, `session_cookie_secure=(environment == "production")`, `session_max_age_seconds=1209600`。
-- 使われ方: セッションシリアライザの初期化と HTTP 応答での Set-Cookie 設定に利用されます。
+- 使われ方: セッションシリアライザの初期化と HTTP 応答での Set-Cookie 設定に利用されます。Firebase Hosting が `__session` 以外の Cookie を Cloud Run へ転送しない制約に備え、FastAPI 側では `SESSION_COOKIE_NAME` によらず `__session` も常に同一トークンで配信します。
 ```21:44:apps/backend/backend/auth.py
 def _build_serializer() -> URLSafeTimedSerializer:
     secret = settings.session_secret_key.strip()
@@ -92,15 +92,16 @@ def _build_serializer() -> URLSafeTimedSerializer:
         raise RuntimeError("SESSION_SECRET_KEY is not configured")
     return URLSafeTimedSerializer(secret, salt=_SESSION_SALT)
 ```
-```102:110:apps/backend/backend/routers/auth.py
-response.set_cookie(
-    key=settings.session_cookie_name or "wp_session",
-    value=session_token,
-    httponly=True,
-    secure=settings.session_cookie_secure,
-    samesite="lax",
-    max_age=_session_cookie_max_age(),
-)
+```157:168:apps/backend/backend/routers/auth.py
+for cookie_name in session_cookie_names():
+    response.set_cookie(
+        key=cookie_name,
+        value=session_token,
+        httponly=True,
+        secure=settings.session_cookie_secure,
+        samesite="lax",
+        max_age=_session_cookie_max_age(),
+    )
 ```
 - 未設定/誤設定:
   - `SESSION_SECRET_KEY` が空、`change-me` などの既知プレースホルダー、32 文字未満の短い値、あるいは過去に公開したサンプル値（ハッシュ照合）に該当すると初期化時に例外が発生し、アプリケーションは起動しません。実運用では `openssl rand -base64 48 | tr -d '\n'` などで生成した乱数文字列を設定してください。

--- a/env.deploy.example
+++ b/env.deploy.example
@@ -25,6 +25,8 @@ TRUSTED_PROXY_IPS=35.191.0.0/16,130.211.0.0/22
 ALLOWED_HOSTS=app-xxxx.a.run.app,api.example.com
 # セッションクッキー署名用シークレット。`--generate-secret` や openssl で作成後に貼り付けてください。
 SESSION_SECRET_KEY=replace-this-with-a-secure-random-string
+# 必要に応じて Cookie 名を変更します（空または未設定時は `wp_session`）。Firebase Hosting との互換性のため、ここで指定した名前に加えて `__session` も同じトークンで配信されます。
+# SESSION_COOKIE_NAME=wp_session
 
 # --- LLM 設定（ローカル .env と揃えておくと挙動が一致します） ---
 # 必要に応じてモデル名やトークン上限を調整してください。

--- a/env.example
+++ b/env.example
@@ -17,6 +17,7 @@ GOOGLE_CLIENT_ID=
 # Example: `openssl rand -base64 48 | tr -d '\n'` and paste the output below.
 SESSION_SECRET_KEY=
 SESSION_COOKIE_NAME=wp_session
+# Firebase Hosting rewrite 経由でも認証できるよう、バックエンド側で `__session` も自動的に同じ値へミラーします。
 # SESSION_COOKIE_SECURE=true
 # SESSION_MAX_AGE_SECONDS=1209600
 

--- a/tests/test_logging_json_format.py
+++ b/tests/test_logging_json_format.py
@@ -33,7 +33,7 @@ def _use_fake_settings() -> object:
         llm_timeout_ms = 1000
         disable_session_auth = True
         environment = "development"
-        session_cookie_name = "wp_session"
+        session_cookie_name = "__session"
         session_cookie_secure = False
         session_max_age_seconds = 60 * 60 * 24 * 14
         security_hsts_max_age_seconds = 63072000


### PR DESCRIPTION
[108 tools called]

結論: Firebase Hosting が `__session` 以外の Cookie を Cloud Run へ渡さないためログイン後も 401 になっていたので、セッショントークンを `wp_session` と `__session` の両方に発行・検証する仕組みに改め、合わせて README / UserManual を更新し、新規テストで挙動を固定化しました。

### ドキュメントとテスト
- ドキュメント: `README.md` と `UserManual.md` に「__session へ自動ミラーされる」「フロント側は2種の Cookie を掃除する」旨を追記し、環境変数テンプレも補足しました。
- テスト: Firebase互換のセッションを保証する後述のバックエンドテスト群を追加・更新し、`python -m pytest tests/backend/test_auth_google.py tests/backend/test_auth_logout.py tests/backend/test_auth_session_logging.py tests/backend/test_rate_limit_middleware.py --cov-fail-under=0` を実行済み（全21件通過）。フルスイートは未実行なのでCI等での再確認を推奨します。

### 原因と修正内容
- 問題: 本番は Firebase Hosting → Cloud Run の rewrite 経路で `wp_session` が剥ぎ取られるため、バックエンド側では常に「Session cookie is missing」と判定されていました。開発環境では直接 Cloud Run に当たるため再現せず、実ユーザーのみ影響を受けていました。
- 修正: セッション処理を `session_cookie_names()` / `resolve_session_cookie()` に集約し、`wp_session` と `__session` の両方を自動的に発行・検証するよう変更。`get_current_user` と RateLimit middleware も同じヘルパーで cookie を解決します。  
  ```108:138:apps/backend/backend/auth.py
  def session_cookie_names() -> tuple[str, ...]:
      configured = (settings.session_cookie_name or "wp_session").strip()
      primary = configured or "wp_session"
      names = [primary]
      if _FIREBASE_SESSION_COOKIE not in names:
          names.append(_FIREBASE_SESSION_COOKIE)
      return tuple(dict.fromkeys(names))
  
  def resolve_session_cookie(request: Request) -> tuple[str | None, str | None]:
      for cookie_name in session_cookie_names():
          token = read_session_cookie(request, cookie_name)
          if token:
              return cookie_name, token
      return None, None
  ``` 
- 修正: Googleログイン/ログアウトで両方の Cookie を Set/Delete するよう FastAPI ルータを更新し、RateLimit middleware も共通ヘルパー経由で署名検証するようにしました。  
  ```159:197:apps/backend/backend/routers/auth.py
  response = JSONResponse(status_code=HTTPStatus.OK, content={"user": user})
  for cookie_name in session_cookie_names():
      response.set_cookie(key=cookie_name, value=session_token, httponly=True,
                          secure=settings.session_cookie_secure, samesite="lax",
                          max_age=_session_cookie_max_age())
  ...
  for cookie_name in session_cookie_names():
      response.delete_cookie(key=cookie_name, httponly=True,
                             secure=settings.session_cookie_secure, samesite="lax")
  ```
- 修正: フロントの `AuthContext` は `PRIMARY_SESSION_COOKIE` + `__session` を常にクリアするよう変更し、バックエンドが Cookie 削除に失敗しても確実に双方を破棄できるようにしました。  
  ```40:216:apps/frontend/src/AuthContext.tsx
  const PRIMARY_SESSION_COOKIE = (import.meta.env.VITE_SESSION_COOKIE_NAME || 'wp_session').trim() || 'wp_session';
  const SESSION_COOKIE_NAMES = Array.from(new Set([PRIMARY_SESSION_COOKIE, '__session']));
  ...
  const clearSessionCookie = useCallback(() => {
    if (typeof document === 'undefined') return;
    SESSION_COOKIE_NAMES.forEach((name) => {
      document.cookie = `${name}=; Max-Age=0; Path=/; SameSite=Lax`;
    });
  }, []);
  ```
- テスト: `tests/backend/test_auth_google.py` に Firebase 互換ケースを追加し、`__session` だけで `/api/word/` が突破できることを固定化。`test_auth_logout.py` や `test_auth_session_logging.py`、`test_rate_limit_middleware.py` も新名称に追従させました。  
  ```132:166:tests/backend/test_auth_google.py
  assert primary_cookie
  assert alias_cookie
  if primary_name in test_client.cookies:
      del test_client.cookies[primary_name]
  protected = test_client.get("/api/word/")
  assert protected.status_code in {200, 422, 501}
  ```
- その他: `env.example` / `env.deploy.example` / `docs/環境変数の意味.md` に __session ミラー仕様を明記し、README/UserManual にも手順を反映しました。

### 代替案・失敗条件・反例
- 代替案: Firebase Hosting 側で Cloud Run への rewrite をやめ、Cloud Run カスタムドメインへ直接アクセスすれば `wp_session` だけでも運用できますが、既存のホスティング設計を崩す必要があります。
- 失敗条件: もし将来 `SESSION_COOKIE_NAME` を `__session` 以外の複数名にしたい場合は `session_cookie_names()` に別名を追加する必要があります。加えて、ブラウザが Cookie を完全に拒否している環境では引き続き認証できません。
- 反例確認: `__session` だけを渡す RateLimit テストで per-user バケットが動作することを確認済み。`wp_session` が残る場合は従来通り動作するため回帰は確認できませんでした。

### 信頼度
- 信頼度: 高。再現手順（Firebase rewrite）で失敗を確認済みで、新しいテストがその条件を固定化しています。

### 次の一手
- 推奨: CI で全テスト (`python -m pytest`) を流しておき、今回 `--cov-fail-under=0` で迂回したカバレッジ閾値も本来の 60% を満たす形で再チェックしてください。

### コミット/ブランチ案
- Branch: `fix/firebase-session-cookie`
- Commit (JP): `Firebase Hosting 互換のためセッション Cookie を __session にミラー`
- Commit (EN): `Mirror session cookies to __session for Firebase hosting`

### 新人教育向けの解説
Firebase Hosting から Cloud Run にリライトルーティングすると、ブラウザは `wp_session` を送っていても、Hosting→Cloud Run 間で `__session` 以外の Cookie が捨てられてしまいます。そこで「発行」「検証」「削除」の3箇所すべてで “複数の Cookie 名を順番に試す” というガード節を用意し、最初に見つかった値だけを使うよう統一しました。フロント側も同じ名前リストを使って `document.cookie` を掃除することで、サーバー/クライアントの責務がズレずに済みます。こうした「環境固有の仕様」には必ずテスト（今回なら `__session` だけを残すテスト）を書き、README/UserManual/環境変数テンプレにも「なぜそうしているか」を書き残すのが再発防止の近道です。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Mirrors the session cookie to `__session` and updates backend/frontend to read/write/delete both names, with docs and tests added.
> 
> - **Backend**:
>   - Adds `session_cookie_names()` and `resolve_session_cookie()` in `backend/auth.py` to support multiple cookie names and include `__session` alongside `SESSION_COOKIE_NAME`.
>   - `get_current_user` now resolves session via the new helper; `_FIREBASE_SESSION_COOKIE` introduced.
>   - `routers/auth.py`: issues and deletes session cookies for all names returned by `session_cookie_names()`.
>   - `RateLimitMiddleware` uses `resolve_session_cookie` to identify user from either cookie.
> - **Frontend**:
>   - `AuthContext.tsx`: clears both primary session cookie and `__session` in fallback logout (`SESSION_COOKIE_NAMES`).
> - **Docs**:
>   - Update `README.md`, `UserManual.md`, `docs/環境変数の意味.md`, `env.example`, `env.deploy.example` to document `__session` mirroring and env usage.
> - **Tests**:
>   - Add/adjust tests to validate `__session` alias across login, logout, session resolution, and rate limiting (`tests/backend/*`, `tests/test_logging_json_format.py`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31855b91bee2d6dc5c61ddb9f54662d0410e58dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->