### PR TITLE
WordPack再生成を非同期化し、60秒タイムアウトと通知誤判定を解消

### DIFF
--- a/apps/frontend/src/ArticleImportPanel.test.tsx
+++ b/apps/frontend/src/ArticleImportPanel.test.tsx
@@ -68,9 +68,15 @@ describe('ArticleImportPanel model/params wiring (mocked fetch)', () => {
           { status: 200, headers: { 'Content-Type': 'application/json' } },
         );
       }
-      if (url.endsWith('/api/word/packs/wp:regen:1/regenerate') && init?.method === 'POST') {
+      if (url.endsWith('/api/word/packs/wp:regen:1/regenerate/async') && init?.method === 'POST') {
         return new Response(
-          JSON.stringify({ ok: true }),
+          JSON.stringify({ job_id: 'job:regen:1', status: 'succeeded' }),
+          { status: 202, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      if (url.endsWith('/api/word/packs/wp:regen:1/regenerate/jobs/job:regen:1')) {
+        return new Response(
+          JSON.stringify({ job_id: 'job:regen:1', status: 'succeeded' }),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
         );
       }
@@ -287,7 +293,7 @@ describe('ArticleImportPanel model/params wiring (mocked fetch)', () => {
     });
 
     const regenBodies = fetchMock.mock.calls
-      .filter((c) => (typeof c[0] === 'string' ? (c[0] as string).endsWith('/api/word/packs/wp:regen:1/regenerate') : ((c[0] as URL).toString().endsWith('/api/word/packs/wp:regen:1/regenerate'))))
+      .filter((c) => (typeof c[0] === 'string' ? (c[0] as string).endsWith('/api/word/packs/wp:regen:1/regenerate/async') : ((c[0] as URL).toString().endsWith('/api/word/packs/wp:regen:1/regenerate/async'))))
       .map((c) => (c[1]?.body ? JSON.parse(c[1]!.body as string) : {}));
     expect(regenBodies.some((b) => b.model === 'gpt-5-nano' && b.reasoning && b.text && !('temperature' in b))).toBe(true);
   });
@@ -315,7 +321,7 @@ describe('ArticleImportPanel model/params wiring (mocked fetch)', () => {
     });
 
     const regenBodies = fetchMock.mock.calls
-      .filter((c) => (typeof c[0] === 'string' ? (c[0] as string).endsWith('/api/word/packs/wp:regen:1/regenerate') : ((c[0] as URL).toString().endsWith('/api/word/packs/wp:regen:1/regenerate'))))
+      .filter((c) => (typeof c[0] === 'string' ? (c[0] as string).endsWith('/api/word/packs/wp:regen:1/regenerate/async') : ((c[0] as URL).toString().endsWith('/api/word/packs/wp:regen:1/regenerate/async'))))
       .map((c) => (c[1]?.body ? JSON.parse(c[1]!.body as string) : {}));
     expect(regenBodies.some((b) => b.model === 'gpt-4o-mini' && typeof b.temperature === 'number' && !('reasoning' in b) && !('text' in b))).toBe(true);
   });

--- a/apps/frontend/src/WordPackListPanel.actions-layout.test.tsx
+++ b/apps/frontend/src/WordPackListPanel.actions-layout.test.tsx
@@ -63,8 +63,11 @@ describe('WordPackListPanel card actions layout (two rows)', () => {
         );
       }
 
-      if (url.endsWith('/api/word/packs/wp:test:1/regenerate') && method === 'POST') {
-        return new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      if (url.endsWith('/api/word/packs/wp:test:1/regenerate/async') && method === 'POST') {
+        return new Response(JSON.stringify({ job_id: 'job:test:1', status: 'succeeded' }), { status: 202, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url.endsWith('/api/word/packs/wp:test:1/regenerate/jobs/job:test:1') && method === 'GET') {
+        return new Response(JSON.stringify({ job_id: 'job:test:1', status: 'succeeded' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
 
       if (url.startsWith('/api/word/packs/wp:test:') && method === 'DELETE') {

--- a/apps/frontend/src/WordPackListPanel.modal.test.tsx
+++ b/apps/frontend/src/WordPackListPanel.modal.test.tsx
@@ -94,9 +94,15 @@ describe('WordPackListPanel modal preview', () => {
         );
       }
 
-      if (url.endsWith('/api/word/packs/wp:test:1/regenerate')) {
+      if (url.endsWith('/api/word/packs/wp:test:1/regenerate/async')) {
         return new Response(
-          JSON.stringify({ message: 'regenerating' }),
+          JSON.stringify({ job_id: 'job:test:1', status: 'succeeded' }),
+          { status: 202, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      if (url.endsWith('/api/word/packs/wp:test:1/regenerate/jobs/job:test:1')) {
+        return new Response(
+          JSON.stringify({ job_id: 'job:test:1', status: 'succeeded' }),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
         );
       }
@@ -510,7 +516,7 @@ describe('WordPackListPanel modal preview', () => {
 
     await waitFor(() =>
       expect(fetchMock).toHaveBeenCalledWith(
-        '/api/word/packs/wp:test:1/regenerate',
+        '/api/word/packs/wp:test:1/regenerate/async',
         expect.objectContaining({ method: 'POST' }),
       ),
     );

--- a/apps/frontend/src/hooks/useWordPack.ts
+++ b/apps/frontend/src/hooks/useWordPack.ts
@@ -348,7 +348,9 @@ export const useWordPack = ({
           abortSignal: ctrl.signal,
         });
 
-        const maxPolls = Math.max(3, Math.ceil(requestTimeoutMs / 2000));
+        // requestTimeoutMs が短くても（例: 60_000）再生成は数分かかり得るため、
+        // ここでは最低 15 分相当までポーリングを継続する。
+        const maxPolls = Math.max(3, Math.ceil(Math.max(requestTimeoutMs, 15 * 60 * 1000) / 2000));
         let latest = job;
         for (let i = 0; i < maxPolls; i += 1) {
           if (ctrl.signal.aborted) break;


### PR DESCRIPTION
まず原因切り分けから入ります。いまの「60秒で通知だけ失敗」は、①まだ同期の `/api/word/pack`（新規生成）が走っていてHosting側60sに当たっている、②非同期化したはずの再生成でもポーリング上限/タイムアウトが60sになっている、のどちらかが濃厚です。コード上でどのAPIが叩かれているかを特定し、通知が「完了まで待つ」ように直します。

[25 tools called]

対応しました。**通知が60秒で失敗扱いになる原因は、フロント側の「待つ上限（requestTimeoutMs）」が短い値（60,000ms等）になっている場合に、ポーリングが途中で打ち切られて“失敗”に見えてしまう**ためです。

## 変更内容（フロントのみ）
- `apps/frontend/src/lib/wordpack.ts` の `regenerateWordPackRequest`  
  - ポーリングの待機上限を **最低15分**に引き上げ（`requestTimeoutMs` が短くても完了まで待つ）
- `apps/frontend/src/hooks/useWordPack.ts` の再生成ポーリングも同様に **最低15分**へ

これで、**数分かかってもジョブが最終的に succeeded/failed になった時点で通知が success/error に確定**します（60秒で勝手に error になりません）。

## 次にやること
フロントをデプロイしてください（Hosting）:

```bash
firebase deploy --only hosting
```

デプロイ後に同じ操作を試して、通知が最後まで progress のまま→完了時に success/error へ変わることを確認できます。

---

### ブランチ名（英語）
- `feat/async-wordpack-regenerate`
- 代替: `fix/wordpack-regenerate-timeout`

### コミットメッセージ案（シンプル）
- 日本語: `再生成: 非同期ジョブ化して60秒タイムアウトを回避`
- English: `Regenerate: async job to avoid 60s proxy timeouts`

### PRタイトル案
- 日本語: `WordPack再生成を非同期化し、60秒タイムアウトと通知誤判定を解消`
- English: `Async WordPack regenerate to avoid 60s timeouts and fix notification status`

### PR本文テンプレ（コピペ用）
- **背景 / 問題**
  - Firebase Hosting 経由の `/api/**` で約60秒で 502（HTML）が返り、WordPack再生成が完了する前にクライアントが失敗扱いになる。
  - Cloud Run 側は後から 200 で完了するため、Cloud Run のエラーログでは追えないケースがある。
- **変更内容**
  - Backend: WordPack再生成を非同期ジョブ化
    - `POST /api/word/packs/{id}/regenerate/async`（202 + job_id）
    - `GET /api/word/packs/{id}/regenerate/jobs/{job_id}`（status/result）
  - Frontend: 再生成はジョブ起動→ポーリングで完了判定し、通知UIは処理完了時点で success/error に確定
    - ポーリング上限を最低15分に（短いタイムアウト値でも誤判定しない）
  - Deploy: Cloud Run timeout/no-cpu-throttling をデプロイ引数/環境変数で指定可能に
- **テスト**
  - `tests/backend/test_word_regenerate_async.py`（成功/404）
- **Docs**
  - `README.md` / `UserManual.md` を更新（再生成がバックグラウンドジョブである旨、デプロイ引数）
- **影響 / 注意**
  - ジョブ管理は現状インメモリのため、スケール/再起動でジョブが消える可能性あり（長期的には永続化/キュー化を検討）
- **Docs: updated**（README/UserManual）

### 新人教育向け（短く）
- 同期HTTPで長時間処理を返すと、手前のCDN/プロキシのタイムアウトでアプリに到達しない 502 が起きる。  
- 解決策は「非同期ジョブ＋状態取得（ポーリング）」が王道。