### PR TITLE
distribute生成のResponses APIパラメータ互換性を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
     env:
       FIRESTORE_PROJECT_ID: wordpack-ci
       FIRESTORE_EMULATOR_PORT: 8080
-      FIRESTORE_EMULATOR_HOST: ""
-      ENABLE_FIRESTORE_EMULATOR: "false"
+      FIRESTORE_EMULATOR_HOST: "127.0.0.1:8080"
+      ENABLE_FIRESTORE_EMULATOR: "true"
     strategy:
       matrix:
         python-version: ['3.13']

--- a/UserManual.md
+++ b/UserManual.md
@@ -632,8 +632,8 @@ base64 -w 0 .env.deploy  # 出力を手動コピー
     ```
 
 - 500 Internal Server Error（WordPack 生成時）で `reason_code=PARAM_UNSUPPORTED`
-  - 原因: SDK が現行の Responses API パラメータに追従していない可能性があります。
-  - 対応: `pip install -U openai` 後に再起動してください。
+  - 原因: Responses API へ送る任意パラメータが、選択モデルの現行仕様で拒否されている可能性があります。
+  - 対応: 最新版では `response_format` を送らず `text.format` を使い、`reasoning` / `text.verbosity` が拒否された場合は自動で外して再試行します。古い環境では最新版へ更新し、必要なら `pip install -U openai` 後に再起動してください。
 
 - 500 Internal Server Error で `ValidationError: 1 validation error for ContrastItem with Field required`
   - 原因: Pydantic v2 のエイリアス設定未適用により `with` → `with_` マッピング不全

--- a/apps/backend/backend/application/wordpack/errors.py
+++ b/apps/backend/backend/application/wordpack/errors.py
@@ -91,7 +91,7 @@ def handle_flow_runtime_error(
                 detail={
                     "message": "LLM parameter not supported by model",
                     "reason_code": "PARAM_UNSUPPORTED",
-                    "hint": "モデルの仕様変更により Responses API パラメータが非対応の可能性。最新SDK/パラメータを使用してください。",
+                    "hint": "任意の reasoning/text 指定を外しても失敗しました。モデル名、OpenAI SDK、Responses API の対応状況を確認してください。",
                 },
             ) from exc
 

--- a/apps/backend/backend/providers/llm.py
+++ b/apps/backend/backend/providers/llm.py
@@ -154,18 +154,63 @@ class _OpenAILLM(_LLMBase):  # pragma: no cover - オンライン利用が前提
         *,
         prompt: str,
         use_json: bool,
+        include_reasoning: bool,
+        include_text_options: bool,
     ) -> Any:
         kwargs: dict[str, Any] = {
             "model": self._model,
             "input": prompt,
-            "reasoning": self._reasoning,
-            "text": self._text,
             "max_output_tokens": int(getattr(settings, "llm_max_tokens", 900)),
             "timeout": settings.llm_timeout_ms / 1000.0,
         }
+        if include_reasoning and self._reasoning:
+            kwargs["reasoning"] = self._reasoning
+        text_options: dict[str, Any] = {}
+        if include_text_options and isinstance(self._text, dict):
+            text_options = dict(self._text)
         if use_json:
-            kwargs["response_format"] = {"type": "json_object"}
+            text_options["format"] = {"type": "json_object"}
+        if text_options:
+            kwargs["text"] = text_options
         return self._client.responses.create(**kwargs)
+
+    @staticmethod
+    def _is_param_unsupported_error(exc: Exception) -> bool:
+        text = (str(exc) or "").lower()
+        error_type = type(exc).__name__.lower()
+        return (
+            "unsupported parameter" in text
+            or "unknown parameter" in text
+            or "unrecognized parameter" in text
+            or "invalid parameter" in text
+            or "not supported" in text
+            or "unexpected keyword argument" in text
+            or "got an unexpected keyword argument" in text
+            or "unsupported" in error_type
+        )
+
+    @staticmethod
+    def _response_attempts() -> list[dict[str, Any]]:
+        return [
+            {
+                "use_json": True,
+                "include_reasoning": True,
+                "include_text_options": True,
+                "label": "json_with_controls",
+            },
+            {
+                "use_json": True,
+                "include_reasoning": False,
+                "include_text_options": False,
+                "label": "json_without_optional_controls",
+            },
+            {
+                "use_json": False,
+                "include_reasoning": False,
+                "include_text_options": False,
+                "label": "plain_without_optional_controls",
+            },
+        ]
 
     def complete(self, prompt: str) -> str:
         logger.info(
@@ -186,9 +231,15 @@ class _OpenAILLM(_LLMBase):  # pragma: no cover - オンライン利用が前提
 
         last_exc: Exception | None = None
         with _langfuse_span("openai.responses.create", self._model, prompt) as current_span:
-            for use_json_flag in [True, False]:
+            attempts = self._response_attempts()
+            for attempt_index, attempt in enumerate(attempts):
                 try:
-                    resp = self._create_response(prompt=prompt, use_json=use_json_flag)
+                    resp = self._create_response(
+                        prompt=prompt,
+                        use_json=bool(attempt["use_json"]),
+                        include_reasoning=bool(attempt["include_reasoning"]),
+                        include_text_options=bool(attempt["include_text_options"]),
+                    )
                     content = self._extract_text(resp)
                     try:
                         import hashlib as hf
@@ -202,8 +253,8 @@ class _OpenAILLM(_LLMBase):  # pragma: no cover - オンライン利用が前提
                             content_sha256=hf.sha256(
                                 (content or "").encode("utf-8", errors="ignore")
                             ).hexdigest(),
-                            json_forced=bool(use_json_flag),
-                            param="max_output_tokens",
+                            json_forced=bool(attempt["use_json"]),
+                            param_profile=str(attempt["label"]),
                         )
                     except Exception:
                         pass
@@ -213,13 +264,25 @@ class _OpenAILLM(_LLMBase):  # pragma: no cover - オンライン利用が前提
                         provider="openai",
                         model=self._model,
                         content_chars=len(content),
-                        json_forced=bool(use_json_flag),
-                        param="max_output_tokens",
+                        json_forced=bool(attempt["use_json"]),
+                        param_profile=str(attempt["label"]),
                     )
                     return content
                 except Exception as exc:
                     last_exc = exc
-                    if use_json_flag and "response_format" in (str(exc) or "").lower():
+                    if (
+                        self._is_param_unsupported_error(exc)
+                        and attempt_index < len(attempts) - 1
+                    ):
+                        logger.info(
+                            "llm_complete_param_fallback",
+                            provider="openai",
+                            model=self._model,
+                            failed_profile=str(attempt["label"]),
+                            next_profile=str(attempts[attempt_index + 1]["label"]),
+                            error_type=type(exc).__name__,
+                            error=str(exc)[:256],
+                        )
                         continue
                     raise
         raise last_exc if last_exc else RuntimeError("LLM call failed with unsupported params")

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,12 +1,15 @@
 # 付録: OpenAIモデル設定（Responses API）
 
-本プロジェクトで選択できる LLM は `gpt-5.4-mini` と `gpt-5.4-nano` の 2 種だけです。バックエンドは Responses API に対して常に `reasoning` / `text` / `max_output_tokens` を送信し、旧世代向けの `temperature`、`max_tokens`、`max_completion_tokens` は使用しません。
+本プロジェクトで選択できる LLM は `gpt-5.4-mini` と `gpt-5.4-nano` の 2 種だけです。バックエンドは Responses API に対して `max_output_tokens` と、必要に応じて `reasoning` / `text` を送信し、旧世代向けの `temperature`、`max_tokens`、`max_completion_tokens` は使用しません。
+
+JSON 生成を強制したい呼び出しでは、Responses API の `text.format={"type":"json_object"}` を使います。`response_format` は Responses API には送信しません。
 
 ## 制御できるパラメータ
 
 - `model`: `gpt-5.4-mini` または `gpt-5.4-nano`
 - `reasoning.effort`: `minimal` / `low` / `medium` / `high`
 - `text.verbosity`: `low` / `medium` / `high`
+- `text.format`: JSON 生成時に内部で `{"type": "json_object"}` を付与
 - `max_output_tokens`: `.env` の `LLM_MAX_TOKENS`
 
 ## 設定例
@@ -24,3 +27,4 @@
 - 通常は `gpt-5.4-mini` を使い、軽量化したい場合に `gpt-5.4-nano` を選びます。
 - 出力のまとまりや一貫性は `reasoning.effort`、文量や詳細度は `text.verbosity` で調整します。
 - JSON 途中切れが疑われる場合は `LLM_MAX_TOKENS` を増やします。
+- モデル側が `reasoning` や `text.verbosity` を拒否した場合、バックエンドは JSON 形式指定だけを残して再試行し、それも拒否された場合はプロンプト内の JSON 指示に委ねて再試行します。

--- a/tests/test_github_actions_branch_policy.py
+++ b/tests/test_github_actions_branch_policy.py
@@ -68,33 +68,30 @@ def test_deploy_dry_run_is_main_only() -> None:
     _assert_contains_all(yml, ["google-github-actions/auth@v2", "setup-gcloud@v2"])
 
 
-def test_deploy_production_runs_only_on_main_push_and_deploys_tested_commit() -> None:
+def test_ci_does_not_embed_production_deploy_job() -> None:
     """
-    Contract: production deployment must appear as a check on the same commit (Checks UI),
-    so it must be implemented as a CI job that runs only for push-to-main after other CI jobs succeed.
+    Contract: production deployment is owned by deploy-production.yml.
+    CI may run guards and dry-runs, but it must not contain the production deploy job.
     """
     yml = _read_text(".github/workflows/ci.yml")
-    # Guardrails: run only on push-to-main.
-    _assert_contains_all(
+    _assert_contains_none(
         yml,
         [
             "deploy_production:",
-            "if: github.event_name == 'push' && github.ref == 'refs/heads/main'",
+            "environment: production",
         ],
     )
-    # Sanity: ensure this job is actually the one touching GCP.
-    _assert_contains_all(yml, ["google-github-actions/auth@v2", "setup-gcloud@v2"])
-    _assert_contains_all(yml, ["make release-cloud-run", "TOOL=firebase"])
+    _assert_contains_all(yml, ["cloud_run_guard:", "deploy_cloud_run.sh --dry-run"])
 
 
-def test_deploy_production_workflow_is_manual_fallback_only() -> None:
+def test_deploy_production_workflow_runs_on_main_push_or_manual_only() -> None:
     """
-    Contract: automatic production deploy runs as a CI job.
-    The standalone deploy-production workflow must not auto-trigger from workflow_run (avoid double deploys).
+    Contract: automatic production deploy runs from the standalone workflow on main push.
+    workflow_dispatch remains as the manual fallback, and workflow_run is not used.
     """
     yml = _read_text(".github/workflows/deploy-production.yml")
     on_block = _extract_on_block(yml)
-    _assert_contains_all(on_block, ["workflow_dispatch:"])
-    _assert_contains_none(on_block, ["workflow_run:"])
+    _assert_contains_all(on_block, ["push:", "branches:", "main", "workflow_dispatch:"])
+    _assert_contains_none(on_block, ["workflow_run:", "pull_request:"])
     _assert_contains_none(yml, ["github.event.workflow_run."])
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -167,8 +167,12 @@ def test_openai_request_uses_reasoning_text_params(monkeypatch):
     first = calls[0]
     assert first["model"] == "gpt-5.4-mini"
     assert first["reasoning"] == {"effort": "high"}
-    assert first["text"] == {"verbosity": "high"}
+    assert first["text"] == {
+        "verbosity": "high",
+        "format": {"type": "json_object"},
+    }
     assert first["max_output_tokens"] > 0
+    assert "response_format" not in first
     assert "temperature" not in first
     assert "max_tokens" not in first
     assert "max_completion_tokens" not in first
@@ -221,5 +225,133 @@ def test_openai_request_uses_nano_model(monkeypatch):
     assert isinstance(out, str) and "\"senses\"" in out
     assert calls[0]["model"] == "gpt-5.4-nano"
     assert calls[0]["reasoning"] == {"effort": "high"}
-    assert calls[0]["text"] == {"verbosity": "high"}
+    assert calls[0]["text"] == {
+        "verbosity": "high",
+        "format": {"type": "json_object"},
+    }
+    assert "response_format" not in calls[0]
     assert "temperature" not in calls[0]
+
+
+def test_openai_request_retries_without_optional_controls(monkeypatch):
+    """モデルが reasoning/text.verbosity を拒否したら JSON 形式だけ残して再試行する。"""
+    monkeypatch.setenv("STRICT_MODE", "false")
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "gpt-5.4-mini")
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy-realistic-key")
+
+    from importlib import reload
+    import backend.config
+    import backend.providers
+    reload(backend.config)
+    reload(backend.providers)
+
+    calls: list[dict] = []
+
+    class _DummyMessage:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+    class _DummyChoice:
+        def __init__(self, content: str) -> None:
+            self.message = _DummyMessage(content)
+
+    class _DummyResp:
+        def __init__(self, content: str) -> None:
+            self.choices = [_DummyChoice(content)]
+
+    class _DummyResponses:
+        def create(self, **kwargs):  # type: ignore[no-untyped-def]
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise RuntimeError(
+                    "Unsupported parameter: 'text.verbosity' is not supported by this model"
+                )
+            return _DummyResp('{"senses": [{"id": "s1", "gloss_ja": "ok"}]}')
+
+    class DummyOpenAI:
+        def __init__(self, api_key: str) -> None:  # type: ignore[no-untyped-def]
+            self.responses = _DummyResponses()
+
+    backend.providers.llm.OpenAI = DummyOpenAI  # type: ignore[attr-defined, assignment]
+
+    from backend.providers import get_llm_provider
+    llm = get_llm_provider(
+        reasoning_override={"effort": "minimal"},
+        text_override={"verbosity": "high"},
+    )
+
+    out = llm.complete("ping")
+
+    assert "\"senses\"" in out
+    assert len(calls) == 2
+    assert calls[0]["reasoning"] == {"effort": "minimal"}
+    assert calls[0]["text"] == {
+        "verbosity": "high",
+        "format": {"type": "json_object"},
+    }
+    assert "reasoning" not in calls[1]
+    assert calls[1]["text"] == {"format": {"type": "json_object"}}
+    assert all("response_format" not in call for call in calls)
+
+
+def test_openai_request_retries_without_json_format_when_needed(monkeypatch):
+    """JSON mode 自体が拒否された場合は、プロンプト指示に委ねて通常出力で再試行する。"""
+    monkeypatch.setenv("STRICT_MODE", "false")
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "gpt-5.4-mini")
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy-realistic-key")
+
+    from importlib import reload
+    import backend.config
+    import backend.providers
+    reload(backend.config)
+    reload(backend.providers)
+
+    calls: list[dict] = []
+
+    class _DummyMessage:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+    class _DummyChoice:
+        def __init__(self, content: str) -> None:
+            self.message = _DummyMessage(content)
+
+    class _DummyResp:
+        def __init__(self, content: str) -> None:
+            self.choices = [_DummyChoice(content)]
+
+    class _DummyResponses:
+        def create(self, **kwargs):  # type: ignore[no-untyped-def]
+            calls.append(kwargs)
+            if len(calls) <= 2:
+                raise RuntimeError(
+                    "The json_object response format is not supported by this model"
+                )
+            return _DummyResp('{"senses": [{"id": "s1", "gloss_ja": "ok"}]}')
+
+    class DummyOpenAI:
+        def __init__(self, api_key: str) -> None:  # type: ignore[no-untyped-def]
+            self.responses = _DummyResponses()
+
+    backend.providers.llm.OpenAI = DummyOpenAI  # type: ignore[attr-defined, assignment]
+
+    from backend.providers import get_llm_provider
+    llm = get_llm_provider(
+        reasoning_override={"effort": "minimal"},
+        text_override={"verbosity": "high"},
+    )
+
+    out = llm.complete("ping")
+
+    assert "\"senses\"" in out
+    assert len(calls) == 3
+    assert calls[0]["text"] == {
+        "verbosity": "high",
+        "format": {"type": "json_object"},
+    }
+    assert calls[1]["text"] == {"format": {"type": "json_object"}}
+    assert "text" not in calls[2]
+    assert "reasoning" not in calls[2]
+    assert all("response_format" not in call for call in calls)


### PR DESCRIPTION
## 変更内容
- Responses API の JSON 指定を `response_format` から `text.format={"type":"json_object"}` へ変更
- モデルが `reasoning` / `text.verbosity` / JSON format などの任意パラメータを拒否した場合、段階的に外して再試行するフォールバックを追加
- `PARAM_UNSUPPORTED` のユーザー向けヒントとモデル設定ドキュメントを更新
- CI の backend job を README と同じ Firestore Emulator 前提へ戻し、デプロイ方針テストを現行の `deploy-production.yml` 運用に合わせて更新

## 保持した既存挙動
- `max_output_tokens` と選択モデルの指定は維持
- 通常時は従来どおり `reasoning` / `text.verbosity` を送信
- JSON format が使えるモデルでは JSON 応答の強制を維持

## 検証結果
- `PYTHONPATH=apps/backend python3 -m pytest --no-cov tests/test_providers.py -q` -> 9 passed
- `python3 -m pytest --no-cov tests/test_github_actions_branch_policy.py -q` -> 4 passed
- `PYTEST_CURRENT_TEST=bootstrap FIRESTORE_EMULATOR_HOST=localhost:8080 FIRESTORE_PROJECT_ID=test-project PYTHONPATH=apps/backend python3 -m pytest` -> 209 passed, 2 skipped, coverage 80.19%
- `git diff --check` -> passed

## 未実行項目
- Frontend typecheck/tests: フロントエンド実装は変更していないため未実行
- Playwright smoke: UI導線変更ではないため未実行
- Security headers / Cloud Run deploy dry-run: 対象ファイル外のため未実行

## 残るリスク
- 実OpenAI APIで該当モデルが `max_output_tokens` やモデル名自体を拒否する場合は、このフォールバックでは救済せず `PARAM_UNSUPPORTED` として返る
- `tests/test_github_actions_branch_policy.py` は既存CRLFをLFへ正規化しているため、内容差分より表示差分が大きめ