### PR TITLE
Production deploy の Firebase CLI 認証をサービスアカウント経由に戻す

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -85,10 +85,13 @@ jobs:
 
       - name: Authenticate to Google Cloud with service account key
         # CI 成功後にのみ実行される本番デプロイなので、サービスアカウントキーで明示的に認証する。
+        # Firebase CLI は GOOGLE_APPLICATION_CREDENTIALS 経由でこの認証情報を使う。
         id: gcp-auth
         uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
+          create_credentials_file: true
+          export_environment_variables: true
 
       - name: Set up gcloud SDK
         # gcloud CLI をプロジェクト/リージョンに合わせて準備する。Cloud Run / Cloud Build は GA コマンドのみ使用。
@@ -105,19 +108,6 @@ jobs:
       - name: Install Firebase CLI
         # firebase deploy --only firestore:indexes は GA であり、gcloud alpha より安定している。
         run: npm install -g firebase-tools@15.22.0
-
-      - name: Prepare Firebase CLI auth token
-        # Firebase CLI は GitHub Actions の ADC ファイルを読めない場合があるため、
-        # 認証済み gcloud から短命 access token を発行して Firebase CLI に渡す。
-        run: |
-          set -euo pipefail
-          token="$(gcloud auth print-access-token)"
-          if [ -z "${token}" ]; then
-            echo "::error::Failed to mint Firebase CLI access token from the authenticated service account." >&2
-            exit 1
-          fi
-          echo "::add-mask::${token}"
-          echo "FIREBASE_TOKEN=${token}" >> "${GITHUB_ENV}"
 
       - name: Install frontend dependencies
         # predeploy の tsc が @types などの devDependencies を必要とするため、事前に導入しておく。

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -165,7 +165,7 @@ firebase deploy --only hosting --project <firebase-project-id>
 | `GCP_SA_KEY` | デプロイ用 service account JSON |
 | `CLOUD_RUN_ENV_FILE_BASE64` | `.env.deploy` を base64 化した値 |
 
-Firebase CLI は Firestore index 同期と Firebase Hosting 更新に使います。workflow 内では `GCP_SA_KEY` で Google Cloud に認証した後、`gcloud auth print-access-token` で短命 token を発行し、実行中の job にだけ `FIREBASE_TOKEN` として渡します。長期保存する `FIREBASE_TOKEN` secret は使いません。
+Firebase CLI は Firestore index 同期と Firebase Hosting 更新に使います。workflow 内では `GCP_SA_KEY` で Google Cloud に認証し、`google-github-actions/auth@v2` が export する `GOOGLE_APPLICATION_CREDENTIALS` の service account credentials file を Firebase CLI に使わせます。長期保存する `FIREBASE_TOKEN` secret や、`gcloud auth print-access-token` で発行した access token の `FIREBASE_TOKEN` 代入は使いません。
 
 サービスアカウントに必要な代表ロール:
 

--- a/tests/test_github_actions_branch_policy.py
+++ b/tests/test_github_actions_branch_policy.py
@@ -96,22 +96,29 @@ def test_deploy_production_workflow_runs_on_main_push_or_manual_only() -> None:
     _assert_contains_none(yml, ["github.event.workflow_run."])
 
 
-def test_deploy_production_prepares_short_lived_firebase_cli_token() -> None:
+def test_deploy_production_uses_service_account_adc_for_firebase_cli() -> None:
     """
-    Contract: Firebase CLI deploys must use a short-lived token minted from the
-    authenticated service account, not a long-lived repository secret.
+    Contract: Firebase CLI deploys must use the service account credentials file
+    exported by google-github-actions/auth, not FIREBASE_TOKEN.
     """
     yml = _read_text(".github/workflows/deploy-production.yml")
 
     _assert_contains_all(
         yml,
         [
-            "Prepare Firebase CLI auth token",
-            "gcloud auth print-access-token",
-            "::add-mask::${token}",
-            'echo "FIREBASE_TOKEN=${token}" >> "${GITHUB_ENV}"',
+            "google-github-actions/auth@v2",
+            "credentials_json: ${{ secrets.GCP_SA_KEY }}",
+            "create_credentials_file: true",
+            "export_environment_variables: true",
             "firebase deploy --only hosting",
             "TOOL=firebase",
         ],
     )
-    _assert_contains_none(yml, ["secrets.FIREBASE_TOKEN"])
+    _assert_contains_none(
+        yml,
+        [
+            "FIREBASE_TOKEN",
+            "gcloud auth print-access-token",
+            "Prepare Firebase CLI auth token",
+        ],
+    )


### PR DESCRIPTION
## Issue

Closes #497

## 変更内容

- Production deploy workflow から `FIREBASE_TOKEN` 用の短命 access token 発行 step を削除しました。
- `google-github-actions/auth@v2` が作る credentials file と環境変数 export を明示し、Firebase CLI が `GOOGLE_APPLICATION_CREDENTIALS` を使う構成に戻しました。
- workflow 契約テストと `docs/deployment.md` の認証説明を更新しました。

## 保持した既存挙動

- Firestore index 同期は引き続き Firebase CLI の GA deploy を使います。
- Cloud Run release 後に Firebase Hosting を同じ workflow で deploy する構成は維持します。
- 長期保存の `FIREBASE_TOKEN` secret は使いません。

## 検証結果

- `PYTHONPATH=apps/backend pytest -q --no-cov tests/test_github_actions_branch_policy.py tests/test_public_docs_security.py`
- `PYTHONPATH=apps/backend pytest -q --no-cov tests/test_deploy_script_env_guard.py`
- `python3 -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/deploy-production.yml').read_text())"`
- `shellcheck scripts/deploy_cloud_run.sh scripts/deploy_firestore_indexes.sh`
- `git diff --check`

## 未実行項目

- 本番 deploy workflow の実行は main merge 後の CD 対象のため、PR 上では実行していません。

## 残るリスク

- Firebase CLI が service account JSON / `GOOGLE_APPLICATION_CREDENTIALS` を受け付ける前提の修正です。`auth@v2` の action 定義では credentials file 作成と環境変数 export がサポートされていることを確認済みです。