### PR TITLE
ゲスト公開WordPack一覧のFirestoreインデックスを追加

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -12,6 +12,15 @@
       "collectionGroup": "word_packs",
       "queryScope": "COLLECTION",
       "fields": [
+        { "fieldPath": "metadata.guest_public", "order": "ASCENDING" },
+        { "fieldPath": "created_at", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "word_packs",
+      "queryScope": "COLLECTION",
+      "fields": [
         { "fieldPath": "lemma_label_lower", "order": "ASCENDING" },
         { "fieldPath": "updated_at", "order": "DESCENDING" },
         { "fieldPath": "__name__", "order": "DESCENDING" }

--- a/tests/config/test_firebase_config.py
+++ b/tests/config/test_firebase_config.py
@@ -64,3 +64,28 @@ def test_examples_cross_corpus_descending_sort_indexes_exist() -> None:
 
   missing = required - configured_fields
   assert not missing, f"examples cross-corpus sort indexes are missing: {sorted(missing)}"
+
+
+def test_guest_public_wordpack_list_index_exists() -> None:
+  firestore_indexes = json.loads(FIRESTORE_INDEXES_PATH.read_text(encoding="utf-8"))
+  indexes = firestore_indexes.get("indexes", [])
+
+  configured_fields = {
+    tuple(
+      (
+        field.get("fieldPath"),
+        field.get("order"),
+        field.get("arrayConfig"),
+      )
+      for field in index.get("fields", [])
+    )
+    for index in indexes
+    if index.get("collectionGroup") == "word_packs"
+  }
+  required = (
+    ("metadata.guest_public", "ASCENDING", None),
+    ("created_at", "DESCENDING", None),
+    ("__name__", "DESCENDING", None),
+  )
+
+  assert required in configured_fields, "guest public WordPack list index is missing"


### PR DESCRIPTION
## Issue
Closes #488

## 変更内容
- `word_packs` のゲスト公開一覧クエリに必要な Firestore composite index を追加。
- `firestore.indexes.json` から同 index の欠落を検出する設定テストを追加。

## Root Cause
本番では `metadata.guest_public=true` の WordPack が存在していたが、ゲスト一覧 API が `metadata.guest_public` で絞り込みつつ `created_at` 降順で並べる Firestore クエリを実行し、必要な composite index が未定義だったため `FailedPrecondition` で 500 になっていた。

## 保持した既存挙動
- ゲストに返す WordPack は引き続き `metadata.guest_public=true` のものだけ。
- API / UI のレスポンス形式や公開フラグ更新処理は変更なし。

## 検証結果
- `python -m json.tool firestore.indexes.json`
- `PYTHONPATH=apps/backend pytest -q --no-cov tests/config/test_firebase_config.py`
- `git diff --check`
- 本番 Firestore: `metadata.guest_public=true` の WordPack が存在することを確認。
- 本番 Cloud Run logs: ゲスト一覧の 500 が Firestore composite index 不足の `FailedPrecondition` であることを確認。
- 本番 Firestore: 追加 index を作成し、対象 index が `READY` になったことを確認。
- 本番 API: Cloud Run 直と Firebase Hosting 経由の両方で、ゲスト認証 200、WordPack 一覧 200、公開済み 1 件が返ることを確認。

## 未実行項目
- Frontend 全体テスト: UI 実装差分がないため未実行。
- Backend 全体テスト: Firestore index 設定のみの変更のため、対象設定テストに限定。

## 残るリスク
- 今回確認したのは WordPack のゲスト公開一覧。Quiz や記事一覧の公開制御は変更対象外。
- 公開安全性のため、本番 URL、project ID、revision、document id、ログ原文、trace/request id、Cookie 値は本文に記載していない。
