### PR TITLE
Playwright nightlyの定期実行を停止する

### DIFF
--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -1,9 +1,6 @@
 name: Playwright nightly regression
 
 on:
-  schedule:
-    # 毎日 02:00 UTC に Chromium で全シナリオを回す。
-    - cron: '0 2 * * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## 変更内容
- `Playwright nightly regression` workflow から `schedule` トリガーを削除しました。
- 必要なときに手動実行できるよう `workflow_dispatch` は維持しています。

## 保持した既存挙動
- workflow 本体のジョブ、Playwright 実行内容、artifact upload、concurrency 設定は変更していません。
- PR / push 用の通常 CI には触れていません。

## 検証結果
- Local: `git diff --check`
- Local: 差分目視（`.github/workflows/playwright-nightly.yml` の cron 削除のみ）
- CI: Backend tests (pytest) (3.13) / Frontend tests (vitest) / Security headers tests (pytest) / Cloud Run config guard / Playwright smoke (PR critical flows) が成功
- Review: PR comments / reviews / reviewThreads は 0 件

## 未実行項目
- ローカルで E2E / frontend / backend test は未実行です。workflow トリガー設定のみの変更でアプリ実装に影響しないためです。

## 残るリスク
- 夜間の Chromium 全シナリオ回帰は自動では走らなくなります。必要時は Actions から手動実行します。