### PR TITLE
Production deploy の Firestore index 同期を Admin API 経由にする

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -168,7 +168,7 @@ jobs:
 
       - name: Run production Cloud Run release
         # Firestore インデックス同期の有無は環境変数で制御し、Makefile 側で一元管理する。
-        # TOOL=gcloud で Firebase CLI 認証に依存せず Firestore index を同期する。
+        # TOOL=gcloud で gcloud 認証の Firestore Admin API を使い、Firebase CLI と gcloud alpha に依存しない。
         env:
           CLOUD_RUN_PROJECT_ID: ${{ env.CLOUD_RUN_PROJECT_ID }}
           CLOUD_RUN_REGION: ${{ env.CLOUD_RUN_REGION }}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,7 +6,7 @@
 
 - backend は `Dockerfile.backend` でビルドし、Cloud Run にデプロイします。
 - frontend は React + Vite の build artifact を Firebase Hosting に配置します。
-- Firestore の複合インデックスは `firestore.indexes.json` を Firebase CLI または gcloud 経由で同期します。
+- Firestore の複合インデックスと single-field override は `firestore.indexes.json` を同期します。既定の `gcloud` 経路は gcloud の認証情報で Firestore Admin API を直接呼び、Firebase CLI と `gcloud alpha` component には依存しません。
 - GitHub Actions の本番デプロイは `main` への push と `workflow_dispatch` をトリガーにします。
 - PR では本番デプロイ job を作らず、Cloud Run config guard の dry-run で設定ミスを検知します。
 
@@ -165,7 +165,7 @@ firebase deploy --only hosting --project <firebase-project-id>
 | `GCP_SA_KEY` | デプロイ用 service account JSON |
 | `CLOUD_RUN_ENV_FILE_BASE64` | `.env.deploy` を base64 化した値 |
 
-Firestore index 同期は `gcloud` 経由で行い、Firebase CLI 認証に依存させません。Firebase Hosting 更新では、workflow 内で `GCP_SA_KEY` から runner の一時 service account credentials file を作成し、`GOOGLE_APPLICATION_CREDENTIALS` として Firebase CLI に渡します。長期保存する `FIREBASE_TOKEN` secret や、`gcloud auth print-access-token` で発行した access token の `FIREBASE_TOKEN` 代入は使いません。
+Firestore index 同期は `gcloud` 認証の Firestore Admin API 経由で行い、Firebase CLI 認証や `gcloud alpha` component に依存させません。Firebase Hosting 更新では、workflow 内で `GCP_SA_KEY` から runner の一時 service account credentials file を作成し、`GOOGLE_APPLICATION_CREDENTIALS` として Firebase CLI に渡します。長期保存する `FIREBASE_TOKEN` secret や、`gcloud auth print-access-token` で発行した access token の `FIREBASE_TOKEN` 代入は使いません。
 
 サービスアカウントに必要な代表ロール:
 

--- a/docs/firestore.md
+++ b/docs/firestore.md
@@ -39,6 +39,8 @@ Cloud Firestore を使う場合は、プロジェクト ID と認証情報を明
 make deploy-firestore-indexes PROJECT_ID=<project-id>
 ```
 
+既定では `gcloud auth print-access-token` で取得した短命の認証情報を使い、Firestore Admin API に直接 `indexes` と `fieldOverrides` を同期します。この経路は Firebase CLI 認証や `gcloud alpha` component を必要としません。
+
 Firebase CLI を使う場合:
 
 ```bash

--- a/scripts/deploy_firestore_indexes.sh
+++ b/scripts/deploy_firestore_indexes.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Firestore の複合インデックスをファイルベースで同期させるためのラッパースクリプト。
-# gcloud / Firebase CLI のどちらでも `firestore.indexes.json` を適用できるように統一している。
+# Firestore のインデックスをファイルベースで同期させるためのラッパースクリプト。
+# 既定の gcloud 経路は gcloud の認証だけを使い、Firestore Admin API へ直接同期する。
 SCRIPT_NAME=$(basename "$0")
 INDEX_FILE=${INDEX_FILE:-firestore.indexes.json}
 PROJECT_ID=""
@@ -14,7 +14,7 @@ Usage: scripts/deploy_firestore_indexes.sh [--project <gcp-or-firebase-project>]
 
 Options:
   --project, -p     Firestore/Firebase プロジェクトID。未指定時は $GOOGLE_CLOUD_PROJECT, $GCLOUD_PROJECT, $FIREBASE_PROJECT の順で探索。
-  --tool, -t        利用するCLIを指定（既定: gcloud）。firebase を指定すると Firebase CLI でデプロイ。
+  --tool, -t        同期経路を指定（既定: gcloud）。gcloud は Firestore Admin API、firebase は Firebase CLI で同期。
   --index-file, -f  読み込むインデックス定義ファイル（既定: firestore.indexes.json）。
   --help, -h        このメッセージを表示。
 USAGE
@@ -66,15 +66,24 @@ case "$TOOL" in
       echo "[${SCRIPT_NAME}] --project か GOOGLE_CLOUD_PROJECT を指定してください" >&2
       exit 1
     fi
-    echo "[${SCRIPT_NAME}] gcloud で $INDEX_FILE の定義を $PROJECT_ID に同期します"
+    if ! command -v python3 >/dev/null 2>&1; then
+      echo "[${SCRIPT_NAME}] python3 が見つかりません。Firestore Admin API 同期には python3 が必要です。" >&2
+      exit 1
+    fi
+    echo "[${SCRIPT_NAME}] gcloud 認証の Firestore Admin API で $INDEX_FILE の定義を $PROJECT_ID に同期します"
     python3 - "$PROJECT_ID" "$INDEX_FILE" <<'PY'
 import json
-import shlex
+import os
 import subprocess
 import sys
+import urllib.error
+import urllib.parse
+import urllib.request
 
 project_id = sys.argv[1]
 index_file = sys.argv[2]
+database_id = os.environ.get("FIRESTORE_DATABASE_ID", "(default)")
+api_base = os.environ.get("FIRESTORE_ADMIN_API_BASE_URL", "https://firestore.googleapis.com/v1").rstrip("/")
 
 try:
     with open(index_file, "r", encoding="utf-8") as fh:
@@ -92,116 +101,190 @@ if not indexes and not field_overrides:
     print("[deploy_firestore_indexes] indexes / fieldOverrides エントリが存在しません。スキップします。")
     sys.exit(0)
 
-def normalize_enum(value: str) -> str:
+def normalize_enum(value, default=None):
+    if value is None:
+        return default
     if not isinstance(value, str):
-        return value
-    lowered = value.lower()
-    # gcloud のオプションはすべて小文字想定なので揃える
-    return lowered
+        raise ValueError(f"enum value must be a string: {value!r}")
+    return value.upper()
 
-def build_field_config(field: dict) -> str:
-    parts = []
-    array_config = field.get("arrayConfig")
-    if array_config:
-        parts.append(f"array-config={normalize_enum(array_config)}")
+def quote_path(value):
+    return urllib.parse.quote(value, safe="")
+
+def collection_group_path(collection_group):
+    return (
+        f"projects/{quote_path(project_id)}"
+        f"/databases/{quote_path(database_id)}"
+        f"/collectionGroups/{quote_path(collection_group)}"
+    )
+
+def field_resource_name(collection_group, field_path):
+    return (
+        f"projects/{project_id}"
+        f"/databases/{database_id}"
+        f"/collectionGroups/{collection_group}"
+        f"/fields/{field_path}"
+    )
+
+def api_url(path, params=None):
+    url = f"{api_base}/{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    return url
+
+def print_and_exit(message, status=1):
+    sys.stderr.write(message.rstrip() + "\n")
+    sys.exit(status)
+
+def get_access_token():
+    proc = subprocess.run(
+        ["gcloud", "auth", "print-access-token", "--quiet"],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "CLOUDSDK_CORE_DISABLE_PROMPTS": "1"},
+    )
+    if proc.returncode != 0:
+        print_and_exit(proc.stderr or proc.stdout or "gcloud auth print-access-token failed", proc.returncode)
+    token = proc.stdout.strip()
+    if not token:
+        print_and_exit("gcloud auth print-access-token did not return an access token")
+    return token
+
+access_token = get_access_token()
+
+def request_json(method, url, body):
+    data = json.dumps(body, separators=(",", ":")).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json; charset=utf-8",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as response:
+            return response.status, response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8", errors="replace")
+    except urllib.error.URLError as exc:
+        print_and_exit(f"Firestore Admin API request failed: {exc}")
+
+def error_message(response_text):
+    try:
+        parsed = json.loads(response_text or "{}")
+    except json.JSONDecodeError:
+        return response_text
+    error = parsed.get("error")
+    if isinstance(error, dict):
+        status = error.get("status")
+        message = error.get("message")
+        if status and message:
+            return f"{status}: {message}"
+        return message or status or response_text
+    return response_text
+
+def already_exists(status, response_text):
+    if status == 409:
+        return True
+    text = response_text.lower()
+    return "already_exists" in text or "already exists" in text
+
+def build_index_field(field):
     field_path = field.get("fieldPath")
     if not field_path:
         raise ValueError("fieldPath is required for each field definition")
-    parts.append(f"field-path={field_path}")
+    result = {"fieldPath": field_path}
     order = field.get("order")
-    if order:
-        parts.append(f"order={normalize_enum(order)}")
+    array_config = field.get("arrayConfig")
     vector_config = field.get("vectorConfig")
-    if vector_config:
-        inner = ",".join(f"{k}={v}" for k, v in vector_config.items())
-        parts.append(f"vector-config={{{inner}}}")
-    return "--field-config=" + ",".join(parts)
-
-def build_single_field_index_config(index: dict) -> str:
-    query_scope = normalize_enum(index.get("queryScope", "collection"))
-    if query_scope != "collection":
-        raise ValueError("gcloud field override sync only supports queryScope=COLLECTION")
-
-    order = index.get("order")
-    array_config = index.get("arrayConfig")
-    if order and array_config:
-        raise ValueError("single-field indexes must not define both order and arrayConfig")
+    modes = [bool(order), bool(array_config), bool(vector_config)]
+    if sum(modes) != 1:
+        raise ValueError(f"exactly one of order, arrayConfig, or vectorConfig is required for {field_path}")
     if order:
-        return "--index=order=" + normalize_enum(order)
+        result["order"] = normalize_enum(order)
     if array_config:
-        return "--index=array-config=" + normalize_enum(array_config)
-    raise ValueError("single-field indexes must define order or arrayConfig")
+        result["arrayConfig"] = normalize_enum(array_config)
+    if vector_config:
+        result["vectorConfig"] = vector_config
+    return result
 
-for index in indexes:
+def build_composite_index_body(index):
     collection_group = index.get("collectionGroup")
     if not collection_group:
-        raise SystemExit("collectionGroup is required for every index definition")
-    query_scope = normalize_enum(index.get("queryScope", "collection"))
-    cmd = [
-        "gcloud",
-        "alpha",
-        "firestore",
-        "indexes",
-        "composite",
-        "create",
-        "--quiet",  # 非インタラクティブ環境（CI/CD）でプロンプトを抑止
-        f"--project={project_id}",
-        f"--collection-group={collection_group}",
-        f"--query-scope={query_scope}",
-    ]
-    for field in index.get("fields", []):
-        cmd.append(build_field_config(field))
+        raise ValueError("collectionGroup is required for every index definition")
+    body = {
+        "queryScope": normalize_enum(index.get("queryScope"), "COLLECTION"),
+        "fields": [build_index_field(field) for field in index.get("fields", [])],
+    }
+    api_scope = index.get("apiScope")
+    if api_scope:
+        body["apiScope"] = normalize_enum(api_scope)
+    return collection_group, body
 
+def build_single_field_index(index, field_path):
+    order = index.get("order")
+    array_config = index.get("arrayConfig")
+    vector_config = index.get("vectorConfig")
+    if order and array_config:
+        raise ValueError("single-field indexes must not define both order and arrayConfig")
+    if (order or array_config) and vector_config:
+        raise ValueError("single-field indexes must not combine vectorConfig with order or arrayConfig")
+    field = {"fieldPath": field_path}
+    if order:
+        field["order"] = normalize_enum(order)
+    if array_config:
+        field["arrayConfig"] = normalize_enum(array_config)
+    if vector_config:
+        field["vectorConfig"] = vector_config
+    if not order and not array_config and not vector_config:
+        raise ValueError("single-field indexes must define order, arrayConfig, or vectorConfig")
+    body = {
+        "queryScope": normalize_enum(index.get("queryScope"), "COLLECTION"),
+        "fields": [field],
+    }
+    api_scope = index.get("apiScope")
+    if api_scope:
+        body["apiScope"] = normalize_enum(api_scope)
+    return body
+
+for index in indexes:
+    collection_group, body = build_composite_index_body(index)
+    path = collection_group_path(collection_group) + "/indexes"
     index_label = f"{collection_group} ({', '.join(f.get('fieldPath', '?') for f in index.get('fields', []))})"
-    print(f"[deploy_firestore_indexes] gcloud 実行: {shlex.join(cmd)}")
-    proc = subprocess.run(cmd, capture_output=True, text=True)
-    if proc.returncode == 0:
-        print(f"[deploy_firestore_indexes] ✅ 作成/更新済み: {index_label}")
+    print(f"[deploy_firestore_indexes] Firestore Admin API 実行: POST collectionGroups/{collection_group}/indexes")
+    status, response_text = request_json("POST", api_url(path), body)
+    if 200 <= status < 300:
+        print(f"[deploy_firestore_indexes] ✅ 作成リクエスト送信済み: {index_label}")
         continue
-
-    stderr = proc.stderr or ""
-    stdout = proc.stdout or ""
-    already_exists = "ALREADY_EXISTS" in stderr or "already exists" in stderr.lower()
-    if already_exists:
+    if already_exists(status, response_text):
         print(f"[deploy_firestore_indexes] 既存のためスキップ: {index_label}")
         continue
-
-    sys.stderr.write(stderr or stdout)
-    sys.exit(proc.returncode)
+    print_and_exit(f"Firestore Admin API composite index sync failed for {index_label}: {error_message(response_text)}")
 
 for override in field_overrides:
     collection_group = override.get("collectionGroup")
     field_path = override.get("fieldPath")
     if not collection_group or not field_path:
         raise SystemExit("collectionGroup and fieldPath are required for every fieldOverrides entry")
-
-    cmd = [
-        "gcloud",
-        "firestore",
-        "indexes",
-        "fields",
-        "update",
-        field_path,
-        "--quiet",
-        f"--project={project_id}",
-        f"--collection-group={collection_group}",
+    single_field_indexes = [
+        build_single_field_index(single_index, field_path)
+        for single_index in override.get("indexes", [])
     ]
-    single_field_indexes = override.get("indexes", [])
-    if single_field_indexes:
-        for single_index in single_field_indexes:
-            cmd.append(build_single_field_index_config(single_index))
-    else:
-        cmd.append("--disable-indexes")
-
+    field_path_url = collection_group_path(collection_group) + f"/fields/{quote_path(field_path)}"
+    body = {
+        "name": field_resource_name(collection_group, field_path),
+        "indexConfig": {"indexes": single_field_indexes},
+    }
     index_label = f"{collection_group}.{field_path}"
-    print(f"[deploy_firestore_indexes] gcloud 実行: {shlex.join(cmd)}")
-    proc = subprocess.run(cmd, capture_output=True, text=True)
-    if proc.returncode == 0:
+    print(f"[deploy_firestore_indexes] Firestore Admin API 実行: PATCH collectionGroups/{collection_group}/fields/{field_path}")
+    status, response_text = request_json("PATCH", api_url(field_path_url, {"updateMask": "indexConfig"}), body)
+    if 200 <= status < 300:
         print(f"[deploy_firestore_indexes] ✅ fieldOverride 同期済み: {index_label}")
         continue
-
-    sys.stderr.write(proc.stderr or proc.stdout)
-    sys.exit(proc.returncode)
+    print_and_exit(f"Firestore Admin API fieldOverride sync failed for {index_label}: {error_message(response_text)}")
 PY
     ;;
   firebase)

--- a/tests/test_deploy_script_env_guard.py
+++ b/tests/test_deploy_script_env_guard.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import json
 import os
 import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 
@@ -50,7 +53,46 @@ def test_release_cloud_run_stops_when_index_sync_fails(tmp_path: Path) -> None:
     assert "CLOUD_RUN_SCRIPT_RAN" not in combined_output
 
 
-def test_gcloud_index_sync_applies_field_overrides(tmp_path: Path) -> None:
+class _FirestoreAdminApiHandler(BaseHTTPRequestHandler):
+    requests: list[dict[str, object]] = []
+
+    def _record(self, status: int, payload: dict[str, object]) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length).decode("utf-8") if length else ""
+        self.requests.append(
+            {
+                "method": self.command,
+                "path": self.path,
+                "authorization": self.headers.get("Authorization"),
+                "body": json.loads(body) if body else {},
+            }
+        )
+        encoded = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def do_POST(self) -> None:
+        self._record(
+            409,
+            {"error": {"status": "ALREADY_EXISTS", "message": "index already exists"}},
+        )
+
+    def do_PATCH(self) -> None:
+        self._record(200, {"name": "operations/mock"})
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+def test_gcloud_index_sync_uses_firestore_admin_api_for_indexes_and_field_overrides(tmp_path: Path) -> None:
+    _FirestoreAdminApiHandler.requests = []
+    server = HTTPServer(("127.0.0.1", 0), _FirestoreAdminApiHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     gcloud_log = tmp_path / "gcloud.log"
@@ -58,7 +100,12 @@ def test_gcloud_index_sync_applies_field_overrides(tmp_path: Path) -> None:
     fake_gcloud.write_text(
         "#!/usr/bin/env bash\n"
         "printf '%s\\n' \"$*\" >> \"${GCLOUD_LOG}\"\n"
-        "exit 0\n",
+        "if [ \"$1\" = \"auth\" ] && [ \"$2\" = \"print-access-token\" ]; then\n"
+        "  printf 'fake-token\\n'\n"
+        "  exit 0\n"
+        "fi\n"
+        "printf 'unexpected gcloud command: %s\\n' \"$*\" >&2\n"
+        "exit 2\n",
         encoding="utf-8",
     )
     fake_gcloud.chmod(0o755)
@@ -90,34 +137,75 @@ def test_gcloud_index_sync_applies_field_overrides(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    proc = subprocess.run(
-        [
-            "scripts/deploy_firestore_indexes.sh",
-            "--project",
-            "demo-project",
-            "--tool",
-            "gcloud",
-            "--index-file",
-            str(index_file),
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
-        env={
-            **os.environ,
-            "PATH": f"{fake_bin}:{os.environ['PATH']}",
-            "GCLOUD_LOG": str(gcloud_log),
-        },
-    )
+    try:
+        proc = subprocess.run(
+            [
+                "scripts/deploy_firestore_indexes.sh",
+                "--project",
+                "demo-project",
+                "--tool",
+                "gcloud",
+                "--index-file",
+                str(index_file),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env={
+                **os.environ,
+                "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                "FIRESTORE_ADMIN_API_BASE_URL": f"http://127.0.0.1:{server.server_port}/v1",
+                "GCLOUD_LOG": str(gcloud_log),
+            },
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
 
     combined_output = proc.stdout + proc.stderr
     assert proc.returncode == 0, combined_output
+    assert "既存のためスキップ" in combined_output
+    assert "fieldOverride 同期済み" in combined_output
 
     calls = gcloud_log.read_text(encoding="utf-8").splitlines()
-    assert any("alpha firestore indexes composite create" in call for call in calls)
-    assert any(
-        "firestore indexes fields update normalized_label" in call
-        and "--collection-group=lemmas" in call
-        and "--index=order=ascending" in call
-        for call in calls
+    assert calls == ["auth print-access-token --quiet"]
+    assert "alpha" not in "\n".join(calls)
+
+    requests = _FirestoreAdminApiHandler.requests
+    assert [request["method"] for request in requests] == ["POST", "PATCH"]
+    assert requests[0]["authorization"] == "Bearer fake-token"
+    assert requests[1]["authorization"] == "Bearer fake-token"
+    assert requests[0]["path"] == (
+        "/v1/projects/demo-project/databases/%28default%29/"
+        "collectionGroups/examples/indexes"
     )
+    assert requests[1]["path"] == (
+        "/v1/projects/demo-project/databases/%28default%29/"
+        "collectionGroups/lemmas/fields/normalized_label?updateMask=indexConfig"
+    )
+
+    composite_body = requests[0]["body"]
+    assert composite_body == {
+        "queryScope": "COLLECTION",
+        "fields": [
+            {"fieldPath": "category", "order": "ASCENDING"},
+            {"fieldPath": "created_at", "order": "DESCENDING"},
+        ],
+    }
+
+    field_override_body = requests[1]["body"]
+    assert field_override_body == {
+        "name": (
+            "projects/demo-project/databases/(default)/"
+            "collectionGroups/lemmas/fields/normalized_label"
+        ),
+        "indexConfig": {
+            "indexes": [
+                {
+                    "queryScope": "COLLECTION",
+                    "fields": [{"fieldPath": "normalized_label", "order": "ASCENDING"}],
+                }
+            ]
+        },
+    }

--- a/tests/test_github_actions_branch_policy.py
+++ b/tests/test_github_actions_branch_policy.py
@@ -100,7 +100,7 @@ def test_deploy_production_prepares_firebase_cli_credentials_file() -> None:
     """
     Contract: production deploy must not pass a gcloud access token as
     FIREBASE_TOKEN. Firebase CLI gets a service account credentials file, while
-    Firestore index sync uses gcloud to avoid Firebase CLI auth for that step.
+    Firestore index sync uses gcloud-authenticated Admin API requests for that step.
     """
     yml = _read_text(".github/workflows/deploy-production.yml")
 


### PR DESCRIPTION
## Issue
Fixes #497

## 変更内容
- production deploy の Firestore index sync で `gcloud alpha firestore indexes composite create` を使わず、gcloud 認証の Firestore Admin API へ直接同期するように変更しました。
- composite index は `indexes.create`、single-field override は `fields.patch` + `updateMask=indexConfig` で同期し、既存 index の `ALREADY_EXISTS` は成功扱いで継続します。
- 回帰テストを更新し、`--tool gcloud` が `gcloud auth print-access-token --quiet` 以外の gcloud サブコマンドを呼ばず、Admin API へ composite index と fieldOverride を送ることを検証しました。
- workflow コメントと Firestore / deployment docs を、Firebase CLI と `gcloud alpha` component に依存しない経路へ更新しました。

## 保持した既存挙動
- `TOOL=firebase` の Firebase CLI 経路は残しています。
- `make release-cloud-run` は引き続き Cloud Run deploy 前に Firestore index sync を実行し、`SKIP_FIRESTORE_INDEX_SYNC=true` の回避も維持しています。
- Firebase Hosting deploy は前回修正どおり、一時 service account credentials file を `GOOGLE_APPLICATION_CREDENTIALS` として使います。

## 検証結果
- `PYTHONPATH=apps/backend pytest -q --no-cov tests/test_deploy_script_env_guard.py tests/test_github_actions_branch_policy.py tests/test_public_docs_security.py`
- `PYTHONPATH=apps/backend pytest -q --no-cov tests/test_deploy_script_env_guard.py tests/test_github_actions_branch_policy.py tests/test_public_docs_security.py tests/config/test_firebase_config.py`
- `shellcheck scripts/deploy_firestore_indexes.sh scripts/deploy_cloud_run.sh`
- `git diff --check`
- `.github/workflows/deploy-production.yml` の YAML parse
- 公開セキュリティチェックリスト確認と差分内の secret/log 警戒語検索

## 未実行項目
- 本番 workflow は PR 上では実行されないため、merge 後の `main` push で確認します。

## 残るリスク
- Firestore Admin API 呼び出しには対象 service account の Firestore index 管理権限が必要です。権限不足の場合は API error として deploy 前に停止します。
