### PR TITLE
README と Cloud Run デプロイの必須設定チェックを強化

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ GitHub Actions では `deploy-dry-run.yml` が pull_request と main ブラン�
   - `PROJECT_ID` と `REGION` を Make 実行時に必ず指定する（gcloud の既定値には依存しません）。
   - Firestore Admin / Cloud Run Admin / Artifact Registry Writer 権限を持つサービスアカウントで `gcloud auth login` または `gcloud auth activate-service-account` を済ませ、`gcloud auth configure-docker` も完了させておく。
 - `.env.deploy` など本番用の env ファイルを準備し、`ADMIN_EMAIL_ALLOWLIST` / `SESSION_SECRET_KEY` / `CORS_ALLOWED_ORIGINS` / `TRUSTED_PROXY_IPS` / `ALLOWED_HOSTS` を必ず含める（`ENV_FILE` でパスを切り替え可能）。開発環境と同じメールアドレスだけが Cloud Run でも認証を通過することを確認してください。
+- `ENVIRONMENT=production` では `ADMIN_EMAIL_ALLOWLIST` が空のままだと Pydantic 設定の検証で即座に失敗し、Google ログインの許可対象が不明な状態で本番デプロイへ進むことを防ぎます。CI では `configs/cloud-run/ci.env` にダミーの許可アドレス（例: `ci-admin@example.com`）を入れた上で dry-run を実行し、本番と同じ必須性チェックを通しています。
 - 使い方
 
 ```bash


### PR DESCRIPTION
## 概要
- デプロイ/CI セットアップに `ENVIRONMENT=production` 時の `ADMIN_EMAIL_ALLOWLIST` 必須と CI でのダミー値利用を追記
- `scripts/deploy_cloud_run.sh` で前段チェック対象の必須環境変数を一覧化し、欠落時はバリデーション前に停止することを明示
- CI 想定の `release-cloud-run` を dry-run で実行し、新しい手順で設定検証が通ることを確認

## テスト
- make SHELL=/bin/bash SKIP_FIRESTORE_INDEX_SYNC=true DRY_RUN=true ENV_FILE=configs/cloud-run/ci.env PROJECT_ID=ci-placeholder-project REGION=asia-northeast1 release-cloud-run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925c805c810832c91f0bf4c6e022bdd)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens Cloud Run deployment by enforcing preflight checks for required env vars and updates README with production allowlist and CI guidance.
> 
> - **Deploy Script (`scripts/deploy_cloud_run.sh`)**:
>   - Add `REQUIRED_DEPLOY_KEYS` array (`ADMIN_EMAIL_ALLOWLIST`, `SESSION_SECRET_KEY`, `CORS_ALLOWED_ORIGINS`, `TRUSTED_PROXY_IPS`, `ALLOWED_HOSTS`).
>   - Preflight validation: log required keys and exit early if any are unset (before Pydantic/gcloud).
> - **Docs (`README.md`)**:
>   - Document that `ENVIRONMENT=production` requires non-empty `ADMIN_EMAIL_ALLOWLIST`; CI should use a dummy allowlisted email in `configs/cloud-run/ci.env`.
>   - Update release flow notes to reflect the stricter preflight/dry-run validation in CI and deployment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b3580d3565842c9b5a25d0e950c66a47b4178a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->