### PR TITLE
Production deploy の Hosting API 手順を公式形式に揃える

### DIFF
--- a/scripts/deploy_firebase_hosting.py
+++ b/scripts/deploy_firebase_hosting.py
@@ -229,10 +229,7 @@ def deploy() -> None:
     api = HostingApi(token, os.environ.get("FIREBASE_HOSTING_API_BASE_URL", DEFAULT_API_BASE))
     quoted_site = urllib.parse.quote(site, safe="")
 
-    print(f"[deploy_firebase_hosting] Verifying Firebase Hosting site {site}")
-    api.request("GET", f"/sites/{quoted_site}")
-
-    print("[deploy_firebase_hosting] Creating Hosting version")
+    print(f"[deploy_firebase_hosting] Creating Hosting version for site {site}")
     create_result = api.request("POST", f"/sites/{quoted_site}/versions", {"status": "CREATED"})
     name = create_result.get("name")
     if not isinstance(name, str) or not name:
@@ -265,13 +262,17 @@ def deploy() -> None:
         "PATCH",
         f"/sites/{quoted_site}/versions/{urllib.parse.quote(vid, safe='')}",
         {"status": "FINALIZED", "config": final_config},
-        query={"updateMask": "status,config"},
+        query={"update_mask": "status,config"},
     )
 
     print(f"[deploy_firebase_hosting] Releasing version to channel {args.channel}")
+    if args.channel == "live":
+        release_path = f"/sites/{quoted_site}/releases"
+    else:
+        release_path = f"/sites/{quoted_site}/channels/{urllib.parse.quote(args.channel, safe='')}/releases"
     api.request(
         "POST",
-        f"/sites/{quoted_site}/channels/{urllib.parse.quote(args.channel, safe='')}/releases",
+        release_path,
         {},
         query={"versionName": name},
     )

--- a/tests/test_firebase_hosting_deploy.py
+++ b/tests/test_firebase_hosting_deploy.py
@@ -39,10 +39,6 @@ class _HostingApiHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(encoded)
 
-    def do_GET(self) -> None:
-        self._record()
-        self._send_json({"name": "sites/demo-project"})
-
     def do_POST(self) -> None:
         record = self._record()
         if record["path"] == "/v1beta1/sites/demo-project/versions":
@@ -60,7 +56,7 @@ class _HostingApiHandler(BaseHTTPRequestHandler):
         if record["path"].startswith("/upload/"):
             self._send_json({})
             return
-        if record["path"] == "/v1beta1/sites/demo-project/channels/live/releases":
+        if record["path"] == "/v1beta1/sites/demo-project/releases":
             self._send_json({"name": "release-1"})
             return
         self.send_error(404)
@@ -154,13 +150,12 @@ def test_deploy_firebase_hosting_uses_hosting_api_and_gcloud_token(tmp_path: Pat
     assert gcloud_log.read_text(encoding="utf-8").splitlines() == ["auth print-access-token --quiet"]
 
     requests = _HostingApiHandler.requests
-    assert [request["method"] for request in requests] == ["GET", "POST", "POST", "POST", "POST", "PATCH", "POST"]
+    assert [request["method"] for request in requests] == ["POST", "POST", "POST", "POST", "PATCH", "POST"]
     assert all(request["authorization"] == "Bearer fake-hosting-token" for request in requests)
-    assert requests[2]["body"]["files"].keys() == {"/assets/app.js", "/index.html"}  # type: ignore[index, union-attr]
-    assert requests[0]["path"] == "/v1beta1/sites/demo-project"
-    assert requests[5]["path"] == "/v1beta1/sites/demo-project/versions/version-1"
-    assert requests[5]["query"] == {"updateMask": ["status,config"]}
-    assert requests[5]["body"]["config"] == {  # type: ignore[index]
+    assert requests[1]["body"]["files"].keys() == {"/assets/app.js", "/index.html"}  # type: ignore[index, union-attr]
+    assert requests[4]["path"] == "/v1beta1/sites/demo-project/versions/version-1"
+    assert requests[4]["query"] == {"update_mask": ["status,config"]}
+    assert requests[4]["body"]["config"] == {  # type: ignore[index]
         "rewrites": [
             {
                 "glob": "/api/**",
@@ -169,5 +164,5 @@ def test_deploy_firebase_hosting_uses_hosting_api_and_gcloud_token(tmp_path: Pat
             {"glob": "**", "path": "/index.html"},
         ]
     }
-    assert requests[6]["path"] == "/v1beta1/sites/demo-project/channels/live/releases"
-    assert requests[6]["query"] == {"versionName": ["sites/demo-project/versions/version-1"]}
+    assert requests[5]["path"] == "/v1beta1/sites/demo-project/releases"
+    assert requests[5]["query"] == {"versionName": ["sites/demo-project/versions/version-1"]}


### PR DESCRIPTION
## Issue
Fixes #497

## 変更内容
- `scripts/deploy_firebase_hosting.py` から deploy guide に存在しない `GET /sites/{site}` verification を削除しました。
- Hosting version finalize の query を `update_mask=status,config` に変更しました。
- live release endpoint を `sites/{site}/releases` に変更し、preview channel 指定時だけ `sites/{site}/channels/{channel}/releases` を使うようにしました。
- Hosting API 契約テストを、version create -> populateFiles -> upload -> finalize -> live release の公式 deploy flow に更新しました。

## 保持した既存挙動
- Firebase CLI 認証に依存せず、gcloud の短命 token で Firebase Hosting API を呼ぶ構成は維持しています。
- Cloud Run release と Firestore index sync の順序は変更していません。
- Firebase Hosting の公開対象は `apps/frontend/dist`、`/api/**` は Cloud Run rewrite、その他は `index.html` rewrite のままです。

## 検証結果
- `python -m py_compile scripts/deploy_firebase_hosting.py`
- `PYTHONPATH=apps/backend pytest -q --no-cov tests/test_firebase_hosting_deploy.py tests/test_github_actions_branch_policy.py tests/test_public_docs_security.py`
- `PYTHONPATH=apps/backend pytest -q --no-cov tests/test_firebase_hosting_deploy.py tests/test_deploy_script_env_guard.py tests/test_github_actions_branch_policy.py tests/test_public_docs_security.py tests/config/test_firebase_config.py`
- `npm --prefix ./apps/frontend run build`
- `.github/workflows/deploy-production.yml` の YAML parse
- `shellcheck scripts/deploy_firestore_indexes.sh scripts/deploy_cloud_run.sh`
- `git diff --check`

## 未実行項目
- 本番 workflow は PR 上では実行されないため、merge 後の `main` push で確認します。

## 残るリスク
- Firebase Hosting API 実行には対象 service account の Hosting 管理権限が必要です。権限不足の場合は API error として Hosting release 前に停止します。
- Hosting site ID は従来の単一 default site 前提に合わせ、production project ID と同じ値を渡しています。site ID が project ID と異なる運用に変える場合は workflow 側に明示変数を追加してください。
