### PR TITLE
ExploreのCI不安定テストを安定化

### DIFF
--- a/apps/frontend/src/pages/ExplorePage/ExplorePage.test.tsx
+++ b/apps/frontend/src/pages/ExplorePage/ExplorePage.test.tsx
@@ -201,8 +201,10 @@ describe('ExplorePage', () => {
     expect(await screen.findByRole('button', { name: 'robust を接続元に選ぶ' })).toBeInTheDocument();
     const user = userEvent.setup();
 
+    const createAction = await screen.findByRole('button', { name: '「resilient」のWordPackを作成' });
+
     await act(async () => {
-      await user.click(screen.getAllByRole('button', { name: /WordPackを作成/ })[0]);
+      await user.click(createAction);
     });
 
     expect(await screen.findByText(/空WordPackを作成しました/)).toBeInTheDocument();
@@ -244,8 +246,8 @@ describe('ExplorePage', () => {
     render(<ExplorePage />);
 
     expect(await screen.findByRole('button', { name: 'robust を接続元に選ぶ' })).toBeInTheDocument();
-    const guestCreateAction = screen.getByRole('button', {
-      name: /resilient.*ログインするとWordPackを作成できます/,
+    const guestCreateAction = await screen.findByRole('button', {
+      name: '「resilient」はログインするとWordPackを作成できます',
     });
 
     expect(guestCreateAction).toBeDisabled();


### PR DESCRIPTION
## 変更内容
- ExplorePage の未登録語作成テストで、接続カードのアクションが描画されるまで待つようにしました。
- ゲスト時の作成ロック確認も、実際の accessible name を待ってから検証するようにしました。

## 保持した既存挙動
- UI 実装、表示文言、API 呼び出し仕様は変更していません。
- 作成成功時に空 WordPack を作成してプレビューを開く挙動は維持しています。
- ゲスト時に書き込みリクエストを送らない挙動は維持しています。

## 検証結果
- `cd apps/frontend && npx tsc -p tsconfig.json`
- `cd apps/frontend && npm test -- --run src/pages/ExplorePage/ExplorePage.test.tsx --silent`
- `cd apps/frontend && npm test -- --coverage --silent`
- `git diff --check`

## 未実行項目
- Backend pytest: frontend テストのみの変更のため未実行。
- Security headers tests: security header に影響しないため未実行。
- Playwright smoke: UI 実装やユーザーフローを変更していないため未実行。

## 残るリスク
- CI の失敗は負荷差で顕在化した非同期待機不足だったため、ローカルでは再現しない環境差があります。CI head で再確認します。