### PR TITLE
本番デプロイのFirebase CLI認証とfail-fastを修正

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -106,6 +106,19 @@ jobs:
         # firebase deploy --only firestore:indexes は GA であり、gcloud alpha より安定している。
         run: npm install -g firebase-tools@15.22.0
 
+      - name: Prepare Firebase CLI auth token
+        # Firebase CLI は GitHub Actions の ADC ファイルを読めない場合があるため、
+        # 認証済み gcloud から短命 access token を発行して Firebase CLI に渡す。
+        run: |
+          set -euo pipefail
+          token="$(gcloud auth print-access-token)"
+          if [ -z "${token}" ]; then
+            echo "::error::Failed to mint Firebase CLI access token from the authenticated service account." >&2
+            exit 1
+          fi
+          echo "::add-mask::${token}"
+          echo "FIREBASE_TOKEN=${token}" >> "${GITHUB_ENV}"
+
       - name: Install frontend dependencies
         # predeploy の tsc が @types などの devDependencies を必要とするため、事前に導入しておく。
         env:
@@ -144,7 +157,6 @@ jobs:
         # Cloud Run デプロイ後に Firebase Hosting を更新し、フロントエンドを同じリリースで揃える。
         env:
           FIREBASE_PROJECT_ID: ${{ env.FIREBASE_PROJECT_ID }}
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcp-auth.outputs.credentials_file_path }}
         run: |
           firebase deploy --only hosting \
             --project "${FIREBASE_PROJECT_ID}" \

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,6 @@ release-cloud-run: ENV_FILE ?= .env.deploy
 # `.env.deploy` などの env ファイル存在チェックと dry-run 成功を必須条件にしています。
 release-cloud-run:
 	@set -euo pipefail; \
-	# 一連のリリース処理で必須パラメータや前提ファイルの欠落を早期に検出する。
 	PROJECT_ID_VALUE="$(PROJECT_ID)"; \
 	REGION_VALUE="$(REGION)"; \
 	ENV_FILE_PATH="$(ENV_FILE)"; \

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -165,6 +165,8 @@ firebase deploy --only hosting --project <firebase-project-id>
 | `GCP_SA_KEY` | デプロイ用 service account JSON |
 | `CLOUD_RUN_ENV_FILE_BASE64` | `.env.deploy` を base64 化した値 |
 
+Firebase CLI は Firestore index 同期と Firebase Hosting 更新に使います。workflow 内では `GCP_SA_KEY` で Google Cloud に認証した後、`gcloud auth print-access-token` で短命 token を発行し、実行中の job にだけ `FIREBASE_TOKEN` として渡します。長期保存する `FIREBASE_TOKEN` secret は使いません。
+
 サービスアカウントに必要な代表ロール:
 
 - `roles/run.admin`

--- a/tests/test_deploy_script_env_guard.py
+++ b/tests/test_deploy_script_env_guard.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 
@@ -16,3 +17,33 @@ def test_deploy_script_requires_firestore_project_id_or_gcp_project_id() -> None
     assert "FIRESTORE_PROJECT_ID, GCP_PROJECT_ID, GOOGLE_CLOUD_PROJECT, or PROJECT_ID" in text
 
 
+def test_release_cloud_run_stops_when_index_sync_fails(tmp_path: Path) -> None:
+    fake_cloud_run = tmp_path / "fake_cloud_run.sh"
+    fake_cloud_run.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo CLOUD_RUN_SCRIPT_RAN\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_cloud_run.chmod(0o755)
+
+    proc = subprocess.run(
+        [
+            "make",
+            "-s",
+            "release-cloud-run",
+            "PROJECT_ID=demo-project",
+            "REGION=asia-northeast1",
+            "ENV_FILE=configs/cloud-run/ci.env",
+            "TOOL=invalid",
+            f"CLOUD_RUN_SCRIPT={fake_cloud_run}",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    combined_output = proc.stdout + proc.stderr
+
+    assert proc.returncode != 0
+    assert "--tool には gcloud または firebase を指定してください" in combined_output
+    assert "CLOUD_RUN_SCRIPT_RAN" not in combined_output

--- a/tests/test_github_actions_branch_policy.py
+++ b/tests/test_github_actions_branch_policy.py
@@ -94,3 +94,24 @@ def test_deploy_production_workflow_runs_on_main_push_or_manual_only() -> None:
     _assert_contains_all(on_block, ["push:", "branches:", "main", "workflow_dispatch:"])
     _assert_contains_none(on_block, ["workflow_run:", "pull_request:"])
     _assert_contains_none(yml, ["github.event.workflow_run."])
+
+
+def test_deploy_production_prepares_short_lived_firebase_cli_token() -> None:
+    """
+    Contract: Firebase CLI deploys must use a short-lived token minted from the
+    authenticated service account, not a long-lived repository secret.
+    """
+    yml = _read_text(".github/workflows/deploy-production.yml")
+
+    _assert_contains_all(
+        yml,
+        [
+            "Prepare Firebase CLI auth token",
+            "gcloud auth print-access-token",
+            "::add-mask::${token}",
+            'echo "FIREBASE_TOKEN=${token}" >> "${GITHUB_ENV}"',
+            "firebase deploy --only hosting",
+            "TOOL=firebase",
+        ],
+    )
+    _assert_contains_none(yml, ["secrets.FIREBASE_TOKEN"])


### PR DESCRIPTION
## Issue

Closes #492

## 変更内容

- `deploy-production.yml` で、認証済み service account から `gcloud auth print-access-token` により短命tokenを発行し、Firebase CLIへ job 内限定の `FIREBASE_TOKEN` として渡すようにしました。
- `Makefile` の `release-cloud-run` で `set -euo pipefail` がコメント行で途切れていた問題を直し、Firestore index 同期失敗時にCloud Run deployへ進まないようにしました。
- workflow/Makefile契約テストと `docs/deployment.md` を更新しました。

## 保持した既存挙動

- 本番デプロイは引き続き `main` push / `workflow_dispatch` のみで起動します。
- Firebase CLI のバージョン固定 `firebase-tools@15.22.0` は維持しました。
- 長期保存の `FIREBASE_TOKEN` secret は追加していません。

## 検証結果

- `python3.13 -m pytest -q --no-cov tests/config/test_firebase_config.py tests/test_deploy_script_env_guard.py tests/test_github_actions_branch_policy.py tests/test_public_docs_security.py`
- `git diff --check`
- `shellcheck scripts/deploy_cloud_run.sh`
- `python3.13` による `.github/workflows/deploy-production.yml` の YAML parse

## 未実行項目

- `./scripts/deploy_cloud_run.sh --dry-run --env-file configs/cloud-run/ci.env --project-id ci-placeholder-project --region asia-northeast1 --service wordpack-backend` はローカルの新しい Bash が x86_64 版で、Python 拡張依存が arm64 版のため `pydantic_core` の architecture mismatch で失敗しました。スクリプト変更はしていないため、代替として shellcheck と対象契約テストを実行しています。
- 本番deploy workflowの実行確認は、このPRのmerge後または手動workflow実行で確認します。

## 残るリスク

- Firebase CLI が短命 access token を受け付ける挙動は `firebase-tools@15.22.0` 前提です。将来CLIを大きく更新する場合は、workflow契約テストと実deployで再確認が必要です。
- service account 側に Firebase Hosting / Firestore index 適用に必要なIAMが不足している場合は、認証後に権限エラーとして別途失敗します。