### PR TITLE
deploy: Cloud Run の timeout/no-cpu-throttling をデプロイ引数で指定可能にする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ DEPLOY_CLOUD_RUN_ARGS = $(if $(PROJECT_ID),--project-id $(PROJECT_ID),) \
         $(if $(BUILD_ARG),--build-arg $(BUILD_ARG),) \
         $(if $(MACHINE_TYPE),--machine-type $(MACHINE_TYPE),) \
         $(if $(BUILD_TIMEOUT),--timeout $(BUILD_TIMEOUT),) \
+        $(if $(RUN_TIMEOUT),--run-timeout $(RUN_TIMEOUT),) \
+        $(if $(NO_CPU_THROTTLING),--no-cpu-throttling,) \
         $(if $(GENERATE_SECRET),--generate-secret,) \
         $(if $(SECRET_LENGTH),--secret-length $(SECRET_LENGTH),) \
         $(if $(DRY_RUN),--dry-run,) \

--- a/README.md
+++ b/README.md
@@ -225,6 +225,13 @@ make release-cloud-run \
   REGION=asia-northeast1 \
   ENV_FILE=.env.deploy
 
+# Cloud Run のリクエストタイムアウトを明示する場合（例: 360s）
+make release-cloud-run \
+  PROJECT_ID=my-prod-project \
+  REGION=asia-northeast1 \
+  ENV_FILE=.env.deploy \
+  RUN_TIMEOUT=360s
+
 # GitHub Actions 等でインデックス同期を省略し、CI専用 env を使う場合
 make release-cloud-run \
   PROJECT_ID=${{ env.GCP_PROJECT_ID }} \
@@ -234,6 +241,7 @@ make release-cloud-run \
 ```
 
 - `SKIP_FIRESTORE_INDEX_SYNC=true` を付けると Firestore 側を更新せず Cloud Run デプロイのみを実行します（既にインデックスを同期済みの CI/CD 環境向け）。
+- `RUN_TIMEOUT=360s` のように指定すると Cloud Run のリクエストタイムアウト（`gcloud run deploy --timeout`）を明示できます。
 - release-cloud-run は先に `make deploy-firestore-indexes` を呼び出してから `SKIP_FIRESTORE_INDEX_SYNC=true` を付けて `scripts/deploy_cloud_run.sh` を実行します。CI などでインデックス同期自体を省略したい場合は `SKIP_FIRESTORE_INDEX_SYNC=true make release-cloud-run PROJECT_ID=... REGION=...` のように指定してください。
 - Dry-run (`scripts/deploy_cloud_run.sh --dry-run`) は必ず本番デプロイの直前に走るため、設定エラーは gcloud コマンドの前で検知されます。
 - `ENV_FILE` を省略した場合でも `.env.deploy` の存在確認を行い、欠落しているとターゲットが失敗します。

--- a/env.deploy.example
+++ b/env.deploy.example
@@ -36,6 +36,16 @@ LLM_TIMEOUT_MS=45000
 LLM_MAX_RETRIES=1
 LLM_MAX_TOKENS=1500
 
+# Cloud Run のリクエストタイムアウト（任意）
+# Firebase Hosting のリライトに起因する 60 秒制限は別問題のため、
+# ここは Cloud Run 側の上限を伸ばしたい場合にのみ設定します。
+# 例: 360s（6分） / 10m（10分）
+CLOUD_RUN_TIMEOUT=360s
+
+# Cloud Run の CPU スロットリング無効化（任意）
+# true にすると、レスポンス送信後も CPU が割り当てられ続けます（運用コスト注意）。
+CLOUD_RUN_NO_CPU_THROTTLING=false
+
 # --- API キー / モデル設定 ---
 # OpenAI など LLM の API キー。CI 用ダミー値はコミットせず、本番値をローカルで設定してください。
 OPENAI_API_KEY=replace-with-real-openai-api-key


### PR DESCRIPTION
了解です。やることは2つに分けます。まず「60秒制限がどこに明記されているか」を一次情報（公式ドキュメント or 公式Issue/FAQ）で探して提示します。並行して、いったん運用上の対処として **Cloud Run 側の timeout を 360s に固定できるようにデプロイスクリプトを対応**し、README/envテンプレも更新します（Hosting 側が原因なら根治ではない点は明示します）。

[14 tools called]

### まず「一旦上記」の対応（360sへ）
**Hosting の60秒制限自体は変えられない可能性が高い**ので根治ではないですが、要望どおり **Cloud Run 側の timeout を 360s で管理できるように**対応しました。

- `scripts/deploy_cloud_run.sh` に以下を追加  
  - `--run-timeout 360s`（= `gcloud run deploy --timeout` を付与）  
  - `--no-cpu-throttling`（任意）
  - env ファイルから `CLOUD_RUN_TIMEOUT` / `CLOUD_RUN_NO_CPU_THROTTLING` を読めるように
- `Makefile` に `RUN_TIMEOUT` / `NO_CPU_THROTTLING` を追加
- `env.deploy.example` と `README.md` に使い方を追記

使い方（例）:

```bash
make release-cloud-run \
  PROJECT_ID=wordpack-for-english \
  REGION=asia-northeast1 \
  ENV_FILE=.env.deploy \
  RUN_TIMEOUT=360s
```

---

### 「60sが変えられない」根拠（公式ドキュメントのどこ？）
正直に言うと、**Firebase Hosting → Cloud Run リライトの “60秒固定” を Firebase の公式ドキュメント本文で明確に断言している一次情報**を、今の web 検索では特定できていません（見つかったのは Qiita/ブログやフォーラム/Issue 系の二次情報が中心でした）。なので、先ほどの **信頼度は中**のままです。

ただし、あなたが出してくれた 502 のレスポンスヘッダ（`text/html`、`x-cache`、`x-served-by`、かつ `X-Request-ID` が無い）から、**アプリ（Cloud Run/FastAPI）ではなく Hosting/CDN 側が返している**のは強く示唆されます（ここは一次観測なので **信頼度: 高**）。

---

### 次にやるべき確認（公式に近い一次観測）
「本当に Hosting 側が 60 秒で落としている」ことを **GCPログで一次観測**して確定させましょう。これが一番強い根拠になります。

```bash
gcloud logging read \
  'logName="projects/wordpack-for-english/logs/firebasehosting.googleapis.com%2Frequests" httpRequest.status=502 httpRequest.requestUrl:"/api/word/packs"' \
  --project=wordpack-for-english \
  --freshness=1h \
  --limit=50 \
  --format='table(timestamp,httpRequest.status,httpRequest.latency,httpRequest.requestUrl,jsonPayload.statusDetails)'
```

ここで `statusDetails` が `response_timeout` 系で `latency` が約 60s なら、**「60秒制限（少なくとも現状の経路では）」は事実として確定**できます。

---

### 付記（新人向け）
- “公式ドキュメントに明記”が無い場合でも、**実システムの一次観測（ログの resource/logName/statusDetails/latency）**は同等かそれ以上に強い根拠になります。
- そして、経路の手前（Hosting/CDN）が落としているなら、Cloud Run 側をどれだけ伸ばしても **同一経路のままでは解けません**。その場合の根治は **非同期化（202→ポーリング）**か **経路変更**です。

---

コミットメッセージ案:
- 日本語: `deploy: Cloud Run の timeout/no-cpu-throttling をデプロイ引数で指定可能にする`
- English: `deploy: allow setting Cloud Run timeout and CPU throttling via deploy args`
ブランチ名案: `chore/deploy-run-timeout`