### PR TITLE
[codex] 文章インポートのプレーン生成でJSON modeを使わない

### DIFF
--- a/apps/backend/backend/flows/article_import.py
+++ b/apps/backend/backend/flows/article_import.py
@@ -423,6 +423,15 @@ CEFR A1〜A2 の日常語（挨拶・カレンダー/時間語・基本動詞 ge
         """
         return strip_code_fences(text, prefer_json_object=False)
 
+    def _complete_text(self, llm: object, prompt: str) -> str:
+        """プレーンテキスト生成では Responses API の JSON mode を使わない。"""
+
+        complete_text = getattr(llm, "complete_text", None)
+        if callable(complete_text):
+            return str(complete_text(prompt) or "")
+        complete = getattr(llm, "complete")
+        return str(complete(prompt) or "")
+
     def _post_filter_lemmas(self, raw: list[str]) -> list[str]:
         return filter_article_lemmas(raw, basic_lemmas=self._BASIC_LEMMAS)
 
@@ -651,7 +660,7 @@ CEFR A1〜A2 の日常語（挨拶・カレンダー/時間語・基本動詞 ge
                     name="article.title.llm",
                     input={"prompt_chars": len(pr)},
                 ):
-                    out = llm.complete(pr)
+                    out = self._complete_text(llm, pr)
                 t = str(out or "").strip()
                 t = self._strip_code_fences(t)
                 # 安全側: 空なら Untitled（UI互換）。ダミー生成ではなく保存時に明示化するだけ。
@@ -675,7 +684,7 @@ CEFR A1〜A2 の日常語（挨拶・カレンダー/時間語・基本動詞 ge
                     name="article.translation.llm",
                     input={"prompt_chars": len(pr)},
                 ):
-                    out = llm.complete(pr)
+                    out = self._complete_text(llm, pr)
                 ja = str(out or "").strip()
                 ja = self._strip_code_fences(ja)
                 s["body_ja"] = ja
@@ -698,7 +707,7 @@ CEFR A1〜A2 の日常語（挨拶・カレンダー/時間語・基本動詞 ge
                     name="article.explanation.llm",
                     input={"prompt_chars": len(pr)},
                 ):
-                    out = llm.complete(pr)
+                    out = self._complete_text(llm, pr)
                 note = str(out or "").strip()
                 note = self._strip_code_fences(note)
                 s["notes_ja"] = note or None

--- a/apps/backend/backend/providers/llm.py
+++ b/apps/backend/backend/providers/llm.py
@@ -26,6 +26,9 @@ class _LLMBase:
     def complete(self, prompt: str) -> str:  # pragma: no cover - interface definition
         raise NotImplementedError
 
+    def complete_text(self, prompt: str) -> str:  # pragma: no cover - interface definition
+        return self.complete(prompt)
+
 
 class _LocalEchoLLM(_LLMBase):
     """外部依存が利用できない環境でのフォールバック LLM。"""
@@ -45,6 +48,9 @@ class _LocalEchoLLM(_LLMBase):
             content_chars=len(out),
         )
         return out
+
+    def complete_text(self, prompt: str) -> str:
+        return self.complete(prompt)
 
 
 def _prepare_span_input(model: str, prompt: str) -> dict[str, Any]:
@@ -212,26 +218,49 @@ class _OpenAILLM(_LLMBase):  # pragma: no cover - オンライン利用が前提
             },
         ]
 
-    def complete(self, prompt: str) -> str:
+    @staticmethod
+    def _plain_response_attempts() -> list[dict[str, Any]]:
+        return [
+            {
+                "use_json": False,
+                "include_reasoning": True,
+                "include_text_options": True,
+                "label": "plain_with_controls",
+            },
+            {
+                "use_json": False,
+                "include_reasoning": False,
+                "include_text_options": False,
+                "label": "plain_without_optional_controls",
+            },
+        ]
+
+    def _complete_with_attempts(
+        self, prompt: str, attempts: list[dict[str, Any]], response_mode: str
+    ) -> str:
         logger.info(
             "llm_complete_call",
             provider="openai",
             model=self._model,
             prompt_chars=len(prompt),
+            response_mode=response_mode,
         )
         if self._api_key == "test-key":
-            out = '{"senses": [{"id": "s1", "gloss_ja": "テスト用の語義", "patterns": ["test pattern"]}], "sense_title": "テスト語義", "collocations": {"general": {"verb_object": ["test verb"], "adj_noun": ["test adj"], "prep_noun": ["test prep"]}, "academic": {"verb_object": [], "adj_noun": [], "prep_noun": []}}, "contrast": [], "examples": {"Dev": [{"en": "This is a test in dev.", "ja": "これは開発現場のテストです。"}], "CS": [], "LLM": [], "Business": [], "Common": []}, "etymology": {"note": "Test etymology", "confidence": "medium"}, "study_card": "テスト用の学習カード", "pronunciation": {"ipa_RP": "/test/"}}'
+            if response_mode == "plain":
+                out = "テスト用のプレーンテキスト応答"
+            else:
+                out = '{"senses": [{"id": "s1", "gloss_ja": "テスト用の語義", "patterns": ["test pattern"]}], "sense_title": "テスト語義", "collocations": {"general": {"verb_object": ["test verb"], "adj_noun": ["test adj"], "prep_noun": ["test prep"]}, "academic": {"verb_object": [], "adj_noun": [], "prep_noun": []}}, "contrast": [], "examples": {"Dev": [{"en": "This is a test in dev.", "ja": "これは開発現場のテストです。"}], "CS": [], "LLM": [], "Business": [], "Common": []}, "etymology": {"note": "Test etymology", "confidence": "medium"}, "study_card": "テスト用の学習カード", "pronunciation": {"ipa_RP": "/test/"}}'
             logger.info(
                 "llm_complete_result",
                 provider="openai",
                 model=self._model,
                 content_chars=len(out),
+                response_mode=response_mode,
             )
             return out
 
         last_exc: Exception | None = None
         with _langfuse_span("openai.responses.create", self._model, prompt) as current_span:
-            attempts = self._response_attempts()
             for attempt_index, attempt in enumerate(attempts):
                 try:
                     resp = self._create_response(
@@ -255,6 +284,7 @@ class _OpenAILLM(_LLMBase):  # pragma: no cover - オンライン利用が前提
                             ).hexdigest(),
                             json_forced=bool(attempt["use_json"]),
                             param_profile=str(attempt["label"]),
+                            response_mode=response_mode,
                         )
                     except Exception:
                         pass
@@ -266,6 +296,7 @@ class _OpenAILLM(_LLMBase):  # pragma: no cover - オンライン利用が前提
                         content_chars=len(content),
                         json_forced=bool(attempt["use_json"]),
                         param_profile=str(attempt["label"]),
+                        response_mode=response_mode,
                     )
                     return content
                 except Exception as exc:
@@ -282,10 +313,21 @@ class _OpenAILLM(_LLMBase):  # pragma: no cover - オンライン利用が前提
                             next_profile=str(attempts[attempt_index + 1]["label"]),
                             error_type=type(exc).__name__,
                             error=str(exc)[:256],
+                            response_mode=response_mode,
                         )
                         continue
                     raise
         raise last_exc if last_exc else RuntimeError("LLM call failed with unsupported params")
+
+    def complete(self, prompt: str) -> str:
+        return self._complete_with_attempts(
+            prompt, self._response_attempts(), response_mode="json"
+        )
+
+    def complete_text(self, prompt: str) -> str:
+        return self._complete_with_attempts(
+            prompt, self._plain_response_attempts(), response_mode="plain"
+        )
 
 
 def _llm_with_policy(llm: _LLMBase) -> _LLMBase:
@@ -295,18 +337,26 @@ def _llm_with_policy(llm: _LLMBase) -> _LLMBase:
 
     class _Wrapped(_LLMBase):
         def complete(self, prompt: str) -> str:
+            return self._run_with_policy("complete", prompt)
+
+        def complete_text(self, prompt: str) -> str:
+            return self._run_with_policy("complete_text", prompt)
+
+        def _run_with_policy(self, method_name: str, prompt: str) -> str:
             last_exc: Exception | None = None
             for attempt in range(1, max(1, settings.llm_max_retries) + 1):
                 future = None
                 try:
                     ctx = contextvars.copy_context()
-                    future = executor.submit(ctx.run, llm.complete, prompt)
+                    method = getattr(llm, method_name)
+                    future = executor.submit(ctx.run, method, prompt)
                     result = future.result(timeout=settings.llm_timeout_ms / 1000.0)
                     if result == "":
                         logger.info(
                             "llm_complete_empty",
                             attempt=attempt,
                             retries=settings.llm_max_retries,
+                            method=method_name,
                         )
                     return result
                 except Exception as exc:
@@ -317,6 +367,7 @@ def _llm_with_policy(llm: _LLMBase) -> _LLMBase:
                         retries=settings.llm_max_retries,
                         error_type=type(exc).__name__,
                         error=str(exc),
+                        method=method_name,
                     )
                     if future is not None:
                         try:
@@ -330,6 +381,7 @@ def _llm_with_policy(llm: _LLMBase) -> _LLMBase:
                 "llm_complete_failed_all_retries",
                 error=str(last_exc) if last_exc else None,
                 error_type=(type(last_exc).__name__ if last_exc else None),
+                method=method_name,
             )
             if settings.strict_mode:
                 reason_code = "UNKNOWN"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1309,6 +1309,54 @@ def test_article_import_includes_llm_metadata(monkeypatch):
     _assert_iso_utc(detail["generation_completed_at"])
     assert detail["generation_duration_ms"] >= 0
 
+
+def test_article_import_uses_plain_text_generation_for_non_json_steps(monkeypatch):
+    """タイトル/翻訳/解説は JSON mode ではなくプレーン生成を使う。"""
+
+    backend_main = _reload_backend_app(monkeypatch, strict=False)
+    from fastapi.testclient import TestClient
+    import backend.providers as providers_mod
+    from backend.flows.article_import import ArticleImportFlow
+
+    monkeypatch.setattr(ArticleImportFlow, "_post_filter_lemmas", lambda self, raw: ["resilience"])
+
+    class _StubLLM:
+        def __init__(self) -> None:
+            self.plain_prompts: list[str] = []
+            self.json_prompts: list[str] = []
+
+        def complete_text(self, prompt: str) -> str:
+            text = str(prompt or "")
+            self.plain_prompts.append(text)
+            if "日本語へ忠実に翻訳" in text:
+                return "これはレジリエンスに関する日本語訳です。"
+            if "詳細な解説" in text:
+                return "レジリエンスは障害からの回復能力を指します。"
+            return "Operational resilience"
+
+        def complete(self, prompt: str) -> str:
+            text = str(prompt or "")
+            self.json_prompts.append(text)
+            return '{"lemmas": ["resilience"]}'
+
+    stub = _StubLLM()
+    providers_mod._LLM_INSTANCE = stub
+    client = TestClient(backend_main.app, raise_server_exceptions=False)
+
+    response = client.post(
+        "/api/article/import",
+        json={"text": "Resilience keeps systems available."},
+    )
+
+    assert response.status_code == 200
+    assert len(stub.plain_prompts) == 3
+    assert any("タイトル" in prompt for prompt in stub.plain_prompts)
+    assert any("日本語へ忠実に翻訳" in prompt for prompt in stub.plain_prompts)
+    assert any("詳細な解説" in prompt for prompt in stub.plain_prompts)
+    assert len(stub.json_prompts) == 1
+    assert "JSON 配列" in stub.json_prompts[0]
+
+
 def test_article_import_category_and_zero_duration(monkeypatch):
     """インポート時に generation_category を指定した場合に保存/再読込で保持され、
     時刻が同一なら duration=0 になることを検証。

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -355,3 +355,115 @@ def test_openai_request_retries_without_json_format_when_needed(monkeypatch):
     assert "text" not in calls[2]
     assert "reasoning" not in calls[2]
     assert all("response_format" not in call for call in calls)
+
+
+def test_openai_plain_text_request_does_not_force_json_format(monkeypatch):
+    """プレーンテキスト生成では text.format=json_object を送らない。"""
+    monkeypatch.setenv("STRICT_MODE", "false")
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "gpt-5.4-mini")
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy-realistic-key")
+
+    from importlib import reload
+    import backend.config
+    import backend.providers
+    reload(backend.config)
+    reload(backend.providers)
+
+    calls: list[dict] = []
+
+    class _DummyMessage:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+    class _DummyChoice:
+        def __init__(self, content: str) -> None:
+            self.message = _DummyMessage(content)
+
+    class _DummyResp:
+        def __init__(self, content: str) -> None:
+            self.choices = [_DummyChoice(content)]
+
+    class _DummyResponses:
+        def create(self, **kwargs):  # type: ignore[no-untyped-def]
+            calls.append(kwargs)
+            return _DummyResp("Concise title")
+
+    class DummyOpenAI:
+        def __init__(self, api_key: str) -> None:  # type: ignore[no-untyped-def]
+            self.responses = _DummyResponses()
+
+    backend.providers.llm.OpenAI = DummyOpenAI  # type: ignore[attr-defined, assignment]
+
+    from backend.providers import get_llm_provider
+    llm = get_llm_provider(
+        reasoning_override={"effort": "minimal"},
+        text_override={"verbosity": "medium"},
+    )
+
+    out = llm.complete_text("入力テキストの内容を忠実に反映した短い英語タイトル")
+
+    assert out == "Concise title"
+    assert len(calls) == 1
+    assert calls[0]["reasoning"] == {"effort": "minimal"}
+    assert calls[0]["text"] == {"verbosity": "medium"}
+    assert "format" not in calls[0]["text"]
+    assert "response_format" not in calls[0]
+
+
+def test_openai_plain_text_request_retries_without_optional_controls(monkeypatch):
+    """プレーン生成でも任意の reasoning/text 指定が拒否されたら外して再試行する。"""
+    monkeypatch.setenv("STRICT_MODE", "false")
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("LLM_MODEL", "gpt-5.4-mini")
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy-realistic-key")
+
+    from importlib import reload
+    import backend.config
+    import backend.providers
+    reload(backend.config)
+    reload(backend.providers)
+
+    calls: list[dict] = []
+
+    class _DummyMessage:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+    class _DummyChoice:
+        def __init__(self, content: str) -> None:
+            self.message = _DummyMessage(content)
+
+    class _DummyResp:
+        def __init__(self, content: str) -> None:
+            self.choices = [_DummyChoice(content)]
+
+    class _DummyResponses:
+        def create(self, **kwargs):  # type: ignore[no-untyped-def]
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise RuntimeError(
+                    "Unsupported parameter: 'text.verbosity' is not supported by this model"
+                )
+            return _DummyResp("Plain retry result")
+
+    class DummyOpenAI:
+        def __init__(self, api_key: str) -> None:  # type: ignore[no-untyped-def]
+            self.responses = _DummyResponses()
+
+    backend.providers.llm.OpenAI = DummyOpenAI  # type: ignore[attr-defined, assignment]
+
+    from backend.providers import get_llm_provider
+    llm = get_llm_provider(
+        reasoning_override={"effort": "minimal"},
+        text_override={"verbosity": "high"},
+    )
+
+    out = llm.complete_text("短い英語タイトルを作成する")
+
+    assert out == "Plain retry result"
+    assert len(calls) == 2
+    assert calls[0]["text"] == {"verbosity": "high"}
+    assert "format" not in calls[0]["text"]
+    assert "text" not in calls[1]
+    assert "reasoning" not in calls[1]


### PR DESCRIPTION
## 変更内容
- OpenAI LLM provider にプレーンテキスト生成用の `complete_text()` を追加しました。
- 既存の `complete()` は JSON を期待する呼び出し向けに維持し、プレーン生成では `text.format={"type":"json_object"}` を送らないようにしました。
- 文章インポートのタイトル・翻訳・解説は `complete_text()`、lemma 抽出は従来どおり JSON 用の `complete()` を使うように分離しました。
- OpenAI request パラメータと文章インポート flow の呼び分けを回帰テストで固定しました。

## 原因
Cloud Run ログでは `/api/article/import` のタイトル生成で OpenAI Responses API が `Response input messages must contain the word json in some form to use text.format of type json_object` を返していました。タイトル・翻訳・解説のようなプレーンテキスト生成にも JSON mode を付けていたため、プロンプト内に `json` を含まないステップが拒否されて 500 になっていました。

## 保持した既存挙動
- WordPack 生成や lemma 抽出など JSON を期待する呼び出しは引き続き `complete()` で JSON mode を使います。
- reasoning / text.verbosity が拒否された場合の任意パラメータ除外リトライは、JSON 生成とプレーン生成の両方で維持します。
- 既存テスト用スタブとの互換のため、`complete_text()` がない LLM では従来の `complete()` にフォールバックします。

## 検証
- `PYTHONPATH=apps/backend python3.13 -m pytest -q --no-cov tests/test_providers.py`
- `PYTHONPATH=apps/backend python3.13 -m pytest -q --no-cov tests/test_api.py::test_article_import_uses_plain_text_generation_for_non_json_steps tests/test_api.py::test_article_import_includes_llm_metadata`
- `FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 FIRESTORE_PROJECT_ID=wordpack-local GCP_PROJECT_ID=wordpack-local PYTHONPATH=apps/backend python3.13 -m pytest -q --no-cov tests/test_providers.py tests/test_api.py::test_article_import_uses_plain_text_generation_for_non_json_steps tests/test_api.py::test_article_import_includes_llm_metadata tests/backend/test_article_import_filters.py tests/backend/test_article_import_wordpack_fallback.py tests/backend/test_article_import_limits.py`
- `OPENAI_API_KEY= FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 FIRESTORE_PROJECT_ID=wordpack-local GCP_PROJECT_ID=wordpack-local PYTHONPATH=apps/backend python3.13 -m pytest`
- `git diff --check`

## 未実行項目
- Frontend typecheck/tests: バックエンド provider と文章インポート flow のみの変更のため未実行。
- Playwright smoke: UI 操作・表示変更なしのため未実行。

## 残るリスク
- 本番 Cloud Run での再現確認は未実施です。CI 通過後にデプロイされれば、同じ `/api/article/import` 経路で確認できます。
- ログ調査中に Cloud Run 環境変数へ秘密情報が平文設定されていることを確認しました。この PR の範囲外ですが、Secret Manager 化とキーのローテーションが必要です。