### PR TITLE
[codex] GoogleログインのクライアントIDを実行時設定から補完

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ npm run prepare:frontend-env
 # 既に .env がある場合や手動で書き換える場合は apps/frontend/.env.example を直接編集してください
 ```
 
-`VITE_GOOGLE_CLIENT_ID` はバックエンドの `GOOGLE_CLIENT_ID` と一致している必要があります。Google Console で発行した OAuth 2.0 Web クライアント ID を指定してください。`AuthContext.tsx` は `VITE_SESSION_COOKIE_NAME` が未設定でも `wp_session`/`__session` の両方をフォールバックで削除するため、FastAPI 側の `SESSION_COOKIE_NAME` をカスタマイズしたときだけ `.env` を更新すれば十分です。
+`VITE_GOOGLE_CLIENT_ID` はバックエンドの `GOOGLE_CLIENT_ID` と一致している必要があります。Google Console で発行した OAuth 2.0 Web クライアント ID を指定してください。本番ビルドで `VITE_GOOGLE_CLIENT_ID` が空だった場合でも、フロントエンドは起動時に `/api/config` から `GOOGLE_CLIENT_ID` を取得して Google ログインを初期化します。`AuthContext.tsx` は `VITE_SESSION_COOKIE_NAME` が未設定でも `wp_session`/`__session` の両方をフォールバックで削除するため、FastAPI 側の `SESSION_COOKIE_NAME` をカスタマイズしたときだけ `.env` を更新すれば十分です。
 
 バックエンド・フロントエンドのどちらも起動前に `.env` と `apps/frontend/.env` を用意し、`GOOGLE_CLIENT_ID`（必要に応じて `GOOGLE_ALLOWED_HD` や `ADMIN_EMAIL_ALLOWLIST`）、`SESSION_SECRET_KEY`、`VITE_GOOGLE_CLIENT_ID`、（必要なら）`VITE_SESSION_COOKIE_NAME` を設定しておくと、初回起動から Google ログインが有効になります。
 
@@ -398,6 +398,7 @@ Cloud Run や Firebase Hosting へ出荷する前に、上記の手順で Firest
 ### 認証フロー
 - フロントエンドへアクセスすると、まず Google アカウントでのサインイン画面が表示されます。
 - 「Googleでログイン」ボタンは Google Identity Services の `GoogleLogin` コンポーネントを用いており、承認後に `credential`（ID トークン）を取得して `/api/auth/google` へ送信し、セッション Cookie を受け取ります。credential が欠落した場合は直ちにエラー帯を表示し、`/api/diagnostics/oauth-telemetry` へ状況を送信して原因調査に活用します。
+- ビルド時の `VITE_GOOGLE_CLIENT_ID` が未設定でも、`/api/config` が `google_client_id` を返す環境では、その値で Google ログインボタンを表示します。バックエンド側の `GOOGLE_CLIENT_ID` も空の場合のみ設定案内を表示します。
 - サインイン画面の「ゲスト閲覧モード」ボタンを押すとログイン不要でアプリの閲覧ができます。ゲスト中は右上にバッジが固定表示され、ヘッダー右側の「ログアウト」ボタンからゲスト閲覧を終了できます。ブラウザを再読み込みしても同じ状態が復元されます。
 - ゲスト閲覧モードではAI機能（生成/再生成/削除などの操作ボタン）が無効化され、ボタンにマウスを重ねると「ゲストモードではAI機能は使用できません」と表示されます。例: ログイン後は「生成」ボタンで処理開始 / ゲストでは同じボタンが押せずツールチップが表示されます。
 - バックエンド側で `ADMIN_EMAIL_ALLOWLIST` を設定している場合、リストに含まれないメールアドレスは検証後でも即座に 403 となり、構造化ログには `google_auth_denied` / `email_not_allowlisted` が記録されます。利用者を追加したい場合はリストへメールアドレスを追記して再起動してください。

--- a/apps/backend/backend/routers/config.py
+++ b/apps/backend/backend/routers/config.py
@@ -17,4 +17,5 @@ def get_runtime_config() -> dict[str, object]:
         "request_timeout_ms": settings.llm_timeout_ms,
         "llm_model": settings.llm_model,
         "session_auth_disabled": settings.disable_session_auth,
+        "google_client_id": settings.google_client_id,
     }

--- a/apps/frontend/src/App.test.tsx
+++ b/apps/frontend/src/App.test.tsx
@@ -93,7 +93,11 @@ const createMatchMediaMock =
 
 const configSuccess = () =>
   new Response(
-    JSON.stringify({ request_timeout_ms: 60000, llm_model: 'gpt-5.4-mini' }),
+    JSON.stringify({
+      request_timeout_ms: 60000,
+      llm_model: 'gpt-5.4-mini',
+      google_client_id: 'test-client',
+    }),
     { status: 200, headers: { 'Content-Type': 'application/json' } },
   );
 
@@ -195,7 +199,12 @@ describe('App navigation', () => {
     fetchMock.mockImplementation((input: RequestInfo | URL) => {
       const url = resolveUrl(input);
       if (url.endsWith('/api/config')) {
-        return Promise.resolve(configSuccess());
+        return Promise.resolve(
+          new Response(JSON.stringify({ request_timeout_ms: 60000, llm_model: 'gpt-5.4-mini' }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
       }
       return Promise.resolve(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
     });
@@ -216,6 +225,22 @@ describe('App navigation', () => {
     const guidanceCard = screen.getByRole('alert');
     expect(guidanceCard).toHaveAttribute('aria-live', 'polite');
     expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it('renders Google login when runtime config supplies the client ID', async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = resolveUrl(input);
+      if (url.endsWith('/api/config')) {
+        return Promise.resolve(configSuccess());
+      }
+      return Promise.resolve(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
+    });
+
+    renderWithProviders('');
+
+    expect(await screen.findByRole('heading', { name: 'WordPack にサインイン' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Google.?でログイン/ })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Google ログインの設定が必要です' })).not.toBeInTheDocument();
   });
 
   it('shows the login screen when /api/config responds with 401', async () => {

--- a/apps/frontend/src/AuthContext.tsx
+++ b/apps/frontend/src/AuthContext.tsx
@@ -137,6 +137,7 @@ export const AuthProvider: React.FC<{ clientId: string; children: React.ReactNod
    * 成功済みセッションを誤って anonymous に戻す競合を防止する。
    */
   const isReissuingGuestRef = useRef<boolean>(false);
+  const shouldWaitForRuntimeClientId = buildTimeClientId.length === 0 && !authConfigResolved;
   const missingClientId = normalizedClientId.length === 0;
 
   useEffect(() => {
@@ -440,6 +441,10 @@ export const AuthProvider: React.FC<{ clientId: string; children: React.ReactNod
       normalizedClientId,
     ],
   );
+
+  if (shouldWaitForRuntimeClientId) {
+    return null;
+  }
 
   const contextNode = <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 

--- a/apps/frontend/src/AuthContext.tsx
+++ b/apps/frontend/src/AuthContext.tsx
@@ -54,6 +54,14 @@ const AUTH_BYPASS_USER: AuthenticatedUser = {
   display_name: 'WordPack Dev User',
 };
 
+function readRuntimeGoogleClientId(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const value = (payload as { google_client_id?: unknown }).google_client_id;
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
 /**
  * ローカルストレージから最後に成功した認証情報を読み取る。
  * 副作用: window が存在しない環境では何もしない。
@@ -111,13 +119,15 @@ export const AuthProvider: React.FC<{ clientId: string; children: React.ReactNod
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [authBypassActive, setAuthBypassActive] = useState(false);
+  const [runtimeGoogleClientId, setRuntimeGoogleClientId] = useState<string | null>(null);
   /**
    * /api/config の初期ロードが完了したかを記録する。
    * 新参メンバー向けに補足すると、このフラグが true になるまでは
    * Google クライアント ID の警告ログを抑制し、誤検知による混乱を避ける。
    */
   const [authConfigResolved, setAuthConfigResolved] = useState(false);
-  const normalizedClientId = useMemo(() => clientId.trim(), [clientId]);
+  const buildTimeClientId = useMemo(() => clientId.trim(), [clientId]);
+  const normalizedClientId = runtimeGoogleClientId ?? buildTimeClientId;
   const clientIdRef = useRef(normalizedClientId);
   const authModeRef = useRef<AuthMode>(authMode);
   /**
@@ -172,8 +182,12 @@ export const AuthProvider: React.FC<{ clientId: string; children: React.ReactNod
         if (!res.ok) return;
         const json = (await res
           .json()
-          .catch(() => null)) as { session_auth_disabled?: boolean } | null;
+          .catch(() => null)) as { session_auth_disabled?: boolean; google_client_id?: string } | null;
         if (aborted) return;
+        const runtimeClientId = readRuntimeGoogleClientId(json);
+        if (runtimeClientId) {
+          setRuntimeGoogleClientId(runtimeClientId);
+        }
         if (json?.session_auth_disabled) {
           setAuthBypassActive(true);
           setUser((prev) => (authModeRef.current === 'guest' ? prev : prev ?? AUTH_BYPASS_USER));
@@ -410,7 +424,7 @@ export const AuthProvider: React.FC<{ clientId: string; children: React.ReactNod
       clearError,
       authBypassActive,
       missingClientId,
-      googleClientId: clientIdRef.current,
+      googleClientId: normalizedClientId,
     }),
     [
       user,
@@ -437,7 +451,7 @@ export const AuthProvider: React.FC<{ clientId: string; children: React.ReactNod
     return contextNode;
   }
 
-  return <GoogleOAuthProvider clientId={clientIdRef.current}>{contextNode}</GoogleOAuthProvider>;
+  return <GoogleOAuthProvider clientId={normalizedClientId}>{contextNode}</GoogleOAuthProvider>;
 };
 
 export const useAuth = (): AuthContextValue => {

--- a/apps/frontend/src/__tests__/AuthContext.test.tsx
+++ b/apps/frontend/src/__tests__/AuthContext.test.tsx
@@ -5,10 +5,11 @@ import { vi } from 'vitest';
 import type { MockedFunction } from 'vitest';
 import { AuthProvider, useAuth } from '../AuthContext';
 
-const googleProviderMock = vi.fn(({ children }: { children: React.ReactNode }) => <>{children}</>);
+const googleProviderMock = vi.fn(({ children }: { clientId?: string; children: React.ReactNode }) => <>{children}</>);
 
 vi.mock('@react-oauth/google', () => ({
-  GoogleOAuthProvider: ({ children }: { children: React.ReactNode }) => googleProviderMock({ children }),
+  GoogleOAuthProvider: ({ clientId, children }: { clientId: string; children: React.ReactNode }) =>
+    googleProviderMock({ clientId, children }),
 }));
 
 const MissingFlagProbe: React.FC = () => {
@@ -83,6 +84,28 @@ describe('AuthProvider logging behaviour', () => {
 
     expect(await screen.findByTestId('client-flag')).toHaveTextContent('missing');
     expect(googleProviderMock).not.toHaveBeenCalled();
+  });
+
+  it('uses Google client ID from runtime config when build-time env is empty', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ google_client_id: 'runtime-client.apps.googleusercontent.com' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    render(
+      <AuthProvider clientId="">
+        <MissingFlagProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('client-flag')).toHaveTextContent('ok');
+    });
+    expect(googleProviderMock).toHaveBeenCalledWith(
+      expect.objectContaining({ clientId: 'runtime-client.apps.googleusercontent.com' }),
+    );
   });
 
   it('prefers console.warn when bypass mode supplies a development credential', async () => {

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -57,7 +57,7 @@ flowchart TB
 | **Artifact Registry** | Cloud Build でビルドした Docker イメージを保存。 |
 | **Cloud Load Balancer** | HTTPS 終端と `X-Forwarded-For` によるクライアント IP 復元。 |
 | **OpenAI API** | WordPack 生成（gpt-5.4-mini）と音声読み上げ（gpt-4o-mini-tts）。 |
-| **Google OAuth 2.0** | フロントエンドでの Google ログイン。バックエンドで ID トークンを検証しセッション発行。 |
+| **Google OAuth 2.0** | フロントエンドでの Google ログイン。バックエンドは `/api/config` でクライアント ID を配布し、受け取った ID トークンを検証してセッションを発行する。 |
 | **Langfuse** | LLM のプロンプト・レスポンスをトレース（任意設定）。 |
 
 ---

--- a/docs/環境変数の意味.md
+++ b/docs/環境変数の意味.md
@@ -22,9 +22,9 @@
 ---
 
 ### 1.5) GOOGLE_CLIENT_ID / GOOGLE_ALLOWED_HD
-- 用途: Google サインインの ID トークン検証とドメイン制限。
+- 用途: Google サインインの ID トークン検証、フロントエンドへのランタイム設定配布、ドメイン制限。
 - 既定値: env.example=`GOOGLE_CLIENT_ID=`（空文字）, `# GOOGLE_ALLOWED_HD=`（未設定）。コード既定は `google_client_id=""`, `google_allowed_hd=None`。
-- 使われ方: Google から受け取った ID トークンを検証し、必要に応じて許可ドメインを照合します。
+- 使われ方: Google から受け取った ID トークンを検証し、必要に応じて許可ドメインを照合します。`GOOGLE_CLIENT_ID` は `/api/config` の `google_client_id` としても返され、ビルド時の `VITE_GOOGLE_CLIENT_ID` が空だった本番フロントエンドでも Google ログインボタンを初期化するために使われます。
 ```37:92:apps/backend/backend/routers/auth.py
     if not settings.google_client_id:
         ...
@@ -40,6 +40,7 @@
   - 一般的な OAuth クライアント: `GOOGLE_CLIENT_ID=12345-abcdefgh.apps.googleusercontent.com`
   - ドメイン制限を掛ける場合: `GOOGLE_ALLOWED_HD=example.com`
   - フロントエンドで同じ ID を共有: `apps/frontend/.env` に `VITE_GOOGLE_CLIENT_ID=12345-abcdefgh.apps.googleusercontent.com`
+  - 本番ではバックエンドの `GOOGLE_CLIENT_ID` が `/api/config` 経由でフロントエンドにも配布されるため、静的ビルドへ `VITE_GOOGLE_CLIENT_ID` を埋め込めないデプロイでもログイン導線を維持できます。
 - 運用メモ:
   - Google Cloud Console で OAuth クライアント ID を作成すると JSON シークレットがダウンロードできます。`google-oauth-client-secret.json` などの名前で安全な場所に保管し、リポジトリには追加しないでください。
   - `.env` を編集したらバックエンドプロセスを再起動し、`apps/frontend/.env` を更新したら `npm run dev` を再実行して読み込み直してください。

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -55,9 +55,9 @@ export const seedAuthenticatedSession = async (
 
 export const mockConfig = async (
   page: Page,
-  options: { requestTimeoutMs?: number; sessionAuthDisabled?: boolean } = {},
+  options: { requestTimeoutMs?: number; sessionAuthDisabled?: boolean; googleClientId?: string } = {},
 ): Promise<void> => {
-  const { requestTimeoutMs = 60000, sessionAuthDisabled = false } = options;
+  const { requestTimeoutMs = 60000, sessionAuthDisabled = false, googleClientId = 'e2e-client' } = options;
   await page.route('**/api/config', (route) =>
     route.fulfill({
       status: 200,
@@ -65,6 +65,7 @@ export const mockConfig = async (
       body: JSON.stringify({
         request_timeout_ms: requestTimeoutMs,
         session_auth_disabled: sessionAuthDisabled,
+        google_client_id: googleClientId,
       }),
     }),
   );

--- a/tests/test_debug_headers.py
+++ b/tests/test_debug_headers.py
@@ -59,4 +59,6 @@ def test_debug_headers_shares_same_application(debug_client: TestClient) -> None
 
     cfg = debug_client.get("/api/config")
     assert cfg.status_code == 200
-    assert "request_timeout_ms" in cfg.json()
+    body = cfg.json()
+    assert "request_timeout_ms" in body
+    assert "google_client_id" in body


### PR DESCRIPTION
## 概要
- `/api/config` でバックエンドの `GOOGLE_CLIENT_ID` を `google_client_id` として返すようにしました。
- フロントエンドがビルド時の `VITE_GOOGLE_CLIENT_ID` が空でも、起動時の `/api/config` から取得したクライアント ID で Google OAuth Provider を初期化するようにしました。
- README と `docs/` の認証設定説明、E2E helper、回帰テストを更新しました。

## 原因
本番ビルド時に `VITE_GOOGLE_CLIENT_ID` が埋め込まれていない場合、フロントエンドがバックエンド側に設定済みの `GOOGLE_CLIENT_ID` を参照できず、Google ログインボタンを表示する前に設定案内へ落ちていました。

## 検証
- `npm test -- AuthContext App.test.tsx`
- `npm run build`
- `npm test`
- `python3 -m py_compile apps/backend/backend/routers/config.py`

## 未実行
- `pytest tests/test_debug_headers.py` はこのローカル環境に Python 依存（`pytest`, `fastapi` など）が未導入のため実行できませんでした。代替として変更ファイルの構文検証を実行しています。