### PR TITLE
[codex] ExploreとShelvesを読み取り専用分析ビューにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 - バックエンド: FastAPI / フロントエンド: React + TypeScript + Vite
 - WordPack の生成・再生成・永続化
 - Lexicon / Reader / Examples Corpus / Explore / Shelves / Settings の辞書型UI。`/lexicon`、`/reader`、`/examples`、`/explore`、`/shelves`、`/settings`、`/wordpacks/:id` のURLで直接開けます。
+- Explore は保存済みWordPackの `senses` / `collocations` / `contrast` / `examples` を読み取り、関連語・共起・対比・未作成語を横断する Connection Explorer として動作します。
+- Shelves は `GET /word/packs` の一覧データを、最近更新・未生成・例文が多い・ゲスト公開中・カテゴリ別などへ自動分類する Smart Shelves として動作します。
 - WordPack再生成は非同期ジョブ化し、ジョブIDを返して完了までポーリング（長時間処理でもUIが切れない）
 - 発音情報（IPA/音節/強勢）の付与
 - 例文（Dev/CS/LLM/Business/Common）の追加・削除

--- a/apps/frontend/src/components/WordPackListPanel.tsx
+++ b/apps/frontend/src/components/WordPackListPanel.tsx
@@ -18,6 +18,7 @@ import { useAuth } from '../AuthContext';
 import { GuestLock } from './GuestLock';
 import { GuestPublicToggle } from './GuestPublicToggle';
 import { APP_EVENTS, dispatchAppEvent } from '../shared/events/appEvents';
+import type { WordPackListItem, WordPackListResponse } from '../features/wordpack/types';
 
 // 削除ボタンの共通コンポーネント
 interface DeleteButtonProps {
@@ -60,25 +61,6 @@ const DeleteButton: React.FC<DeleteButtonProps> = ({ onClick, disabled = false, 
     </GuestLock>
   );
 };
-
-interface WordPackListItem {
-  id: string;
-  lemma: string;
-  sense_title?: string;
-  created_at: string;
-  updated_at: string;
-  is_empty?: boolean;
-  guest_public?: boolean;
-  examples_count?: {
-    Dev: number;
-    CS: number;
-    LLM: number;
-    Business: number;
-    Common: number;
-  };
-  checked_only_count: number;
-  learned_count: number;
-}
 
 type SortKey = 'created_at' | 'updated_at' | 'lemma' | 'total_examples';
 type SortOrder = 'asc' | 'desc';
@@ -139,13 +121,6 @@ const matchString = (text: string, query: string, mode: SearchMode): boolean => 
   if (mode === 'suffix') return text.endsWith(query);
   return text.includes(query);
 };
-
-interface WordPackListResponse {
-  items: WordPackListItem[];
-  total: number;
-  limit: number;
-  offset: number;
-}
 
 export const WordPackListPanel: React.FC = () => {
   const { isGuest } = useAuth();

--- a/apps/frontend/src/components/WordPackPreviewModal.tsx
+++ b/apps/frontend/src/components/WordPackPreviewModal.tsx
@@ -1,0 +1,57 @@
+import React, { useMemo, useRef } from 'react';
+import { Modal } from './Modal';
+import { WordPackPanel, type WordPackPreviewMeta } from './WordPackPanel';
+import type { WordPackListItem } from '../features/wordpack/types';
+
+interface WordPackPreviewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  wordPackId: string | null;
+  wordPacks: WordPackListItem[];
+  onWordPackUpdated?: () => void;
+  onStudyProgressRecorded?: (payload: { wordPackId: string; checked_only_count: number; learned_count: number }) => void;
+}
+
+export const WordPackPreviewModal: React.FC<WordPackPreviewModalProps> = ({
+  isOpen,
+  onClose,
+  wordPackId,
+  wordPacks,
+  onWordPackUpdated,
+  onStudyProgressRecorded,
+}) => {
+  const focusRef = useRef<HTMLElement>(null);
+  const previewMeta = useMemo<WordPackPreviewMeta | null>(() => {
+    if (!wordPackId) return null;
+    const meta = wordPacks.find((wordPack) => wordPack.id === wordPackId);
+    if (!meta) return null;
+    return {
+      id: meta.id,
+      lemma: meta.lemma,
+      senseTitle: meta.sense_title,
+      created_at: meta.created_at,
+      updated_at: meta.updated_at,
+    };
+  }, [wordPackId, wordPacks]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="WordPack プレビュー">
+      {wordPackId ? (
+        <WordPackPanel
+          focusRef={focusRef}
+          selectedWordPackId={wordPackId}
+          selectedMeta={
+            previewMeta?.created_at && previewMeta?.updated_at
+              ? { created_at: previewMeta.created_at, updated_at: previewMeta.updated_at }
+              : null
+          }
+          fallbackMeta={previewMeta ? { id: previewMeta.id, lemma: previewMeta.lemma, senseTitle: previewMeta.senseTitle } : null}
+          onWordPackGenerated={() => {
+            onWordPackUpdated?.();
+          }}
+          onStudyProgressRecorded={onStudyProgressRecorded}
+        />
+      ) : null}
+    </Modal>
+  );
+};

--- a/apps/frontend/src/features/wordpack/api.ts
+++ b/apps/frontend/src/features/wordpack/api.ts
@@ -5,3 +5,8 @@ export {
   regenerateWordPackRequest,
   updateGuestPublicFlag,
 } from '../../lib/wordpack';
+
+export {
+  fetchWordPack,
+  fetchWordPackList,
+} from './api/wordpackApi';

--- a/apps/frontend/src/features/wordpack/api/index.ts
+++ b/apps/frontend/src/features/wordpack/api/index.ts
@@ -2,6 +2,7 @@ export {
   composeModelRequestFields,
   createEmptyWordPackRequest,
   fetchWordPack,
+  fetchWordPackList,
   generateWordPackRequest,
   regenerateWordPackRequest,
   updateGuestPublicFlag,

--- a/apps/frontend/src/features/wordpack/api/wordpackApi.ts
+++ b/apps/frontend/src/features/wordpack/api/wordpackApi.ts
@@ -4,7 +4,7 @@ import {
   regenerateWordPackRequest,
   updateGuestPublicFlag,
 } from '../../../lib/wordpack';
-import type { WordPack } from '../types';
+import type { WordPack, WordPackListResponse } from '../types';
 
 export { composeModelRequestFields, regenerateWordPackRequest, updateGuestPublicFlag };
 
@@ -15,6 +15,18 @@ export const fetchWordPack = (
 ): Promise<WordPack> => (
   fetchJson<WordPack>(`${apiBase}/word/packs/${wordPackId}`, options)
 );
+
+export const fetchWordPackList = (
+  apiBase: string,
+  options?: { limit?: number; offset?: number; signal?: AbortSignal; timeoutMs?: number },
+): Promise<WordPackListResponse> => {
+  const limit = options?.limit ?? 200;
+  const offset = options?.offset ?? 0;
+  return fetchJson<WordPackListResponse>(`${apiBase}/word/packs?limit=${limit}&offset=${offset}`, {
+    signal: options?.signal,
+    timeoutMs: options?.timeoutMs,
+  });
+};
 
 export const createEmptyWordPackRequest = (
   apiBase: string,

--- a/apps/frontend/src/features/wordpack/hooks/useWordPackList.ts
+++ b/apps/frontend/src/features/wordpack/hooks/useWordPackList.ts
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSettings } from '../../../SettingsContext';
+import { ApiError } from '../../../lib/fetcher';
+import { APP_EVENTS } from '../../../shared/events/appEvents';
+import { fetchWordPackList } from '../api';
+import type { WordPackListItem } from '../types';
+
+export type WordPackListMessage = { kind: 'status' | 'alert'; text: string } | null;
+
+interface UseWordPackListOptions {
+  limit?: number;
+}
+
+interface UseWordPackListResult {
+  loading: boolean;
+  message: WordPackListMessage;
+  total: number;
+  wordPacks: WordPackListItem[];
+  reload: () => Promise<void>;
+  applyStudyProgress: (payload: { wordPackId: string; checked_only_count: number; learned_count: number }) => void;
+}
+
+const DEFAULT_LIMIT = 200;
+
+export const sumExamples = (counts?: WordPackListItem['examples_count']): number => {
+  if (!counts) return 0;
+  return Object.values(counts).reduce((sum, count) => sum + (Number(count) || 0), 0);
+};
+
+export const normalizeWordPackListItem = (item: WordPackListItem): WordPackListItem => ({
+  ...item,
+  checked_only_count: item.checked_only_count ?? 0,
+  learned_count: item.learned_count ?? 0,
+  guest_public: item.guest_public ?? false,
+  is_empty: item.is_empty ?? false,
+});
+
+export const useWordPackList = ({ limit = DEFAULT_LIMIT }: UseWordPackListOptions = {}): UseWordPackListResult => {
+  const { settings } = useSettings();
+  const { apiBase, requestTimeoutMs } = settings;
+  const abortRef = useRef<AbortController | null>(null);
+  const [wordPacks, setWordPacks] = useState<WordPackListItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<WordPackListMessage>(null);
+
+  const reload = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+    setMessage(null);
+    try {
+      const res = await fetchWordPackList(apiBase, {
+        limit,
+        offset: 0,
+        signal: controller.signal,
+        timeoutMs: requestTimeoutMs,
+      });
+      setWordPacks(res.items.map(normalizeWordPackListItem));
+      setTotal(res.total);
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      const text = error instanceof ApiError ? error.message : 'WordPack一覧の読み込みに失敗しました';
+      setMessage({ kind: 'alert', text });
+    } finally {
+      if (!controller.signal.aborted) {
+        setLoading(false);
+      }
+    }
+  }, [apiBase, limit, requestTimeoutMs]);
+
+  const applyStudyProgress = useCallback(
+    (payload: { wordPackId: string; checked_only_count: number; learned_count: number }) => {
+      if (!payload.wordPackId) return;
+      setWordPacks((prev) =>
+        prev.map((wp) =>
+          wp.id === payload.wordPackId
+            ? {
+                ...wp,
+                checked_only_count: payload.checked_only_count,
+                learned_count: payload.learned_count,
+              }
+            : wp,
+        ),
+      );
+    },
+    [],
+  );
+
+  useEffect(() => {
+    void reload();
+    return () => abortRef.current?.abort();
+  }, [reload]);
+
+  useEffect(() => {
+    const onUpdated = () => {
+      void reload();
+    };
+    window.addEventListener(APP_EVENTS.wordPackUpdated, onUpdated as EventListener);
+    return () => window.removeEventListener(APP_EVENTS.wordPackUpdated, onUpdated as EventListener);
+  }, [reload]);
+
+  return { loading, message, total, wordPacks, reload, applyStudyProgress };
+};

--- a/apps/frontend/src/features/wordpack/types.ts
+++ b/apps/frontend/src/features/wordpack/types.ts
@@ -27,6 +27,8 @@ export interface ContrastItem { with: string; diff_ja: string }
 
 export interface ExampleItem { en: string; ja: string; grammar_ja?: string; llm_model?: string; llm_params?: string }
 export interface Examples { Dev: ExampleItem[]; CS: ExampleItem[]; LLM: ExampleItem[]; Business: ExampleItem[]; Common: ExampleItem[] }
+export type ExampleCategory = keyof Examples;
+export type ExampleCounts = Record<ExampleCategory, number>;
 
 export interface Etymology { note: string; confidence: 'low' | 'medium' | 'high' }
 
@@ -47,4 +49,24 @@ export interface WordPack {
   guest_public?: boolean;
   checked_only_count?: number;
   learned_count?: number;
+}
+
+export interface WordPackListItem {
+  id: string;
+  lemma: string;
+  sense_title?: string;
+  created_at: string;
+  updated_at: string;
+  is_empty?: boolean;
+  guest_public?: boolean;
+  examples_count?: ExampleCounts | null;
+  checked_only_count: number;
+  learned_count: number;
+}
+
+export interface WordPackListResponse {
+  items: WordPackListItem[];
+  total: number;
+  limit: number;
+  offset: number;
 }

--- a/apps/frontend/src/pages/ExplorePage/ExplorePage.test.tsx
+++ b/apps/frontend/src/pages/ExplorePage/ExplorePage.test.tsx
@@ -1,23 +1,140 @@
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ExplorePage } from './index';
+import type { WordPack } from '../../features/wordpack/types';
+
+vi.mock('../../SettingsContext', () => ({
+  useSettings: () => ({
+    settings: {
+      apiBase: '/api',
+      requestTimeoutMs: 60000,
+    },
+  }),
+}));
+
+const wordPackDetail: WordPack = {
+  lemma: 'robust',
+  sense_title: '壊れにくい',
+  pronunciation: { linking_notes: [] },
+  senses: [
+    {
+      id: 's1',
+      gloss_ja: '壊れにくい',
+      patterns: ['robust against N'],
+      synonyms: ['resilient'],
+      antonyms: ['fragile'],
+    },
+  ],
+  collocations: {
+    general: {
+      verb_object: [],
+      adj_noun: ['robust fallback', 'robust evidence'],
+      prep_noun: [],
+    },
+    academic: {
+      verb_object: [],
+      adj_noun: [],
+      prep_noun: [],
+    },
+  },
+  contrast: [{ with: 'brittle', diff_ja: 'brittle は壊れやすさを示す。' }],
+  examples: {
+    Dev: [{ en: 'The service uses a robust fallback.', ja: 'サービスは堅牢なフォールバックを使う。' }],
+    CS: [],
+    LLM: [],
+    Business: [],
+    Common: [],
+  },
+  etymology: { note: 'test', confidence: 'low' },
+  study_card: 'test',
+  citations: [],
+  confidence: 'low',
+};
+
+const setupFetch = () => {
+  const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.startsWith('/api/word/packs?')) {
+      return Promise.resolve(
+        new Response(JSON.stringify({
+          items: [
+            {
+              id: 'wp:robust',
+              lemma: 'robust',
+              sense_title: '壊れにくい',
+              created_at: '2024-01-01T00:00:00Z',
+              updated_at: '2024-01-02T00:00:00Z',
+              is_empty: false,
+              guest_public: true,
+              examples_count: { Dev: 1, CS: 0, LLM: 0, Business: 0, Common: 0 },
+              checked_only_count: 1,
+              learned_count: 0,
+            },
+            {
+              id: 'wp:fallback',
+              lemma: 'fallback',
+              sense_title: '代替手段',
+              created_at: '2024-01-01T00:00:00Z',
+              updated_at: '2024-01-01T00:00:00Z',
+              is_empty: false,
+              guest_public: true,
+              examples_count: { Dev: 0, CS: 0, LLM: 0, Business: 0, Common: 0 },
+              checked_only_count: 0,
+              learned_count: 0,
+            },
+          ],
+          total: 2,
+          limit: 200,
+          offset: 0,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      );
+    }
+    if (url.endsWith('/api/word/packs/wp:robust')) {
+      return Promise.resolve(
+        new Response(JSON.stringify(wordPackDetail), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      );
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify({ ...wordPackDetail, lemma: 'fallback', sense_title: '代替手段' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+  });
+  (globalThis as any).fetch = fetchMock;
+  return fetchMock;
+};
 
 describe('ExplorePage', () => {
-  it('lets the user switch relation mode and selected lemma', async () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    setupFetch();
+  });
+
+  it('loads existing WordPacks and shows relation cards from selected detail', async () => {
     render(<ExplorePage />);
 
     expect(screen.getByRole('heading', { name: 'Explore' })).toBeInTheDocument();
     expect(screen.getByLabelText('探索する lemma を検索')).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /robust/ })).toBeInTheDocument();
 
     const user = userEvent.setup();
     await act(async () => {
-      await user.click(screen.getByRole('button', { name: 'contrast' }));
-      await user.click(screen.getByRole('button', { name: /brittle/ }));
+      await user.click(screen.getByRole('button', { name: 'Collocations' }));
     });
 
-    expect(screen.getByRole('button', { name: 'contrast' })).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByRole('heading', { name: 'brittle' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Collocations' })).toHaveAttribute('aria-pressed', 'true');
+    expect(await screen.findByText('robust fallback')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '開く' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: '未作成' })).toBeDisabled();
+
+    await act(async () => {
+      await user.type(screen.getByLabelText('探索する lemma を検索'), 'fall');
+    });
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: /robust/ })).not.toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /fallback/ })).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/pages/ExplorePage/exploreRelations.ts
+++ b/apps/frontend/src/pages/ExplorePage/exploreRelations.ts
@@ -1,0 +1,138 @@
+import type { ExampleCategory, Examples, WordPack, WordPackListItem } from '../../features/wordpack/types';
+
+export type ExploreMode = 'related' | 'collocations' | 'contrast' | 'examples' | 'unknown';
+export type ExploreRelationKind = Exclude<ExploreMode, 'unknown'>;
+export type ExploreRelationStatus = 'existing' | 'empty' | 'unknown';
+
+export interface RawExploreRelation {
+  id: string;
+  kind: ExploreRelationKind;
+  label: string;
+  source: string;
+  description?: string;
+}
+
+export interface ExploreRelation extends RawExploreRelation {
+  status: ExploreRelationStatus;
+  targetWordPack?: WordPackListItem;
+}
+
+const EXAMPLE_CATEGORIES: ExampleCategory[] = ['Dev', 'CS', 'LLM', 'Business', 'Common'];
+
+const normalize = (value: string): string => value.trim().toLowerCase();
+
+const compactUnique = (items: RawExploreRelation[]): RawExploreRelation[] => {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    const key = `${item.kind}:${normalize(item.label)}:${item.source}`;
+    if (!item.label.trim() || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};
+
+const flattenCollocationGroup = (
+  groupName: 'general' | 'academic',
+  lists: WordPack['collocations']['general'],
+): RawExploreRelation[] =>
+  (Object.entries(lists) as [string, string[]][]).flatMap(([listName, values]) =>
+    values.map((value, index) => ({
+      id: `collocation-${groupName}-${listName}-${index}`,
+      kind: 'collocations' as const,
+      label: value,
+      source: `${groupName} / ${listName}`,
+    })),
+  );
+
+const flattenExamples = (examples: Examples): RawExploreRelation[] =>
+  EXAMPLE_CATEGORIES.flatMap((category) =>
+    (examples[category] ?? []).map((example, index) => ({
+      id: `example-${category}-${index}`,
+      kind: 'examples' as const,
+      label: example.en,
+      description: example.ja,
+      source: category,
+    })),
+  );
+
+export const buildExploreRelations = (wordPack: WordPack): RawExploreRelation[] => {
+  const related = wordPack.senses.flatMap((sense, senseIndex) => [
+    ...(sense.synonyms ?? []).map((label, index) => ({
+      id: `synonym-${senseIndex}-${index}`,
+      kind: 'related' as const,
+      label,
+      source: 'synonym',
+    })),
+    ...(sense.antonyms ?? []).map((label, index) => ({
+      id: `antonym-${senseIndex}-${index}`,
+      kind: 'related' as const,
+      label,
+      source: 'antonym',
+    })),
+    ...(sense.patterns ?? []).map((label, index) => ({
+      id: `pattern-${senseIndex}-${index}`,
+      kind: 'related' as const,
+      label,
+      source: 'pattern',
+      description: sense.gloss_ja,
+    })),
+  ]);
+
+  const collocations = [
+    ...flattenCollocationGroup('general', wordPack.collocations.general),
+    ...flattenCollocationGroup('academic', wordPack.collocations.academic),
+  ];
+
+  const contrasts = wordPack.contrast.map((item, index) => ({
+    id: `contrast-${index}`,
+    kind: 'contrast' as const,
+    label: item.with,
+    description: item.diff_ja,
+    source: 'contrast',
+  }));
+
+  return compactUnique([...related, ...collocations, ...contrasts, ...flattenExamples(wordPack.examples)]);
+};
+
+const findWordPackForRelation = (
+  label: string,
+  wordPacks: WordPackListItem[],
+  currentLemma: string,
+): WordPackListItem | undefined => {
+  const normalizedCurrent = normalize(currentLemma);
+  const byLemma = new Map(wordPacks.map((wordPack) => [normalize(wordPack.lemma), wordPack]));
+  const exact = byLemma.get(normalize(label));
+  if (exact && normalize(exact.lemma) !== normalizedCurrent) return exact;
+
+  const tokens = label
+    .toLowerCase()
+    .split(/[^a-z0-9'-]+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 3 && token !== normalizedCurrent);
+  return tokens.map((token) => byLemma.get(token)).find(Boolean);
+};
+
+export const attachRelationStatus = (
+  relations: RawExploreRelation[],
+  wordPacks: WordPackListItem[],
+  currentLemma: string,
+): ExploreRelation[] =>
+  relations.map((relation) => {
+    const targetWordPack = findWordPackForRelation(relation.label, wordPacks, currentLemma);
+    if (!targetWordPack) return { ...relation, status: 'unknown' };
+    return {
+      ...relation,
+      targetWordPack,
+      status: targetWordPack.is_empty ? 'empty' : 'existing',
+    };
+  });
+
+export const filterExploreRelations = (
+  relations: ExploreRelation[],
+  mode: ExploreMode,
+): ExploreRelation[] => {
+  if (mode === 'unknown') {
+    return relations.filter((relation) => relation.status === 'unknown');
+  }
+  return relations.filter((relation) => relation.kind === mode);
+};

--- a/apps/frontend/src/pages/ExplorePage/index.tsx
+++ b/apps/frontend/src/pages/ExplorePage/index.tsx
@@ -1,29 +1,66 @@
-import React, { useState } from 'react';
-import { Badge, Button, SearchBox, SegmentedControl } from '../../shared/ui';
+import React, { useMemo, useState } from 'react';
+import { WordPackPreviewModal } from '../../components/WordPackPreviewModal';
+import { Badge, Button, EmptyState, SearchBox, SegmentedControl } from '../../shared/ui';
+import { attachRelationStatus, buildExploreRelations, filterExploreRelations, type ExploreMode, type ExploreRelation } from './exploreRelations';
+import { useExploreData } from './useExploreData';
 
-type ExploreMode = 'collocations' | 'contrast' | 'article-links' | 'unknown';
-
-const relationNodes = [
-  { lemma: 'robust', className: 'center', status: '中心ノード' },
-  { lemma: 'fallback', className: 'purple', status: 'existing' },
-  { lemma: 'parser', className: 'green', status: 'existing' },
-  { lemma: 'resilient', className: 'yellow', status: 'related' },
-  { lemma: 'brittle', className: 'rose', status: 'contrast' },
-  { lemma: 'stale', className: 'empty', status: 'empty' },
+const modeOptions: { value: ExploreMode; label: string }[] = [
+  { value: 'related', label: 'Related' },
+  { value: 'collocations', label: 'Collocations' },
+  { value: 'contrast', label: 'Contrast' },
+  { value: 'examples', label: 'Examples' },
+  { value: 'unknown', label: 'Empty / Unknown' },
 ];
 
+const statusLabel = (relation: ExploreRelation): string => {
+  if (relation.status === 'existing') return '開く';
+  if (relation.status === 'empty') return '空WordPack';
+  return '未作成';
+};
+
 export const ExplorePage: React.FC = () => {
-  const [mode, setMode] = useState<ExploreMode>('collocations');
-  const [selected, setSelected] = useState('robust');
+  const [mode, setMode] = useState<ExploreMode>('related');
+  const [previewWordPackId, setPreviewWordPackId] = useState<string | null>(null);
+  const {
+    applyStudyProgress,
+    detailLoading,
+    detailMessage,
+    filteredWordPacks,
+    loading,
+    message,
+    query,
+    reload,
+    selectedDetail,
+    selectedWordPack,
+    selectedWordPackId,
+    setQuery,
+    setSelectedWordPackId,
+    wordPacks,
+  } = useExploreData();
+
+  const relations = useMemo(() => {
+    if (!selectedDetail) return [];
+    return attachRelationStatus(buildExploreRelations(selectedDetail), wordPacks, selectedDetail.lemma);
+  }, [selectedDetail, wordPacks]);
+  const visibleRelations = useMemo(() => filterExploreRelations(relations, mode), [mode, relations]);
+
   return (
     <div className="dictionary-main">
       <div className="dictionary-page-heading">
         <div className="dictionary-page-title">
           <h2>Explore</h2>
-          <p>関連語、共起、対比、未生成語へ自由に脱線する。</p>
+          <p>保存済みWordPackから、共起・対比・語義・例文のつながりを読む。</p>
         </div>
         <div className="dictionary-top-actions">
-          <SearchBox label="探索する lemma を検索" placeholder="Search lemma..." />
+          <SearchBox
+            label="探索する lemma を検索"
+            placeholder="Search lemma..."
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+          <Button variant="subtle" onClick={() => { void reload(); }} disabled={loading}>
+            更新
+          </Button>
         </div>
       </div>
       <section className="dictionary-section explore-browser">
@@ -32,50 +69,85 @@ export const ExplorePage: React.FC = () => {
             label="Explore relation mode"
             value={mode}
             onChange={setMode}
-            options={[
-              { value: 'collocations', label: 'collocations' },
-              { value: 'contrast', label: 'contrast' },
-              { value: 'article-links', label: 'article links' },
-              { value: 'unknown', label: 'unknown lemmas' },
-            ]}
+            options={modeOptions}
           />
-          <Badge variant="accent">{selected}</Badge>
+          <Badge variant="accent">{selectedWordPack?.lemma ?? '未選択'}</Badge>
         </div>
         <div className="explore-layout">
-          <div className="explore-graph" aria-label="関連語ブラウザ">
-            {relationNodes.map((node) => (
+          <div className="explore-list" aria-label="探索候補">
+            {message ? <div role="alert" className="dictionary-empty compact">{message.text}</div> : null}
+            {!message && filteredWordPacks.length === 0 ? (
+              <EmptyState>一致するWordPackがありません。</EmptyState>
+            ) : null}
+            {filteredWordPacks.map((wordPack) => (
               <button
-                key={node.lemma}
+                key={wordPack.id}
                 type="button"
-                className={`explore-node ${node.className}`}
-                aria-pressed={selected === node.lemma}
-                onClick={() => setSelected(node.lemma)}
+                className="explore-list-item"
+                aria-pressed={selectedWordPackId === wordPack.id}
+                onClick={() => setSelectedWordPackId(wordPack.id)}
               >
-                <strong>{node.lemma}</strong>
-                <span>{node.status}</span>
+                <strong>{wordPack.lemma}</strong>
+                <span>{wordPack.sense_title || '語義タイトル未設定'}</span>
               </button>
             ))}
           </div>
+          <div className="explore-connections" aria-label="接続カード">
+            {detailLoading ? <EmptyState>接続を読み込んでいます。</EmptyState> : null}
+            {detailMessage ? <div role="alert" className="dictionary-empty">{detailMessage}</div> : null}
+            {!detailLoading && !detailMessage && visibleRelations.length === 0 ? (
+              <EmptyState>このモードで表示できる接続はまだありません。</EmptyState>
+            ) : null}
+            {!detailLoading && !detailMessage && visibleRelations.map((relation) => (
+              <article key={relation.id} className="explore-connection-card">
+                <div>
+                  <div className="dictionary-meta-row">
+                    <Badge>{relation.source}</Badge>
+                    <Badge variant={relation.status === 'existing' ? 'accent' : 'default'}>{relation.status}</Badge>
+                  </div>
+                  <h3>{relation.label}</h3>
+                  {relation.description ? <p>{relation.description}</p> : null}
+                </div>
+                <Button
+                  variant="subtle"
+                  disabled={!relation.targetWordPack}
+                  onClick={() => {
+                    if (relation.targetWordPack) {
+                      setPreviewWordPackId(relation.targetWordPack.id);
+                    }
+                  }}
+                >
+                  {statusLabel(relation)}
+                </Button>
+              </article>
+            ))}
+          </div>
           <aside className="explore-side">
-            <h3>{selected}</h3>
-            <p>中心ノード。ここから関連へ飛ぶ。</p>
-            <h4>Collocations</h4>
-            <ul>
-              <li>robust fallback</li>
-              <li>robust parser</li>
-              <li>robust evidence</li>
-            </ul>
-            <h4>Contrast</h4>
-            <ul>
-              <li>brittle</li>
-              <li>fragile</li>
-              <li>ad hoc</li>
-            </ul>
-            <Button variant="subtle">Side Peekで開く</Button>
+            <h3>{selectedWordPack?.lemma ?? 'No WordPack'}</h3>
+            <p>{selectedWordPack?.sense_title || 'WordPackを選ぶと接続を表示します。'}</p>
+            <div className="dictionary-chip-list">
+              <Badge>{relations.length} connections</Badge>
+              <Badge>{relations.filter((relation) => relation.status === 'unknown').length} unknown</Badge>
+              {selectedWordPack?.is_empty ? <Badge>empty</Badge> : null}
+            </div>
+            <Button
+              variant="subtle"
+              disabled={!selectedWordPackId}
+              onClick={() => setPreviewWordPackId(selectedWordPackId)}
+            >
+              プレビューを開く
+            </Button>
           </aside>
         </div>
       </section>
+      <WordPackPreviewModal
+        isOpen={Boolean(previewWordPackId)}
+        onClose={() => setPreviewWordPackId(null)}
+        wordPackId={previewWordPackId}
+        wordPacks={wordPacks}
+        onWordPackUpdated={() => { void reload(); }}
+        onStudyProgressRecorded={applyStudyProgress}
+      />
     </div>
   );
 };
-

--- a/apps/frontend/src/pages/ExplorePage/useExploreData.ts
+++ b/apps/frontend/src/pages/ExplorePage/useExploreData.ts
@@ -1,0 +1,84 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSettings } from '../../SettingsContext';
+import { ApiError } from '../../lib/fetcher';
+import { fetchWordPack } from '../../features/wordpack/api';
+import { useWordPackList } from '../../features/wordpack/hooks/useWordPackList';
+import type { WordPack } from '../../features/wordpack/types';
+
+export const useExploreData = () => {
+  const { settings } = useSettings();
+  const list = useWordPackList();
+  const [query, setQuery] = useState('');
+  const [selectedWordPackId, setSelectedWordPackId] = useState<string | null>(null);
+  const [selectedDetail, setSelectedDetail] = useState<WordPack | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailMessage, setDetailMessage] = useState<string | null>(null);
+
+  const filteredWordPacks = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) return list.wordPacks;
+    return list.wordPacks.filter((wordPack) => {
+      const lemma = wordPack.lemma.toLowerCase();
+      const senseTitle = (wordPack.sense_title ?? '').toLowerCase();
+      return lemma.includes(normalizedQuery) || senseTitle.includes(normalizedQuery);
+    });
+  }, [list.wordPacks, query]);
+
+  useEffect(() => {
+    if (filteredWordPacks.length === 0) {
+      setSelectedWordPackId(null);
+      return;
+    }
+    if (!selectedWordPackId || !filteredWordPacks.some((wordPack) => wordPack.id === selectedWordPackId)) {
+      setSelectedWordPackId(filteredWordPacks[0].id);
+    }
+  }, [filteredWordPacks, selectedWordPackId]);
+
+  useEffect(() => {
+    if (!selectedWordPackId) {
+      setSelectedDetail(null);
+      setDetailMessage(null);
+      return undefined;
+    }
+    const controller = new AbortController();
+    setDetailLoading(true);
+    setDetailMessage(null);
+    setSelectedDetail(null);
+    fetchWordPack(settings.apiBase, selectedWordPackId, {
+      signal: controller.signal,
+      timeoutMs: settings.requestTimeoutMs,
+    })
+      .then((wordPack) => {
+        setSelectedDetail(wordPack);
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        const text = error instanceof ApiError ? error.message : 'WordPack詳細の読み込みに失敗しました';
+        setDetailMessage(text);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setDetailLoading(false);
+        }
+      });
+    return () => controller.abort();
+  }, [selectedWordPackId, settings.apiBase, settings.requestTimeoutMs]);
+
+  const selectedWordPack = useMemo(
+    () => list.wordPacks.find((wordPack) => wordPack.id === selectedWordPackId) ?? null,
+    [list.wordPacks, selectedWordPackId],
+  );
+
+  return {
+    ...list,
+    detailLoading,
+    detailMessage,
+    filteredWordPacks,
+    query,
+    selectedDetail,
+    selectedWordPack,
+    selectedWordPackId,
+    setQuery,
+    setSelectedWordPackId,
+  };
+};

--- a/apps/frontend/src/pages/ShelvesPage/ShelfWordPackList.tsx
+++ b/apps/frontend/src/pages/ShelvesPage/ShelfWordPackList.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { sumExamples } from '../../features/wordpack/hooks/useWordPackList';
+import { Badge, Button, EmptyState } from '../../shared/ui';
+import type { WordPackListItem } from '../../features/wordpack/types';
+
+interface ShelfWordPackListProps {
+  items: WordPackListItem[];
+  onOpenPreview: (wordPackId: string) => void;
+}
+
+const resolveSenseTitle = (wordPack: WordPackListItem): string =>
+  wordPack.sense_title?.trim() || '語義タイトル未設定';
+
+export const ShelfWordPackList: React.FC<ShelfWordPackListProps> = ({ items, onOpenPreview }) => {
+  if (items.length === 0) {
+    return <EmptyState>この棚に入るWordPackはまだありません。</EmptyState>;
+  }
+
+  return (
+    <div className="shelf-wordpack-list" aria-label="棚内WordPack一覧">
+      {items.map((wordPack) => (
+        <article key={wordPack.id} className="shelf-wordpack-card">
+          <div>
+            <div className="dictionary-meta-row">
+              {wordPack.is_empty ? <Badge>empty</Badge> : <Badge>{sumExamples(wordPack.examples_count)} examples</Badge>}
+              {wordPack.guest_public ? <Badge variant="accent">guest public</Badge> : null}
+              <Badge>学 {wordPack.learned_count}</Badge>
+              <Badge>確 {wordPack.checked_only_count}</Badge>
+            </div>
+            <h3>{wordPack.lemma}</h3>
+            <p>{resolveSenseTitle(wordPack)}</p>
+          </div>
+          <Button variant="subtle" onClick={() => onOpenPreview(wordPack.id)}>
+            プレビュー
+          </Button>
+        </article>
+      ))}
+    </div>
+  );
+};

--- a/apps/frontend/src/pages/ShelvesPage/ShelvesPage.test.tsx
+++ b/apps/frontend/src/pages/ShelvesPage/ShelvesPage.test.tsx
@@ -1,36 +1,85 @@
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ShelvesPage } from './index';
+
+vi.mock('../../SettingsContext', () => ({
+  useSettings: () => ({
+    settings: {
+      apiBase: '/api',
+      requestTimeoutMs: 60000,
+    },
+  }),
+}));
+
+const setupFetch = () => {
+  const fetchMock = vi.fn().mockImplementation((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.startsWith('/api/word/packs?')) {
+      return Promise.resolve(
+        new Response(JSON.stringify({
+          items: [
+            {
+              id: 'wp:robust',
+              lemma: 'robust',
+              sense_title: '壊れにくい',
+              created_at: '2024-01-01T00:00:00Z',
+              updated_at: '2024-01-03T00:00:00Z',
+              is_empty: false,
+              guest_public: true,
+              examples_count: { Dev: 3, CS: 0, LLM: 0, Business: 2, Common: 1 },
+              checked_only_count: 2,
+              learned_count: 1,
+            },
+            {
+              id: 'wp:stale',
+              lemma: 'stale',
+              sense_title: '',
+              created_at: '2024-01-01T00:00:00Z',
+              updated_at: '2024-01-02T00:00:00Z',
+              is_empty: true,
+              guest_public: false,
+              examples_count: { Dev: 0, CS: 0, LLM: 0, Business: 0, Common: 0 },
+              checked_only_count: 0,
+              learned_count: 0,
+            },
+          ],
+          total: 2,
+          limit: 200,
+          offset: 0,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+      );
+    }
+    return Promise.resolve(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
+  });
+  (globalThis as any).fetch = fetchMock;
+  return fetchMock;
+};
 
 describe('ShelvesPage', () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     localStorage.clear();
+    setupFetch();
   });
 
-  it('shows dictionary shelves and lets the user add a local shelf draft', async () => {
+  it('builds smart shelves from existing WordPacks and switches the active shelf', async () => {
     render(<ShelvesPage />);
 
     expect(screen.getByRole('heading', { name: 'Shelves' })).toBeInTheDocument();
-    expect(screen.getByText('LLMまわり')).toBeInTheDocument();
+    expect((await screen.findAllByText('最近更新')).length).toBeGreaterThan(0);
+    expect(screen.getByText('未生成')).toBeInTheDocument();
 
     const user = userEvent.setup();
+    const emptyShelf = screen.getByText('未生成').closest('article') as HTMLElement;
     await act(async () => {
-      await user.type(screen.getByLabelText('棚名'), '気になる語');
-      await user.type(screen.getByLabelText('棚の説明'), 'curious / crisp');
-      await user.click(screen.getByRole('button', { name: '追加' }));
+      await user.click(within(emptyShelf).getByRole('button', { name: 'Open' }));
     });
 
-    expect(screen.getByText('気になる語')).toBeInTheDocument();
-    expect(screen.getByText('curious / crisp')).toBeInTheDocument();
-    expect(JSON.parse(localStorage.getItem('wp.localShelves.v1') || '[]')).toEqual([
-      {
-        name: '気になる語',
-        description: 'curious / crisp',
-        count: 0,
-        color: 'sky',
-      },
-    ]);
+    expect(screen.getAllByRole('heading', { name: '未生成' }).length).toBeGreaterThan(0);
+    expect(screen.getByText('stale')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'プレビュー' })).toBeEnabled();
+    expect(localStorage.getItem('wp.localShelves.v1')).toBeNull();
   });
 });

--- a/apps/frontend/src/pages/ShelvesPage/index.tsx
+++ b/apps/frontend/src/pages/ShelvesPage/index.tsx
@@ -1,98 +1,110 @@
-import React, { useMemo, useState } from 'react';
-import { Badge, Button, Input, SearchBox, Tag } from '../../shared/ui';
-
-interface ShelfDraft {
-  name: string;
-  description: string;
-}
-
-const defaultShelves = [
-  { name: 'LLMまわり', description: 'prompt, context, latent, entail', count: 32, color: 'sky' },
-  { name: '仕事で使う', description: 'friction, robust, alignment', count: 18, color: 'yellow' },
-  { name: '似ていて混乱', description: 'brittle / fragile / delicate', count: 11, color: 'rose' },
-  { name: '文章から拾った', description: 'API reliability notes', count: 24, color: 'green' },
-  { name: '音が好き', description: 'curious, mellow, crisp', count: 7, color: 'purple' },
-  { name: 'まだ掴めてない', description: 'granular, elusive', count: 9, color: 'gold' },
-];
+import React, { useEffect, useMemo, useState } from 'react';
+import { WordPackPreviewModal } from '../../components/WordPackPreviewModal';
+import { useWordPackList } from '../../features/wordpack/hooks/useWordPackList';
+import { Badge, Button, EmptyState, SearchBox } from '../../shared/ui';
+import { ShelfWordPackList } from './ShelfWordPackList';
+import { useSmartShelves } from './useSmartShelves';
 
 export const ShelvesPage: React.FC = () => {
-  const [draft, setDraft] = useState<ShelfDraft>({ name: '', description: '' });
-  const [customShelves, setCustomShelves] = useState<typeof defaultShelves>(() => {
-    try {
-      const raw = localStorage.getItem('wp.localShelves.v1');
-      return raw ? JSON.parse(raw) : [];
-    } catch {
-      return [];
+  const [query, setQuery] = useState('');
+  const [activeShelfId, setActiveShelfId] = useState('recent');
+  const [previewWordPackId, setPreviewWordPackId] = useState<string | null>(null);
+  const { applyStudyProgress, loading, message, reload, wordPacks } = useWordPackList();
+  const shelves = useSmartShelves(wordPacks);
+  const normalizedQuery = query.trim().toLowerCase();
+  const visibleShelves = useMemo(() => {
+    if (!normalizedQuery) return shelves;
+    return shelves.filter((shelf) => (
+      shelf.title.toLowerCase().includes(normalizedQuery) ||
+      shelf.description.toLowerCase().includes(normalizedQuery) ||
+      shelf.items.some((wordPack) =>
+        wordPack.lemma.toLowerCase().includes(normalizedQuery) ||
+        (wordPack.sense_title ?? '').toLowerCase().includes(normalizedQuery)
+      )
+    ));
+  }, [normalizedQuery, shelves]);
+  const activeShelf = shelves.find((shelf) => shelf.id === activeShelfId) ?? shelves[0];
+  const activeItems = useMemo(() => {
+    if (!activeShelf) return [];
+    if (!normalizedQuery) return activeShelf.items;
+    return activeShelf.items.filter((wordPack) =>
+      wordPack.lemma.toLowerCase().includes(normalizedQuery) ||
+      (wordPack.sense_title ?? '').toLowerCase().includes(normalizedQuery)
+    );
+  }, [activeShelf, normalizedQuery]);
+
+  useEffect(() => {
+    if (shelves.length === 0) return;
+    if (!shelves.some((shelf) => shelf.id === activeShelfId)) {
+      setActiveShelfId(shelves[0].id);
     }
-  });
-  const shelves = useMemo(() => [...defaultShelves, ...customShelves], [customShelves]);
-  const addShelf = () => {
-    const name = draft.name.trim();
-    if (!name) return;
-    const next = [...customShelves, { name, description: draft.description.trim() || '自由分類', count: 0, color: 'sky' }];
-    setCustomShelves(next);
-    setDraft({ name: '', description: '' });
-    try { localStorage.setItem('wp.localShelves.v1', JSON.stringify(next)); } catch {}
-  };
+  }, [activeShelfId, shelves]);
+
   return (
     <div className="dictionary-main">
       <div className="dictionary-page-heading">
         <div className="dictionary-page-title">
           <h2>Shelves</h2>
-          <p>単元ではなく、自分で作る棚・タグ・ブックマーク。</p>
+          <p>保存済みWordPackを条件別に自動分類して眺める。</p>
         </div>
         <div className="dictionary-top-actions">
-          <SearchBox label="棚、タグ、メモを検索" placeholder="Search shelves, tags, notes" shortcut="⌘K" />
+          <SearchBox
+            label="棚とWordPackを検索"
+            placeholder="Search shelves and entries"
+            shortcut="⌘K"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+          <Button variant="subtle" onClick={() => { void reload(); }} disabled={loading}>
+            更新
+          </Button>
         </div>
       </div>
-      <section className="dictionary-section shelf-create">
+      <section className="dictionary-section">
         <div className="dictionary-section-header">
           <div>
-            <h3>棚を作る</h3>
-            <p>ローカルの下書き棚です。WordPack API 追加までは分類の入口として扱います。</p>
+            <h3>Smart Shelves</h3>
+            <p>一覧レスポンスだけを使い、保存や更新を行わずに自動分類します。</p>
           </div>
+          <Badge variant="accent">{wordPacks.length} entries</Badge>
         </div>
-        <div className="shelf-create-row">
-          <Input
-            aria-label="棚名"
-            placeholder="棚名"
-            value={draft.name}
-            onChange={(event) => setDraft((prev) => ({ ...prev, name: event.target.value }))}
-          />
-          <Input
-            aria-label="棚の説明"
-            placeholder="説明や語のメモ"
-            value={draft.description}
-            onChange={(event) => setDraft((prev) => ({ ...prev, description: event.target.value }))}
-          />
-          <Button onClick={addShelf}>追加</Button>
+        {message ? <div role="alert" className="dictionary-empty compact">{message.text}</div> : null}
+        {!message && visibleShelves.length === 0 ? <EmptyState>表示できる棚がありません。</EmptyState> : null}
+        <div className="shelf-grid" aria-label="棚一覧">
+          {visibleShelves.map((shelf) => (
+            <article key={shelf.id} className={`shelf-card ${shelf.accent}`} aria-current={activeShelfId === shelf.id ? 'true' : undefined}>
+              <h3>{shelf.title}</h3>
+              <p>{shelf.description}</p>
+              <div className="shelf-card-footer">
+                <span>{shelf.items.length} entries</span>
+                <Button variant="subtle" onClick={() => setActiveShelfId(shelf.id)}>Open</Button>
+              </div>
+            </article>
+          ))}
         </div>
-      </section>
-      <section className="shelf-grid" aria-label="棚一覧">
-        {shelves.map((shelf) => (
-          <article key={`${shelf.name}-${shelf.description}`} className={`shelf-card ${shelf.color}`}>
-            <h3>{shelf.name}</h3>
-            <p>{shelf.description}</p>
-            <div className="shelf-card-footer">
-              <span>{shelf.count} entries</span>
-              <Button variant="subtle">Open →</Button>
-            </div>
-          </article>
-        ))}
       </section>
       <section className="dictionary-section">
         <div className="dictionary-section-header">
           <div>
-            <h3>Tag cloud</h3>
+            <h3>{activeShelf?.title ?? '選択中の棚'}</h3>
+            <p>{activeShelf?.description ?? '棚を選ぶとWordPackを表示します。'}</p>
           </div>
+          {activeShelf ? <Badge variant="accent">{activeItems.length} shown</Badge> : null}
         </div>
-        <div className="dictionary-chip-list">
-          {['nuance', 'dev', 'business', 'formal', 'article-source', 'audio-good', 'compare', 'empty', 'guest-public', 'note'].map((tag) => (
-            <Tag key={tag}>{tag}</Tag>
-          ))}
-        </div>
+        {activeShelf ? (
+          <ShelfWordPackList items={activeItems} onOpenPreview={setPreviewWordPackId} />
+        ) : (
+          <EmptyState>棚データを読み込んでいます。</EmptyState>
+        )}
       </section>
+      <WordPackPreviewModal
+        isOpen={Boolean(previewWordPackId)}
+        onClose={() => setPreviewWordPackId(null)}
+        wordPackId={previewWordPackId}
+        wordPacks={wordPacks}
+        onWordPackUpdated={() => { void reload(); }}
+        onStudyProgressRecorded={applyStudyProgress}
+      />
     </div>
   );
 };
-

--- a/apps/frontend/src/pages/ShelvesPage/smartShelfRules.ts
+++ b/apps/frontend/src/pages/ShelvesPage/smartShelfRules.ts
@@ -1,0 +1,108 @@
+import { sumExamples } from '../../features/wordpack/hooks/useWordPackList';
+import type { ExampleCategory, WordPackListItem } from '../../features/wordpack/types';
+
+export type SmartShelfAccent = 'sky' | 'yellow' | 'rose' | 'green' | 'purple' | 'gold';
+
+export interface SmartShelf {
+  id: string;
+  title: string;
+  description: string;
+  accent: SmartShelfAccent;
+  items: WordPackListItem[];
+}
+
+const byUpdatedAtDesc = (a: WordPackListItem, b: WordPackListItem): number =>
+  new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime();
+
+const byExampleCountDesc = (a: WordPackListItem, b: WordPackListItem): number =>
+  sumExamples(b.examples_count) - sumExamples(a.examples_count);
+
+const hasCategoryExamples = (wordPack: WordPackListItem, category: ExampleCategory): boolean =>
+  (wordPack.examples_count?.[category] ?? 0) > 0;
+
+const missingSenseTitle = (wordPack: WordPackListItem): boolean => {
+  const value = (wordPack.sense_title ?? '').trim().toLowerCase();
+  return !value || value === 'fallback' || value === '語義タイトル未設定';
+};
+
+export const buildSmartShelves = (wordPacks: WordPackListItem[]): SmartShelf[] => {
+  const sortedByUpdatedAt = [...wordPacks].sort(byUpdatedAtDesc);
+  const manyExamples = [...wordPacks]
+    .filter((wordPack) => sumExamples(wordPack.examples_count) >= 5)
+    .sort(byExampleCountDesc);
+
+  return [
+    {
+      id: 'recent',
+      title: '最近更新',
+      description: '更新日時の新しいWordPack',
+      accent: 'sky',
+      items: sortedByUpdatedAt.slice(0, 30),
+    },
+    {
+      id: 'empty',
+      title: '未生成',
+      description: '空のまま保存されているWordPack',
+      accent: 'rose',
+      items: wordPacks.filter((wordPack) => wordPack.is_empty),
+    },
+    {
+      id: 'many-examples',
+      title: '例文が多い',
+      description: '合計5件以上の例文を持つWordPack',
+      accent: 'green',
+      items: manyExamples,
+    },
+    {
+      id: 'learned',
+      title: '学習済み多め',
+      description: '学習済み記録があるWordPack',
+      accent: 'purple',
+      items: wordPacks.filter((wordPack) => wordPack.learned_count > 0).sort(byUpdatedAtDesc),
+    },
+    {
+      id: 'checked-only',
+      title: '確認だけ多め',
+      description: '確認数が学習済み数を上回るWordPack',
+      accent: 'yellow',
+      items: wordPacks
+        .filter((wordPack) => wordPack.checked_only_count > wordPack.learned_count)
+        .sort(byUpdatedAtDesc),
+    },
+    {
+      id: 'guest-public',
+      title: 'ゲスト公開中',
+      description: 'guest_public が有効なWordPack',
+      accent: 'gold',
+      items: wordPacks.filter((wordPack) => wordPack.guest_public).sort(byUpdatedAtDesc),
+    },
+    {
+      id: 'sense-missing',
+      title: '語義未設定',
+      description: '語義タイトルが空またはfallbackのWordPack',
+      accent: 'rose',
+      items: wordPacks.filter(missingSenseTitle).sort(byUpdatedAtDesc),
+    },
+    {
+      id: 'dev',
+      title: 'Dev語彙',
+      description: 'Dev例文を持つWordPack',
+      accent: 'green',
+      items: wordPacks.filter((wordPack) => hasCategoryExamples(wordPack, 'Dev')).sort(byUpdatedAtDesc),
+    },
+    {
+      id: 'business',
+      title: 'Business語彙',
+      description: 'Business例文を持つWordPack',
+      accent: 'purple',
+      items: wordPacks.filter((wordPack) => hasCategoryExamples(wordPack, 'Business')).sort(byUpdatedAtDesc),
+    },
+    {
+      id: 'common',
+      title: 'Common語彙',
+      description: 'Common例文を持つWordPack',
+      accent: 'sky',
+      items: wordPacks.filter((wordPack) => hasCategoryExamples(wordPack, 'Common')).sort(byUpdatedAtDesc),
+    },
+  ];
+};

--- a/apps/frontend/src/pages/ShelvesPage/useSmartShelves.ts
+++ b/apps/frontend/src/pages/ShelvesPage/useSmartShelves.ts
@@ -1,0 +1,6 @@
+import { useMemo } from 'react';
+import { buildSmartShelves } from './smartShelfRules';
+import type { WordPackListItem } from '../../features/wordpack/types';
+
+export const useSmartShelves = (wordPacks: WordPackListItem[]) =>
+  useMemo(() => buildSmartShelves(wordPacks), [wordPacks]);

--- a/apps/frontend/src/shared/styles/layout.css
+++ b/apps/frontend/src/shared/styles/layout.css
@@ -146,87 +146,70 @@ body.theme-dark .dictionary-reader-canvas {
 
 .explore-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1.5fr) minmax(260px, 0.8fr);
+  grid-template-columns: minmax(220px, 0.7fr) minmax(0, 1.25fr) minmax(260px, 0.8fr);
   gap: 1rem;
 }
 
-.explore-graph {
+.explore-list,
+.explore-connections {
   min-height: 440px;
-  position: relative;
-  overflow: hidden;
+  display: grid;
+  align-content: start;
+  gap: 0.6rem;
+  overflow: auto;
   border: 1px solid var(--dict-border);
   border-radius: var(--dict-radius);
-  background:
-    linear-gradient(90deg, rgba(131, 206, 248, 0.06) 1px, transparent 1px),
-    linear-gradient(0deg, rgba(131, 206, 248, 0.06) 1px, transparent 1px),
-    var(--dict-bg-subtle);
-  background-size: 54px 54px;
+  background: var(--dict-bg-subtle);
+  padding: 0.65rem;
 }
 
-.explore-node {
-  position: absolute;
+.explore-list-item,
+.explore-connection-card,
+.shelf-wordpack-card {
   display: grid;
-  place-items: center;
-  gap: 0.15rem;
-  width: 7rem;
-  height: 7rem;
-  border: 2px solid var(--dict-accent);
-  border-radius: 999px;
-  background: rgba(131, 206, 248, 0.14);
+  gap: 0.45rem;
+  border: 1px solid var(--dict-border);
+  border-radius: var(--dict-radius-sm);
+  background: var(--dict-surface);
   color: var(--dict-text);
+}
+
+.explore-list-item {
+  width: 100%;
+  grid-template-columns: 1fr;
+  text-align: left;
+  padding: 0.65rem 0.75rem;
   cursor: pointer;
 }
 
-.explore-node span {
+.explore-list-item span,
+.explore-connection-card p,
+.shelf-wordpack-card p {
+  margin: 0;
   color: var(--dict-muted);
-  font-size: 0.72rem;
 }
 
-.explore-node.center {
-  left: calc(50% - 3.5rem);
-  top: calc(50% - 3.5rem);
-  width: 8rem;
-  height: 8rem;
-}
-
-.explore-node.purple {
-  left: 24%;
-  top: 28%;
-  border-color: var(--dict-purple);
-}
-
-.explore-node.green {
-  left: 18%;
-  top: 62%;
-  border-color: var(--dict-green);
-}
-
-.explore-node.yellow {
-  right: 16%;
-  top: 15%;
-  border-color: var(--dict-yellow);
-}
-
-.explore-node.rose {
-  right: -2.5rem;
-  top: 32%;
-  border-color: var(--dict-rose);
-}
-
-.explore-node.empty {
-  left: 46%;
-  bottom: 10%;
-  width: 5.5rem;
-  height: 5.5rem;
-  border-style: dashed;
-}
-
-.explore-node[aria-pressed='true'] {
+.explore-list-item[aria-pressed='true'] {
   background: rgba(131, 206, 248, 0.24);
   box-shadow: var(--dict-focus);
 }
 
+.explore-connection-card {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  padding: 0.85rem;
+}
+
+.explore-connection-card h3,
+.shelf-wordpack-card h3 {
+  margin: 0.45rem 0 0.25rem;
+  overflow-wrap: anywhere;
+}
+
 .explore-side {
+  display: grid;
+  align-content: start;
+  gap: 0.85rem;
   padding: 1rem;
   border: 1px solid var(--dict-border);
   border-radius: var(--dict-radius);
@@ -235,7 +218,8 @@ body.theme-dark .dictionary-reader-canvas {
 
 .explore-side h3 {
   margin: 0;
-  font-size: 2rem;
+  font-size: 1.7rem;
+  overflow-wrap: anywhere;
 }
 
 .explore-side h4 {
@@ -281,6 +265,10 @@ body.theme-dark .dictionary-reader-canvas {
   background: var(--dict-surface);
 }
 
+.shelf-card[aria-current='true'] {
+  box-shadow: var(--dict-focus);
+}
+
 .shelf-card h3 {
   margin: 0;
   font-size: 1.4rem;
@@ -314,6 +302,17 @@ body.theme-dark .dictionary-reader-canvas {
 
 .shelf-card.purple {
   border-left-color: var(--dict-purple);
+}
+
+.shelf-wordpack-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.shelf-wordpack-card {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  padding: 0.85rem;
 }
 
 .settings-grid {
@@ -383,8 +382,10 @@ body.theme-dark .dictionary-reader-canvas {
     grid-template-columns: 1fr;
   }
 
-  .explore-graph {
-    min-height: 340px;
+  .explore-list,
+  .explore-connections {
+    min-height: auto;
+    max-height: none;
   }
 
   .shelf-create-row {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,6 +70,8 @@ repository alias は `backend.infrastructure.firestore.repositories.*` に集約
 | `src/app/styles/*` | app shell / login CSS。旧 inline CSS から移動 |
 | `src/app/routes.ts` | `/lexicon`、`/wordpacks/:id`、`/reader`、`/examples`、`/explore`、`/shelves`、`/settings` の軽量 route 互換 |
 | `src/pages/*Page` | Lexicon / WordPack Detail / Reader / Examples / Explore / Shelves / Settings の画面単位の構成 |
+| `src/pages/ExplorePage` | 既存WordPack詳細を読み取り、関連語・共起・対比・例文の接続カードへ変換する Connection Explorer |
+| `src/pages/ShelvesPage` | 既存WordPack一覧を条件別に自動分類する Smart Shelves |
 | `src/features/auth` | Google OAuth telemetry と sanitization |
 | `src/features/wordpack` | WordPack domain types、API helper、feature hooks/components。旧 `src/components/WordPackPanel.tsx` は re-export |
 | `src/features/article-import` | Article import API/type/hook/components。旧 `src/components/ArticleImportPanel.tsx` は re-export |


### PR DESCRIPTION
## 概要

- 固定モックだった Explore を、既存 WordPack の一覧と詳細を読む Connection Explorer に置換
- Shelves を localStorage の手動棚から、既存 WordPack 一覧を条件別に自動分類する Smart Shelves に置換
- WordPack プレビュー用の共通モーダルと一覧取得フックを追加
- README / architecture docs に Explore / Shelves の責務を追記

## 既存挙動

- 生成、削除、guest_public 更新、学習進捗更新、Article import、Examples 操作には新しい書き込み経路を追加していません
- Explore / Shelves は既存の GET API を使う読み取り中心のビューです
- WordPack プレビュー内の既存操作は既存 `WordPackPanel` に委譲しています

## 検証

- `cd apps/frontend && npx tsc -p tsconfig.json`
- `cd apps/frontend && npm test -- pages/ExplorePage/ExplorePage.test.tsx pages/ShelvesPage/ShelvesPage.test.tsx`
- `cd apps/frontend && npm test`
- `cd apps/frontend && npm run build`
- `git diff --check`

## 補足

- ローカルブラウザ確認ではバックエンドの `backend` ホストが未起動のため `/api/config` が失敗し、実データ表示までは確認できていません。型・単体テスト・ビルドで読み取りビューの動作を固定しています。