### PR TITLE
CI環境の許可リスト設定とセキュリティヘッダーテストの安定化

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -10,6 +10,7 @@ ALLOWED_HOSTS=api.ci.wordpack.example.com,localhost,testserver
 # ProxyHeadersMiddleware 用に GCLB 既定の CIDR を適用し、CI でも検証を通過させる。
 TRUSTED_PROXY_IPS=35.191.0.0/16,130.211.0.0/22
 # CSP/HSTS などのセキュリティヘッダ向け既定値を明示し、テストの意図をドキュメント化。
+ADMIN_EMAIL_ALLOWLIST=test@example.com
 SECURITY_HSTS_MAX_AGE_SECONDS=63072000
 SECURITY_HSTS_INCLUDE_SUBDOMAINS=true
 SECURITY_HSTS_PRELOAD=false


### PR DESCRIPTION
## 概要
- セキュリティヘッダー検証テスト用に環境と管理者メール許可リストを自動上書きするフィクスチャを追加し、設定バリデーションで落ちないようにしました。
- CI 用環境変数ファイルに ADMIN_EMAIL_ALLOWLIST のダミー値を追加し、本番相当環境でも起動チェックを通過するようにしました。

## テスト
- `pytest -q --no-cov tests/test_security_headers.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69259e907b18832c8537cbc4d3549920)