### PR TITLE
Cloud Run minimum instances をデプロイ設定で切り替え可能にする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,4 +268,4 @@ jobs:
         run: shellcheck scripts/deploy_cloud_run.sh
 
       - name: Dry-run Cloud Run deployment
-        run: ./scripts/deploy_cloud_run.sh --dry-run --env-file configs/cloud-run/ci.env --project-id ci-placeholder-project --region asia-northeast1 --service wordpack-backend
+        run: ./scripts/deploy_cloud_run.sh --dry-run --env-file configs/cloud-run/ci.env --project-id ci-placeholder-project --region asia-northeast1 --service wordpack-backend --min-instances 1

--- a/.github/workflows/deploy-dry-run.yml
+++ b/.github/workflows/deploy-dry-run.yml
@@ -27,6 +27,7 @@ jobs:
       CLOUD_RUN_PROJECT_ID: ci-placeholder-project
       CLOUD_RUN_REGION: asia-northeast1
       CLOUD_RUN_ENV_FILE: configs/cloud-run/ci.env
+      CLOUD_RUN_MIN_INSTANCES: "1"
       GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
     steps:
       - name: Checkout repository
@@ -88,5 +89,6 @@ jobs:
             PROJECT_ID=${{ env.CLOUD_RUN_PROJECT_ID }} \
             REGION=${{ env.CLOUD_RUN_REGION }} \
             ENV_FILE=${{ env.CLOUD_RUN_ENV_FILE }} \
+            MIN_INSTANCES=${{ env.CLOUD_RUN_MIN_INSTANCES }} \
             SKIP_FIRESTORE_INDEX_SYNC=true \
             DRY_RUN=true

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -23,6 +23,7 @@ jobs:
       CLOUD_RUN_PROJECT_ID: ${{ secrets.GCP_SA_PROJECT_ID }}
       CLOUD_RUN_REGION: asia-northeast1
       CLOUD_RUN_ENV_FILE: .env.deploy
+      CLOUD_RUN_MIN_INSTANCES: ${{ vars.CLOUD_RUN_MIN_INSTANCES || '1' }}
       SKIP_FIRESTORE_INDEX_SYNC: "false"
       FIREBASE_PROJECT_ID: ${{ secrets.GCP_SA_PROJECT_ID }}
       TRIGGER_BRANCH: ${{ github.ref_name }}
@@ -130,12 +131,14 @@ jobs:
           CLOUD_RUN_PROJECT_ID: ${{ env.CLOUD_RUN_PROJECT_ID }}
           CLOUD_RUN_REGION: ${{ env.CLOUD_RUN_REGION }}
           CLOUD_RUN_ENV_FILE: ${{ env.CLOUD_RUN_ENV_FILE }}
+          CLOUD_RUN_MIN_INSTANCES: ${{ env.CLOUD_RUN_MIN_INSTANCES }}
           SKIP_FIRESTORE_INDEX_SYNC: ${{ env.SKIP_FIRESTORE_INDEX_SYNC }}
         run: |
           make release-cloud-run \
             PROJECT_ID="${CLOUD_RUN_PROJECT_ID}" \
             REGION="${CLOUD_RUN_REGION}" \
             ENV_FILE="${CLOUD_RUN_ENV_FILE}" \
+            MIN_INSTANCES="${CLOUD_RUN_MIN_INSTANCES}" \
             SKIP_FIRESTORE_INDEX_SYNC="${SKIP_FIRESTORE_INDEX_SYNC}" \
             TOOL=gcloud
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ DEPLOY_CLOUD_RUN_ARGS = $(if $(PROJECT_ID),--project-id $(PROJECT_ID),) \
         $(if $(MACHINE_TYPE),--machine-type $(MACHINE_TYPE),) \
         $(if $(BUILD_TIMEOUT),--timeout $(BUILD_TIMEOUT),) \
         $(if $(RUN_TIMEOUT),--run-timeout $(RUN_TIMEOUT),) \
+        $(if $(MIN_INSTANCES),--min-instances $(MIN_INSTANCES),) \
         $(if $(NO_CPU_THROTTLING),--no-cpu-throttling,) \
         $(if $(GENERATE_SECRET),--generate-secret,) \
         $(if $(SECRET_LENGTH),--secret-length $(SECRET_LENGTH),) \

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -111,6 +111,18 @@ make release-cloud-run \
   RUN_TIMEOUT=360s
 ```
 
+紹介用の本番 URL で cold start による初回待ち時間を避けたい場合は、Cloud Run の minimum instances を `1` にします。後で費用優先へ戻す場合は `0` を指定します。
+
+```bash
+make release-cloud-run \
+  PROJECT_ID=<project-id> \
+  REGION=asia-northeast1 \
+  ENV_FILE=.env.deploy \
+  MIN_INSTANCES=1
+```
+
+`MIN_INSTANCES=0` は Cloud Run service の minimum instances を 0 に戻します。`MIN_INSTANCES=default` を指定すると gcloud の `--min default` に渡し、Cloud Run 側の既定値へ戻します。
+
 既に Firestore インデックスを同期済みの CI/CD 環境では、次のように同期を省略できます。
 
 ```bash
@@ -156,6 +168,7 @@ firebase deploy --only hosting --project <firebase-project-id>
 - 手動実行用に `workflow_dispatch` もあります。
 - PR では本番 deploy job を作りません。
 - CI 成功を必須にする場合は、GitHub の branch protection で必要な check を指定します。
+- Cloud Run の minimum instances は repository variable `CLOUD_RUN_MIN_INSTANCES` で上書きできます。未設定時は紹介用 URL の初回体験を優先して `1` を使います。費用優先へ戻す場合は `0` を設定します。
 
 必要な repository secrets:
 

--- a/env.deploy.example
+++ b/env.deploy.example
@@ -52,6 +52,10 @@ LLM_MAX_TOKENS=1500
 # 例: 360s（6分） / 10m（10分）
 CLOUD_RUN_TIMEOUT=360s
 
+# Cloud Run の minimum instances（任意）
+# 紹介用 URL の cold start を避ける場合は 1、費用優先へ戻す場合は 0。
+CLOUD_RUN_MIN_INSTANCES=1
+
 # Cloud Run の CPU スロットリング無効化（任意）
 # true にすると、レスポンス送信後も CPU が割り当てられ続けます（運用コスト注意）。
 CLOUD_RUN_NO_CPU_THROTTLING=false

--- a/scripts/deploy_cloud_run.sh
+++ b/scripts/deploy_cloud_run.sh
@@ -41,6 +41,7 @@ Options:
   --build-arg KEY=VALUE      Additional docker build arg (repeatable)
   --env-file <path>          Explicit env file (default: .env.deploy or .env)
   --run-timeout <duration>   Cloud Run request timeout, e.g. 360s, 10m (default: use existing service setting)
+  --min-instances <count>    Cloud Run minimum instances, e.g. 0, 1, default (default: keep current)
   --no-cpu-throttling        Disable CPU throttling to allow background work after responses (default: keep current)
   --generate-secret          Generate SESSION_SECRET_KEY via openssl if missing
   --secret-length <bytes>    Byte size for openssl rand -base64 (default: 48)
@@ -120,13 +121,24 @@ DRY_RUN=false
 MACHINE_TYPE="e2-medium"
 BUILD_TIMEOUT="30m"
 RUN_TIMEOUT_ARG=""
+MIN_INSTANCES_ARG=""
 NO_CPU_THROTTLING=false
 declare -a EXTRA_BUILD_ARGS=()
 
 declare -A DEPLOY_ENV_KEYS=()
-declare -a IGNORE_DEPLOY_KEYS=(PROJECT_ID REGION CLOUD_RUN_SERVICE ARTIFACT_REPOSITORY IMAGE_TAG MACHINE_TYPE BUILD_TIMEOUT)
+declare -a IGNORE_DEPLOY_KEYS=(PROJECT_ID REGION CLOUD_RUN_SERVICE ARTIFACT_REPOSITORY IMAGE_TAG MACHINE_TYPE BUILD_TIMEOUT CLOUD_RUN_MIN_INSTANCES)
 declare -a REQUIRED_DEPLOY_KEYS=(ADMIN_EMAIL_ALLOWLIST SESSION_SECRET_KEY CORS_ALLOWED_ORIGINS TRUSTED_PROXY_IPS ALLOWED_HOSTS)
 GCLOUD_CMD_CHECKED=false
+
+validate_min_instances() {
+  local value="$1"
+  [[ -z "$value" || "$value" == "default" ]] && return 0
+  if [[ "$value" =~ ^[0-9]+$ ]]; then
+    return 0
+  fi
+  err "Cloud Run minimum instances must be a non-negative integer or 'default'"
+  exit 1
+}
 
 # コマンドライン引数のパース。
 # たとえば `--project-id` や `--region` などを受け取って、内部変数へ格納します。
@@ -158,6 +170,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --run-timeout)
       RUN_TIMEOUT_ARG="$2"
+      shift 2
+      ;;
+    --min-instances)
+      MIN_INSTANCES_ARG="$2"
       shift 2
       ;;
     --no-cpu-throttling)
@@ -289,9 +305,12 @@ add_env_key "TRUSTED_PROXY_IPS"
 add_env_key "ALLOWED_HOSTS"
 # Cloud Run へ適用する実行パラメータ（任意）
 # - CLOUD_RUN_TIMEOUT: 例 360s, 10m
+# - CLOUD_RUN_MIN_INSTANCES: 例 0, 1, default
 # - CLOUD_RUN_NO_CPU_THROTTLING: true/false
 
 RUN_TIMEOUT="${RUN_TIMEOUT_ARG:-${CLOUD_RUN_TIMEOUT:-}}"
+MIN_INSTANCES="${MIN_INSTANCES_ARG:-${CLOUD_RUN_MIN_INSTANCES:-}}"
+validate_min_instances "$MIN_INSTANCES"
 NO_CPU_THROTTLING="${NO_CPU_THROTTLING:-${CLOUD_RUN_NO_CPU_THROTTLING:-false}}"
 
 while IFS= read -r line || [[ -n "$line" ]]; do
@@ -342,6 +361,9 @@ log "Backend configuration validated successfully"
 if [[ "$DRY_RUN" == true ]]; then
   log "Dry run mode: skipping gcloud build/deploy"
   log "Prepared image URI: $IMAGE_URI"
+  if [[ -n "$MIN_INSTANCES" ]]; then
+    log "Prepared Cloud Run minimum instances: $MIN_INSTANCES"
+  fi
   exit 0
 fi
 
@@ -451,6 +473,9 @@ log "Deploying service ${SERVICE_NAME} to region ${REGION} with env file ${ENV_V
 RUN_ARGS=()
 if [[ -n "${RUN_TIMEOUT:-}" ]]; then
   RUN_ARGS+=(--timeout "$RUN_TIMEOUT")
+fi
+if [[ -n "${MIN_INSTANCES:-}" ]]; then
+  RUN_ARGS+=(--min "$MIN_INSTANCES")
 fi
 if [[ "${NO_CPU_THROTTLING}" == "true" ]]; then
   RUN_ARGS+=(--no-cpu-throttling)

--- a/tests/test_deploy_script_env_guard.py
+++ b/tests/test_deploy_script_env_guard.py
@@ -21,6 +21,53 @@ def test_deploy_script_requires_firestore_project_id_or_gcp_project_id() -> None
     assert "FIRESTORE_PROJECT_ID, GCP_PROJECT_ID, GOOGLE_CLOUD_PROJECT, or PROJECT_ID" in text
 
 
+def test_deploy_script_supports_cloud_run_min_instances() -> None:
+    deploy_script = Path("scripts/deploy_cloud_run.sh").read_text(encoding="utf-8")
+    makefile = Path("Makefile").read_text(encoding="utf-8")
+    ci_workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+    dry_run_workflow = Path(".github/workflows/deploy-dry-run.yml").read_text(encoding="utf-8")
+    production_workflow = Path(".github/workflows/deploy-production.yml").read_text(encoding="utf-8")
+    deploy_env_example = Path("env.deploy.example").read_text(encoding="utf-8")
+
+    assert "--min-instances <count>" in deploy_script
+    assert "CLOUD_RUN_MIN_INSTANCES: 例 0, 1, default" in deploy_script
+    assert 'RUN_ARGS+=(--min "$MIN_INSTANCES")' in deploy_script
+    assert "$(if $(MIN_INSTANCES),--min-instances $(MIN_INSTANCES),)" in makefile
+    assert "--min-instances 1" in ci_workflow
+    assert 'CLOUD_RUN_MIN_INSTANCES: "1"' in dry_run_workflow
+    assert "MIN_INSTANCES=${{ env.CLOUD_RUN_MIN_INSTANCES }}" in dry_run_workflow
+    assert "CLOUD_RUN_MIN_INSTANCES: ${{ vars.CLOUD_RUN_MIN_INSTANCES || '1' }}" in production_workflow
+    assert 'MIN_INSTANCES="${CLOUD_RUN_MIN_INSTANCES}"' in production_workflow
+    assert "CLOUD_RUN_MIN_INSTANCES=1" in deploy_env_example
+
+
+def test_deploy_script_rejects_invalid_cloud_run_min_instances() -> None:
+    proc = subprocess.run(
+        [
+            "scripts/deploy_cloud_run.sh",
+            "--dry-run",
+            "--env-file",
+            "configs/cloud-run/ci.env",
+            "--project-id",
+            "ci-placeholder-project",
+            "--region",
+            "asia-northeast1",
+            "--service",
+            "wordpack-backend",
+            "--min-instances",
+            "one",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    combined_output = proc.stdout + proc.stderr
+
+    assert proc.returncode != 0
+    assert "Cloud Run minimum instances must be a non-negative integer or 'default'" in combined_output
+    assert "Validating backend settings" not in combined_output
+
+
 def test_release_cloud_run_stops_when_index_sync_fails(tmp_path: Path) -> None:
     fake_cloud_run = tmp_path / "fake_cloud_run.sh"
     fake_cloud_run.write_text(


### PR DESCRIPTION
## Issue
Closes #509

## 変更内容
- `scripts/deploy_cloud_run.sh` に `--min-instances` / `CLOUD_RUN_MIN_INSTANCES` を追加し、`gcloud run deploy --min` へ渡すようにしました。
- `Makefile` の `MIN_INSTANCES`、GitHub Actions の本番 deploy / dry-run / CI guard へ値を伝搬しました。
- 本番 GitHub Actions は repository variable `CLOUD_RUN_MIN_INSTANCES` が未設定なら `1` を使い、後で `0` に戻せるようにしました。
- `docs/deployment.md` と `env.deploy.example` に、`1` / `0` / `default` の運用手順を追記しました。

## 保持した既存挙動
- `MIN_INSTANCES` / `CLOUD_RUN_MIN_INSTANCES` を指定しない手動 deploy は、Cloud Run の既存 minimum instances 設定を維持します。
- Cloud Run の timeout、CPU throttling、Firestore index sync、Firebase Hosting deploy の既存経路は変更していません。

## 検証結果
- `shellcheck scripts/deploy_cloud_run.sh`
- `PYTHONPATH=apps/backend .venv/bin/python -m pytest -q --no-cov tests/test_deploy_script_env_guard.py tests/test_cloud_build_config.py tests/test_github_actions_branch_policy.py`
- `PATH=.venv/bin:$PATH ./scripts/deploy_cloud_run.sh --dry-run --env-file configs/cloud-run/ci.env --project-id ci-placeholder-project --region asia-northeast1 --service wordpack-backend --min-instances 1`
- `PATH=.venv/bin:$PATH ./scripts/deploy_cloud_run.sh --dry-run --env-file configs/cloud-run/ci.env --project-id ci-placeholder-project --region asia-northeast1 --service wordpack-backend --min-instances 0`
- `PATH=.venv/bin:$PATH ./scripts/deploy_cloud_run.sh --dry-run --env-file configs/cloud-run/ci.env --project-id ci-placeholder-project --region asia-northeast1 --service wordpack-backend --min-instances default`
- `git diff --check`
- GitHub Actions workflow YAML parse

## 未実行項目
- 実際の Cloud Run 本番 deploy は PR 上では実行していません。main merge 後の本番 deploy workflow で反映されます。

## 残るリスク
- `CLOUD_RUN_MIN_INSTANCES=1` は cold start を抑える代わりに idle 課金が発生します。費用優先に戻す場合は repository variable を `0` に設定してください。