### PR TITLE
READMEのブランチ運用説明をmain基準に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ npm install -g firebase-tools
 
 ## ブランチ運用（開発/本番）
 
-- **デフォルトブランチ**: `develop`（ローカル開発・日常的な変更はここへ集約）
-- **本番デプロイ用ブランチ**: `main`（GCP/Cloud Run へのリリースは `main` のみ）
+- **デフォルトブランチ**: `main`（日常的な変更の取り込み先。GCP/Cloud Run への本番リリースも `main` への反映を起点にします）
+- **開発用ブランチ**: 必要に応じて `feature/**` などの作業ブランチを作成し、Pull Request で `main` へ集約します
 
 GitHub Actions の挙動は次の方針に合わせています。
 
-- **CI**: `develop`（および `main`）への push、`develop`/`main` 向け pull_request で実行します。
-- **GCP を触り得る dry-run（Cloud Run リリース検証）**: `main` 向け pull_request と `main` への push のみで実行します（`develop` では実行しません）。
+- **CI**: `main` / `develop` / `feature/**` への push、`main` / `develop` 向け pull_request で実行します。
+- **GCP を触り得る dry-run（Cloud Run リリース検証）**: `main` 向け pull_request と `main` への push のみで実行します。
 
 ### Google OAuth クライアントの準備
 1. [Google Cloud Console](https://console.cloud.google.com/) にアクセスし、対象プロジェクトを作成または選択します。


### PR DESCRIPTION
## 変更内容
- README のブランチ運用説明を、現在の default branch である `main` 基準に更新しました。
- 本番リリースも `main` への反映を起点にする説明へ整理しました。
- GitHub Actions の CI 対象ブランチ説明を、現行の `main` / `develop` / `feature/**` push と `main` / `develop` 向け PR に合わせました。

## 保持した既存挙動
- Cloud Run リリース検証の dry-run が `main` 向け PR と `main` push で実行される、という説明は維持しています。
- コードや CI workflow の挙動は変更していません。

## 検証結果
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- `nl -ba README.md` による該当行の目視確認

## 未実行項目
- Backend / frontend / E2E テストは未実行です。README の文書のみ変更であり、実行時挙動に影響しないためです。

## 残るリスク
- GitHub 上の branch protection や workflow 設定そのものは変更していません。README と現行設定の整合化に限定しています。