### PR TITLE
ログ: 5xxレスポンスをERRORとして記録しテスト追加

### DIFF
--- a/apps/backend/backend/main.py
+++ b/apps/backend/backend/main.py
@@ -184,6 +184,12 @@ class AccessLogAndMetricsMiddleware(BaseHTTPMiddleware):
                             error_type = "HTTPUnauthorized"
                         if error_message is None:
                             error_message = "HTTP 401 Unauthorized"
+                    if isinstance(status_code, int) and status_code >= 500:
+                        is_error = True
+                        if error_type is None:
+                            error_type = f"HTTP{status_code}"
+                        if error_message is None:
+                            error_message = f"HTTP {status_code} response"
                 except Exception:  # pragma: no cover - ログ用補完に失敗しても本処理は継続
                     pass
                 return response


### PR DESCRIPTION
[11 tools called]

結論: 5xxレスポンス（例外化されないケースを含む）が Cloud Logging で ERROR として確実に拾われるようにミドルウェアを補強し、その挙動をテストで固定化しました。信頼度: 高。

変更内容:
- 5xxレスポンスを検知して `is_error=True`・`error_type`/`error_message` を補完し、必ず `logger.error` で出力するようにアクセスログを修正。401の扱いは維持。  
```156:195:apps/backend/backend/main.py
                response = await call_next(request)
                status_code = getattr(response, "status_code", None)
                ...
                try:
                    if (
                        not is_error
                        and isinstance(status_code, int)
                        and status_code == 401
                    ):
                        is_error = True
                        if error_type is None:
                            error_type = "HTTPUnauthorized"
                        if error_message is None:
                            error_message = "HTTP 401 Unauthorized"
                    if isinstance(status_code, int) and status_code >= 500:
                        is_error = True
                        if error_type is None:
                            error_type = f"HTTP{status_code}"
                        if error_message is None:
                            error_message = f"HTTP {status_code} response"
                except Exception:
                    pass
```
- 例外が発生しない 502 応答でも ERROR ログになることを検証するテストを追加。  
```369:405:tests/test_logging_json_format.py
def test_request_log_marks_5xx_response_as_error() -> None:
    """例外化されない 5xx レスポンスも ERROR として記録する。"""
    ...
            @app.get("/fail502")
            async def fail502() -> JSONResponse:
                return JSONResponse({"detail": "upstream error"}, status_code=502)
    ...
    assert data.get("status_code") == 502
    assert data.get("is_error") is True
    assert data.get("severity") == "ERROR"
    assert data.get("error_type") in {"HTTP502", "HTTP 502", "HTTPError"}
```

根本原因:
- AccessLog ミドルウェアは例外時のみ `is_error=True` にしていたため、アプリがレスポンスとして 5xx を返した場合（HTTPException がレスポンス化されるケース含む）でも INFO ログとなり、Cloud Logging でエラーとしてカウントされなかった。

テスト:
- `python -m pytest tests/test_logging_json_format.py --override-ini addopts="" -p no:cov`（既定の addopts でカバレッジ下限に引っかかるため、単体確認では ini を上書き）

ドキュメント更新:
- API/UI 仕様変更なし・ログ粒度のみの内部改善のため README/UserManual は更新不要と判断。

リスク/代替・反例:
- 既存ログのフォーマット/キーは維持しており後方互換性は高い。もし 5xx を INFO で扱うことに依存した外部集計があれば警告ログ件数が増える可能性（代替: 5xx だけ別 sink を追加）。反例として 499/408 などクライアント中断系は現状 INFO のまま。

次の確認ポイント:
- 本番 GCP ログで 5xx リクエストが `severity=ERROR` で出力されることを1件確認。
- 追加で実行する際は既定の addopts に戻してフルスイートを推奨。

コミットメッセージ案:
- 日本語: `ログ: 5xxレスポンスをERRORとして記録しテスト追加`
- 英語: `Log: mark 5xx responses as ERROR and add coverage`

ブランチ名案:
- `fix/5xx-error-logging`

新人向け解説:
- 何を直したか: アクセスログが 5xx レスポンスをエラー扱いしていなかったので、Cloud Logging にも ERROR で載らなかった問題を修正しました。
- どこを直したか: `AccessLogAndMetricsMiddleware` でレスポンスのステータスコードを見て 500 以上なら `is_error=True` にし、`error_type`/`error_message` を埋めてからエラーログを出すようにしました。テストでは 502 を返す簡単なエンドポイントを追加し、ログ出力が ERROR になることを確認しています。
- 影響: API の挙動は変わらず、ログとメトリクスだけがより正確になります。 Cloud Logging で 5xx が確実にエラーとして表示されるようになります。
- ローカル確認方法: 上の pytest コマンドでログ用テストだけを動かせます。CI では既定の addopts（カバレッジ付き）で全体を回す想定です。