### PR TITLE
CI環境の管理者許可リストを追加してデプロイ検証を通過

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,6 @@ API_KEY=change-me
 ALLOWED_ORIGINS=http://localhost
 # TRUSTED_PROXY_IPS=35.191.0.0/16,130.211.0.0/22
 # ALLOWED_HOSTS=app-1234567890-uc.a.run.app,api.example.com
+# Production では必須。CI/検証で ENVIRONMENT=production を使う場合はダミー値を設定し、
+# 本番デプロイ時は実際の許可メールアドレスに置き換えてください。
 ADMIN_EMAIL_ALLOWLIST=test@example.com

--- a/configs/cloud-run/ci.env
+++ b/configs/cloud-run/ci.env
@@ -9,4 +9,5 @@ TRUSTED_PROXY_IPS=35.191.0.0/16,130.211.0.0/22
 ALLOWED_HOSTS=ci-wordpack.a.run.app,api-ci.wordpack.dev
 GOOGLE_CLIENT_ID=1234567890-ci.apps.googleusercontent.com
 GOOGLE_ALLOWED_HD=wordpack.dev
+ADMIN_EMAIL_ALLOWLIST=ci-admin@example.com
 OPENAI_API_KEY=dummy-openai-key

--- a/env.example
+++ b/env.example
@@ -7,7 +7,8 @@ STRICT_MODE=true
 GOOGLE_CLIENT_ID=
 # Optional: Restrict sign-in to Google Workspace domain (example.com)
 # GOOGLE_ALLOWED_HD=
-# Optional: Restrict sign-in to specific email addresses (comma separated)
+# Optional in development: Restrict sign-in to specific email addresses (comma separated).
+# ENVIRONMENT=production では必須となるため、デプロイ前に本番の許可リストへ置き換えてください。
 # ADMIN_EMAIL_ALLOWLIST=admin@example.com,owner@example.com
 # Optional: Allow small clock skew when verifying Google ID tokens (seconds)
 # GOOGLE_CLOCK_SKEW_SECONDS=60


### PR DESCRIPTION
## 変更概要
- Cloud Run CI 用 env (`configs/cloud-run/ci.env`) にダミーの管理者メール許可リストを追加し、ENVIRONMENT=production の必須チェックを満たすようにしました。
- `.env.example` および `env.example` に ADMIN_EMAIL_ALLOWLIST の必須条件を明示するコメントを追加し、開発と本番の使い分けをわかりやすくしました。

## テスト
- ./scripts/deploy_cloud_run.sh --dry-run --env-file configs/cloud-run/ci.env --project-id ci-placeholder-project --region asia-northeast1 --service wordpack-backend

## ドキュメント
- 既存の README.md / UserManual.md に同変数の記載があるため追記は不要と判断しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a9967074832c9c3a61c005cc18ed)