### PR TITLE
ローカル環境セットアップで Python 3.13+ の venv を使う

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -1,0 +1,62 @@
+version = 1
+name = "wordpack-for-english"
+
+[setup]
+script = '''
+set -e
+WORKTREE_PATH="${CODEX_WORKTREE_PATH:-$PWD}"
+cd "$WORKTREE_PATH"
+export PIP_CACHE_DIR="$WORKTREE_PATH/.cache/pip"
+export PLAYWRIGHT_BROWSERS_PATH="$WORKTREE_PATH/.cache/ms-playwright"
+python3 - <<'PY'
+import sys
+
+if sys.version_info < (3, 13):
+    raise SystemExit(
+        f"Python 3.13+ is required, but python3 at {sys.executable} "
+        f"is {sys.version.split()[0]}"
+    )
+PY
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install -r requirements.txt
+npm ci --no-audit
+cd apps/frontend
+npm ci --no-audit
+cd "$WORKTREE_PATH"
+npm run prepare:frontend-env
+npx playwright install --with-deps
+'''
+
+[setup.darwin]
+script = '''
+set -e
+WORKTREE_PATH="${CODEX_WORKTREE_PATH:-$PWD}"
+cd "$WORKTREE_PATH"
+export PIP_CACHE_DIR="$WORKTREE_PATH/.cache/pip"
+export PLAYWRIGHT_BROWSERS_PATH="$WORKTREE_PATH/.cache/ms-playwright"
+python3 - <<'PY'
+import sys
+
+if sys.version_info < (3, 13):
+    raise SystemExit(
+        f"Python 3.13+ is required, but python3 at {sys.executable} "
+        f"is {sys.version.split()[0]}"
+    )
+PY
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install -r requirements.txt
+npm ci --no-audit
+cd apps/frontend
+npm ci --no-audit
+cd "$WORKTREE_PATH"
+npm run prepare:frontend-env
+npx playwright install --with-deps
+'''
+
+[cleanup]
+script = ""
+
+[cleanup.darwin]
+script = "docker compose down --remove-orphans"

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -8,16 +8,48 @@ WORKTREE_PATH="${CODEX_WORKTREE_PATH:-$PWD}"
 cd "$WORKTREE_PATH"
 export PIP_CACHE_DIR="$WORKTREE_PATH/.cache/pip"
 export PLAYWRIGHT_BROWSERS_PATH="$WORKTREE_PATH/.cache/ms-playwright"
-python3 - <<'PY'
+select_python() {
+    for candidate in "${PYTHON:-}" python3.14 python3.13 python3; do
+        [ -n "$candidate" ] || continue
+        if command -v "$candidate" >/dev/null 2>&1 && "$candidate" - <<'PY' >/dev/null 2>&1; then
 import sys
 
-if sys.version_info < (3, 13):
-    raise SystemExit(
-        f"Python 3.13+ is required, but python3 at {sys.executable} "
-        f"is {sys.version.split()[0]}"
-    )
+raise SystemExit(0 if sys.version_info >= (3, 13) else 1)
 PY
-python3 -m venv .venv
+            command -v "$candidate"
+            return 0
+        fi
+    done
+
+    if command -v pyenv >/dev/null 2>&1; then
+        while IFS= read -r version; do
+            [ -n "$version" ] || continue
+            prefix="$(pyenv prefix "$version" 2>/dev/null)" || continue
+            candidate="$prefix/bin/python"
+            [ -x "$candidate" ] || continue
+            if "$candidate" - <<'PY' >/dev/null 2>&1; then
+import sys
+
+raise SystemExit(0 if sys.version_info >= (3, 13) else 1)
+PY
+                printf '%s\n' "$candidate"
+                return 0
+            fi
+        done <<EOF
+$(pyenv versions --bare 2>/dev/null)
+EOF
+    fi
+
+    echo "Python 3.13+ is required, but no usable interpreter was found." >&2
+    return 1
+}
+PYTHON_BIN="$(select_python)"
+"$PYTHON_BIN" - <<'PY'
+import sys
+
+print(f"Using Python {sys.version.split()[0]} at {sys.executable}")
+PY
+"$PYTHON_BIN" -m venv .venv
 . .venv/bin/activate
 python -m pip install -r requirements.txt
 npm ci --no-audit
@@ -35,16 +67,48 @@ WORKTREE_PATH="${CODEX_WORKTREE_PATH:-$PWD}"
 cd "$WORKTREE_PATH"
 export PIP_CACHE_DIR="$WORKTREE_PATH/.cache/pip"
 export PLAYWRIGHT_BROWSERS_PATH="$WORKTREE_PATH/.cache/ms-playwright"
-python3 - <<'PY'
+select_python() {
+    for candidate in "${PYTHON:-}" python3.14 python3.13 python3; do
+        [ -n "$candidate" ] || continue
+        if command -v "$candidate" >/dev/null 2>&1 && "$candidate" - <<'PY' >/dev/null 2>&1; then
 import sys
 
-if sys.version_info < (3, 13):
-    raise SystemExit(
-        f"Python 3.13+ is required, but python3 at {sys.executable} "
-        f"is {sys.version.split()[0]}"
-    )
+raise SystemExit(0 if sys.version_info >= (3, 13) else 1)
 PY
-python3 -m venv .venv
+            command -v "$candidate"
+            return 0
+        fi
+    done
+
+    if command -v pyenv >/dev/null 2>&1; then
+        while IFS= read -r version; do
+            [ -n "$version" ] || continue
+            prefix="$(pyenv prefix "$version" 2>/dev/null)" || continue
+            candidate="$prefix/bin/python"
+            [ -x "$candidate" ] || continue
+            if "$candidate" - <<'PY' >/dev/null 2>&1; then
+import sys
+
+raise SystemExit(0 if sys.version_info >= (3, 13) else 1)
+PY
+                printf '%s\n' "$candidate"
+                return 0
+            fi
+        done <<EOF
+$(pyenv versions --bare 2>/dev/null)
+EOF
+    fi
+
+    echo "Python 3.13+ is required, but no usable interpreter was found." >&2
+    return 1
+}
+PYTHON_BIN="$(select_python)"
+"$PYTHON_BIN" - <<'PY'
+import sys
+
+print(f"Using Python {sys.version.split()[0]} at {sys.executable}")
+PY
+"$PYTHON_BIN" -m venv .venv
 . .venv/bin/activate
 python -m pip install -r requirements.txt
 npm ci --no-audit

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@
 ### セットアップ
 ```bash
 # Python（リポジトリルートで）
-python -m venv .venv
+python3 -m venv .venv
 # macOS / Linux
 source .venv/bin/activate
 # Windows PowerShell
@@ -78,7 +78,7 @@ source .venv/bin/activate
 # source .venv/Scripts/activate
 # WSL
 # source .venv/bin/activate
-pip install -r requirements.txt
+python -m pip install -r requirements.txt
 
 # Frontend
 cd apps/frontend

--- a/UserManual.md
+++ b/UserManual.md
@@ -207,13 +207,18 @@
 - ドキュメント作成: `docs-authoring.mdc`
 
 ### B-1. ローカル実行（開発用）
-- 必要環境: Python 3.11+（venv 推奨）, Node.js 20.19.0+
+- 必要環境: Python 3.13+（venv 推奨）, Node.js 20.19.0+
 - 依存インストール:
   ```bash
   # Python
-  python -m venv .venv
-  . .venv/Scripts/activate   # Windows PowerShell: .venv\Scripts\Activate.ps1
-  pip install -r requirements.txt
+  python3 -m venv .venv
+  # macOS / Linux
+  source .venv/bin/activate
+  # Windows PowerShell
+  # .venv\Scripts\Activate.ps1
+  # Windows (Git Bash)
+  # source .venv/Scripts/activate
+  python -m pip install -r requirements.txt
 
   # Frontend
   cd apps/frontend


### PR DESCRIPTION
## 変更内容
- `.codex/environments/environment.toml` を追加し、Codex セットアップで Python 3.13+ の実体を選んでから `.venv` を作成するようにしました。
- Python 選択は `PYTHON` / `python3.14` / `python3.13` / `python3` / `pyenv versions` の順に確認し、`python3` が古い環境でもインストール済みの 3.13+ を利用できるようにしました。
- venv 内で `python -m pip install -r requirements.txt` を実行し、裸の `pip` が Anaconda Python 3.7 などを拾う経路を避けました。
- Playwright browser の保存先をワークツリー内 `.cache/ms-playwright` に固定し、ユーザーキャッシュ権限への依存を減らしました。
- README / UserManual のローカルセットアップ手順を `python3` と venv 内 `python -m pip` に揃えました。

## 原因
元の環境設定は裸の `pip install -r requirements.txt` を実行しており、この端末では `pip` が Anaconda の Python 3.7 に紐づいていました。そのため `fastapi>=0.136` の Python 要件を満たせず、セットアップが依存解決で停止していました。

## 保持した既存挙動
- ルート npm 依存、frontend npm 依存、frontend `.env` 生成、Playwright install の順序は維持しています。
- cleanup の `docker compose down --remove-orphans` は維持しています。

## 検証
- `git diff --check`
- `python3 -c "import pathlib, tomllib; tomllib.loads(pathlib.Path('.codex/environments/environment.toml').read_text())"`
- `python3 -c "import pathlib, tomllib; print(tomllib.loads(pathlib.Path('.codex/environments/environment.toml').read_text())['setup']['script'])" | bash -n`
- 修復後 setup 相当のコマンド列をこのワークツリーで実行し、exit 0 を確認
- `PYTHON=/Users/Taishi/anaconda3/bin/python ...setup script... | bash` で古い Python 3.7 指定時も Python 3.14.5 へフォールバックして setup が完了することを確認
- `.venv/bin/python -c "import fastapi, uvicorn; print(fastapi.__version__)"` -> `0.136.3`
- `ENVIRONMENT=test FIRESTORE_EMULATOR_HOST=localhost:8080 FIRESTORE_PROJECT_ID=test-project GCP_PROJECT_ID=test-project ADMIN_EMAIL_ALLOWLIST=test@example.com SESSION_SECRET_KEY=testing-secret-key-with-32-characters PYTHONPATH=apps/backend .venv/bin/python -m pytest -q --no-cov tests/test_security_headers.py` -> `2 passed`
- GitHub Actions CI run `27486099838` -> success

## 未実行項目
- ローカルのフル `PYTHONPATH=apps/backend pytest` は、今回の修復対象がセットアップ経路であり、ローカルでは setup 再実行と security headers smoke に絞ったため未実行です。CI の `Backend tests (pytest) (3.13)` は成功済みです。

## 残るリスク
- セットアップの初回実行では PyPI / npm registry / Playwright CDN へのネットワーク到達が必要です。
- Python 3.13+ がどの候補にも存在しない環境では、意図的に早期エラーで停止します。