### PR TITLE
PRテンプレートのIssue欄とブランチ方針コメントを整合する

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,10 +5,12 @@
 大型Issueの一部: Part of #123 （自動クローズしない）
 関連のみ: Related to #123 （自動クローズしない）
 Issue省略: Issue: N/A — 省略理由
+default branch 以外を base にするPRでは closing keyword による自動クローズへ依存しない
 -->
 - Issue:
 - 対応範囲:
 - 対応していないこと:
+- 完了条件との差分:
 
 ## 変更内容
 -

--- a/tests/test_github_actions_branch_policy.py
+++ b/tests/test_github_actions_branch_policy.py
@@ -30,7 +30,7 @@ def _extract_on_block(yml: str) -> str:
 
 def test_ci_runs_on_develop_and_prs_to_develop() -> None:
     """
-    Contract: develop is the default branch for day-to-day development.
+    Contract: develop remains a day-to-day CI target even though main is the default branch.
     CI must run for pushes to develop and PRs targeting develop.
     """
     yml = _read_text(".github/workflows/ci.yml")
@@ -94,4 +94,3 @@ def test_deploy_production_workflow_runs_on_main_push_or_manual_only() -> None:
     _assert_contains_all(on_block, ["push:", "branches:", "main", "workflow_dispatch:"])
     _assert_contains_none(on_block, ["workflow_run:", "pull_request:"])
     _assert_contains_none(yml, ["github.event.workflow_run."])
-


### PR DESCRIPTION
## Issue
- Issue: Refs #453
- 対応範囲: PR本文テンプレートのIssue欄補足と、branch policy testの古いコメント表現の整合。
- 対応していないこと: `AGENTS.md` と4種類のIssue templateは既に要件を満たしていたため変更しない。GitHub Projects、milestones、priority label、Issue forms YAMLは初期必須化しない。
- 完了条件との差分: 既存Issue #453は既に完了済みのため、このPRでは残っていた小さな整合差分だけを `Refs` として扱う。

## 変更内容
- `.github/pull_request_template.md` のIssue欄コメントに、default branch以外をbaseにするPRではclosing keywordによる自動クローズへ依存しない注意を追加。
- `.github/pull_request_template.md` に `完了条件との差分` 欄を追加。
- `tests/test_github_actions_branch_policy.py` のdocstringを、`main` がdefault branchで `develop` はCI targetである実態に合わせて修正。

## 保持した既存挙動
- `AGENTS.md` のIssue-firstルール、完了報告ゲート、PR/CI/Codex review確認ルールは変更しない。
- feature / bug / investigation / operations のIssue template構成は変更しない。
- GitHub Actionsのtriggerやテストロジックは変更しない。

## 検証結果
- `git diff --check`: pass
- `bash scripts/verify-ai-governance.sh`: `AI governance verification: PASS`
- `PYTHONPATH=apps/backend pytest -q --no-cov tests/test_github_actions_branch_policy.py`: `4 passed`
- GitHub Actions latest head: Backend tests, Security headers tests, Frontend tests, Cloud Run config guard, Playwright smoke all passed.

## UI/UX 証跡
- N/A。GitHub運用ルールとPRテンプレート、テストコメントのみの変更で、アプリのユーザー画面・文言・状態・アクセシビリティ挙動を変更しないため。

## セキュリティ・運用確認
- `docs/security-publication-checklist.md` を確認済み。
- 差分にsecret、認証情報、個人情報、本番ログ原文、request/trace/job IDの実値、不要な本番リソース識別子は含めていない。

## Codex review / review thread
- Codex review: なし。
- 未解決 review thread: なし。
- 対応不要と判断した指摘: N/A。

## 未実行項目
- Backend full test: 文書・テンプレート・テストdocstringのみの変更でbackend実行時挙動を変更しないため未実行。
- Frontend typecheck / frontend tests: アプリUI実装とTypeScriptを変更しないため未実行。
- Playwright: UI操作フローを変更しないためローカルでは未実行。GitHub ActionsのPlaywright smokeは通過済み。
- 本番ログ確認: 本番障害調査ではなくGitHub運用ルールの文書整合のため未実行。

## 残るリスク
- PR本文テンプレートの注意は運用ルールであり、CI lintで強制していない。
- 既存Issue #453は完了済みのため、このPRは追加整合として `Refs` に留める。