### PR TITLE
CIのFirestoreインデックス同期前提を修正する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,16 @@ jobs:
           project_id: ${{ env.CLOUD_RUN_PROJECT_ID }}
           install_components: beta
 
+      - name: Set up Node.js for Firebase CLI
+        if: env.GCP_SA_KEY != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Firebase CLI
+        if: env.GCP_SA_KEY != ''
+        run: npm install -g firebase-tools
+
       - name: Deploy Firestore indexes
         if: env.GCP_SA_KEY != ''
         run: make deploy-firestore-indexes PROJECT_ID=${{ env.CLOUD_RUN_PROJECT_ID }} TOOL=firebase


### PR DESCRIPTION
## 変更内容
- `CI` workflow の `deploy_production` job で、Firestore インデックス同期前に Node.js 22 をセットアップするようにしました。
- `TOOL=firebase` で呼び出す `make deploy-firestore-indexes` の前提として、`firebase-tools` をインストールするステップを追加しました。

## 保持した既存挙動
- `GCP_SA_KEY` が空の場合は deploy 関連ステップをスキップする既存条件を維持しました。
- Cloud Run deploy と Firestore index deploy の呼び出し順は変更していません。

## 検証結果
- `git diff --check`
- `shellcheck scripts/deploy_cloud_run.sh`
- `/usr/local/bin/bash ./scripts/deploy_cloud_run.sh --dry-run --env-file configs/cloud-run/ci.env --project-id ci-placeholder-project --region asia-northeast1 --service wordpack-backend` 相当を Bash 5 / Python 3.13 で実行し、設定検証と dry-run 完了を確認

## 未実行項目
- Backend / Frontend / Playwright は workflow 前提修正のみのため未実行です。
- 実際の本番 deploy は GitHub Actions 上の secrets と GCP 権限に依存するためローカルでは未実行です。

## 残るリスク
- main push 時の本番 deploy job は secrets / GCP 権限 / Firebase project 設定に依存します。PR CI 通過後も、main 反映後の deploy job で最終確認が必要です。