### PR TITLE
PR時点で本番デプロイ事前検証を実行する

### DIFF
--- a/.github/workflows/production-deploy-preflight.yml
+++ b/.github/workflows/production-deploy-preflight.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: production-deploy-preflight-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: production-deploy-preflight-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/production-deploy-preflight.yml
+++ b/.github/workflows/production-deploy-preflight.yml
@@ -1,0 +1,253 @@
+name: Production deploy preflight
+
+on:
+  pull_request:
+    branches: [ main ]
+  pull_request_target:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
+  workflow_dispatch:
+
+concurrency:
+  group: production-deploy-preflight-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  static_preflight:
+    name: Static deploy preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js for frontend artifact
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: apps/frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        env:
+          NPM_CONFIG_PRODUCTION: "false"
+        run: npm ci --prefix ./apps/frontend
+
+      - name: Build frontend artifact
+        run: npm --prefix ./apps/frontend run build
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install backend dependencies for Cloud Run dry-run
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run Cloud Run dry-run preflight
+        run: |
+          ./scripts/deploy_cloud_run.sh \
+            --dry-run \
+            --env-file configs/cloud-run/ci.env \
+            --project-id ci-placeholder-project \
+            --region asia-northeast1 \
+            --service wordpack-backend
+
+      - name: Plan Firebase Hosting API deploy without writes
+        run: |
+          python scripts/deploy_firebase_hosting.py \
+            --project ci-placeholder-project \
+            --site ci-placeholder-project \
+            --public apps/frontend/dist \
+            --plan-only
+
+      - name: Guard production deploy contract
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+          import sys
+
+          forbidden = {
+              "gcloud " + "alpha": "Production deploy preflight forbids alpha gcloud commands because CI images may prompt for components.",
+              "firebase deploy --only " + "hosting": "Production Hosting deploy must use scripts/deploy_firebase_hosting.py, not Firebase CLI Hosting deploy.",
+              "FIREBASE" + "_TOKEN": "Production deploy must not depend on Firebase CLI token credentials.",
+          }
+          files = [
+              Path(".github/workflows/deploy-production.yml"),
+              Path("scripts/deploy_cloud_run.sh"),
+              Path("scripts/deploy_firestore_indexes.sh"),
+              Path("scripts/deploy_firebase_hosting.py"),
+              Path("Makefile"),
+          ]
+
+          failed = False
+          for path in files:
+              for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+                  stripped = line.strip()
+                  if not stripped or stripped.startswith("#"):
+                      continue
+                  for needle, message in forbidden.items():
+                      if needle in line:
+                          print(f"::error file={path},line={number}::{message}")
+                          failed = True
+
+          if failed:
+              sys.exit(1)
+          PY
+
+  authenticated_read_only_probe:
+    name: Authenticated deploy read-only probe
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch'
+    env:
+      CLOUD_RUN_PROJECT_ID: ${{ secrets.GCP_SA_PROJECT_ID }}
+      FIREBASE_PROJECT_ID: ${{ secrets.GCP_SA_PROJECT_ID }}
+      GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+      FIRESTORE_DATABASE_ID: "(default)"
+    steps:
+      - name: Checkout trusted base code
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Checkout selected ref
+        if: github.event_name != 'pull_request_target'
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Validate probe secrets
+        run: |
+          set -euo pipefail
+          missing=0
+          if [ -z "${CLOUD_RUN_PROJECT_ID}" ]; then
+            echo "::error::GCP_SA_PROJECT_ID secret is not set; production deploy would not know the target project."
+            missing=1
+          fi
+          if [ -z "${GCP_SA_KEY}" ]; then
+            echo "::error::GCP_SA_KEY secret is not set; production deploy cannot authenticate."
+            missing=1
+          fi
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+          echo "::add-mask::${CLOUD_RUN_PROJECT_ID}"
+          echo "::add-mask::${FIREBASE_PROJECT_ID}"
+
+      - name: Authenticate to Google Cloud with service account key
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          create_credentials_file: true
+          export_environment_variables: true
+
+      - name: Set up gcloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.CLOUD_RUN_PROJECT_ID }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Verify gcloud can mint an access token
+        run: |
+          set -euo pipefail
+          gcloud auth print-access-token --quiet >/dev/null
+
+      - name: Probe Firestore Admin API read access
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import subprocess
+          import sys
+          import urllib.error
+          import urllib.parse
+          import urllib.request
+
+          with open("firestore.indexes.json", encoding="utf-8") as fh:
+              payload = json.load(fh)
+
+          collection_group = next(
+              (
+                  index.get("collectionGroup")
+                  for index in payload.get("indexes", [])
+                  if index.get("collectionGroup")
+              ),
+              None,
+          )
+          if not collection_group:
+              print("[preflight] No composite indexes to probe; skipping Firestore Admin API list check.")
+              sys.exit(0)
+
+          token = subprocess.check_output(
+              ["gcloud", "auth", "print-access-token", "--quiet"],
+              text=True,
+          ).strip()
+          if not token:
+              print("::error::gcloud did not return an access token for Firestore probe.", file=sys.stderr)
+              sys.exit(1)
+
+          def quote(value: str) -> str:
+              return urllib.parse.quote(value, safe="")
+
+          project_id = os.environ["CLOUD_RUN_PROJECT_ID"]
+          database_id = os.environ.get("FIRESTORE_DATABASE_ID", "(default)")
+          path = (
+              f"projects/{quote(project_id)}"
+              f"/databases/{quote(database_id)}"
+              f"/collectionGroups/{quote(collection_group)}"
+              "/indexes"
+          )
+          url = f"https://firestore.googleapis.com/v1/{path}?pageSize=1"
+          request = urllib.request.Request(
+              url,
+              headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+          )
+          try:
+              with urllib.request.urlopen(request, timeout=60) as response:
+                  response.read()
+          except urllib.error.HTTPError as exc:
+              text = exc.read().decode("utf-8", errors="replace")
+              try:
+                  error = json.loads(text).get("error", {})
+              except json.JSONDecodeError:
+                  error = {}
+              message = error.get("message") or error.get("status") or f"HTTP {exc.code}"
+              print(
+                  "::error::Firestore Admin API read-only probe failed "
+                  f"for collectionGroup '{collection_group}': {message}",
+                  file=sys.stderr,
+              )
+              sys.exit(1)
+          except urllib.error.URLError as exc:
+              print(f"::error::Firestore Admin API read-only probe failed: {exc}", file=sys.stderr)
+              sys.exit(1)
+
+          print(f"[preflight] Firestore Admin API read-only probe passed for collectionGroup '{collection_group}'.")
+          PY
+
+      - name: Probe Firebase Hosting API read access
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/hosting-preflight"
+          printf '<!doctype html><title>preflight</title>\n' > "${RUNNER_TEMP}/hosting-preflight/index.html"
+          python scripts/deploy_firebase_hosting.py \
+            --project "${FIREBASE_PROJECT_ID}" \
+            --site "${FIREBASE_PROJECT_ID}" \
+            --public "${RUNNER_TEMP}/hosting-preflight" \
+            --probe-only

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,7 +8,7 @@
 - frontend は React + Vite の build artifact を Firebase Hosting API で配置します。
 - Firestore の複合インデックスと single-field override は `firestore.indexes.json` を同期します。既定の `gcloud` 経路は gcloud の認証情報で Firestore Admin API を直接呼び、Firebase CLI と `gcloud alpha` component には依存しません。
 - GitHub Actions の本番デプロイは `main` への push と `workflow_dispatch` をトリガーにします。
-- PR では本番デプロイ job を作らず、Cloud Run config guard の dry-run で設定ミスを検知します。
+- PR では本番デプロイ job を作らず、production deploy preflight で Cloud Run dry-run、Firebase Hosting API plan、認証済み read-only probe を非破壊で確認します。
 
 ## 事前準備
 
@@ -166,6 +166,17 @@ firebase deploy --only hosting --project <firebase-project-id>
 | `CLOUD_RUN_ENV_FILE_BASE64` | `.env.deploy` を base64 化した値 |
 
 Firestore index 同期は `gcloud` 認証の Firestore Admin API 経由で行い、Firebase Hosting 更新は `gcloud` 認証の Firebase Hosting API 経由で行います。どちらも Firebase CLI 認証や `gcloud alpha` component に依存させません。長期保存する `FIREBASE_TOKEN` secret や、`gcloud auth print-access-token` で発行した access token の `FIREBASE_TOKEN` 代入は使いません。
+
+### Production deploy preflight
+
+`.github/workflows/production-deploy-preflight.yml` は、PR 時点で本番デプロイの主要な前提を非破壊で確認します。
+
+- `pull_request` では PR コードを checkout し、secrets なしで frontend build、Cloud Run dry-run、Firebase Hosting API の `--plan-only`、production deploy contract guard を実行します。
+- `pull_request_target` では secrets を使うため、PR コードは checkout せず、base branch の信頼済みコードだけで read-only probe を実行します。
+- read-only probe は `gcloud auth print-access-token`、Firestore Admin API の index list、Firebase Hosting API の releases list を確認します。
+- `workflow_dispatch` では選択した ref に対して同じ静的 preflight と read-only probe を手動実行できます。
+
+この preflight は Hosting version 作成、file upload、version finalize、release 作成、Firestore index 作成/更新、Cloud Run 実デプロイを実行しません。そのため write 権限、quota、release 作成時の最終検証までは完全保証できません。実デプロイを伴わない範囲で、API path、認証前提、build artifact、dry-run 可能な設定、禁止 CLI 依存を先に検知するための check です。
 
 サービスアカウントに必要な代表ロール:
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -130,6 +130,7 @@ flowchart LR
         FrontendTest["Frontend tests<br/>(vitest)"]
         PlaywrightSmoke["Playwright smoke<br/>(PR critical flows)"]
         CloudRunGuard["Cloud Run config guard<br/>(dry-run)"]
+        DeployPreflight["Production deploy preflight<br/>(no deploy)"]
     end
 
     subgraph CD["CD"]
@@ -147,6 +148,7 @@ flowchart LR
     BackendTest --> PlaywrightSmoke
     FrontendTest --> PlaywrightSmoke
     SecurityTest --> CloudRunGuard
+    Actions -->|PR| DeployPreflight
     Actions -->|main push| DryRun
     Actions -->|main push| ProductionDeploy
     ProductionDeploy --> FirestoreIndex
@@ -164,10 +166,11 @@ flowchart LR
 | **Playwright smoke** | `pull_request`（Backend / Frontend テスト成功後） | Playwright の主要導線スモークテスト（`auth.spec.ts` / `guest.spec.ts` / `wordpack.spec.ts`） |
 | **Visual regression** | `pull_request`（UI 変更のみ） | UI 変更が検知された場合に Playwright の視覚回帰 (`tests/e2e/visual.spec.ts`) を実行 |
 | **Cloud Run config guard** | Security headers 成功後 | デプロイスクリプトの lint と dry-run 検証 |
+| **Production deploy preflight** | `pull_request` / `pull_request_target` / 手動実行 | PR コードでは secrets なしの frontend build、Cloud Run dry-run、Hosting API plan を実行し、secrets を使う read-only probe は base branch の信頼済みコードだけで実行 |
 | **Cloud Run dry-run** | `main` push | `CD / Cloud Run dry-run` として main に取り込まれた commit のチェック一覧に表示し、`make release-cloud-run` の dry-run モードを実行 |
 | **Deploy to production** | `main` push / 手動実行 | `deploy-production.yml` が `make release-cloud-run` と Firebase Hosting deploy を実行。PR では本番デプロイ job を作らない |
 
-Cloud Run dry-run と `Deploy to production` は `main` ブランチへの push で直接起動し、GitHub のコミットチェック一覧に CD の状態を表示する。PR では本番デプロイ job を作らず、マージ前のデプロイ検証は CI 内の Cloud Run config guard に限定する。CI 成功を必須にする場合は main ブランチ保護でチェックを必須化する。
+Cloud Run dry-run と `Deploy to production` は `main` ブランチへの push で直接起動し、GitHub のコミットチェック一覧に CD の状態を表示する。PR では本番デプロイ job を作らず、`Production deploy preflight` で非破壊の事前検証を行う。CI 成功を必須にする場合は main ブランチ保護でチェックを必須化する。
 
 CD のチェック表示は GitHub Actions と Cloud Build の二経路で行う。main への push または手動リリース時は `Deploy to production` ワークフローが起動する。Cloud Build は `cloudbuild.backend.yaml` 内で GitHub Checks API に結果を送信する。`deploy-production.yml` から `GITHUB_CHECKS_TOKEN` を渡すことで、Cloud Build の成功結果もコミットチェック一覧に追加される。
 

--- a/scripts/deploy_firebase_hosting.py
+++ b/scripts/deploy_firebase_hosting.py
@@ -34,6 +34,17 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--config", default="firebase.json", help="Path to firebase.json.")
     parser.add_argument("--public", help="Hosting public directory override.")
     parser.add_argument("--channel", default="live", help="Hosting channel ID.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--plan-only",
+        action="store_true",
+        help="Build the Hosting deploy plan without gcloud auth or Hosting API requests.",
+    )
+    mode.add_argument(
+        "--probe-only",
+        action="store_true",
+        help="Run the deploy plan and a read-only Hosting API probe without creating a version or release.",
+    )
     return parser.parse_args()
 
 
@@ -210,6 +221,36 @@ def version_id(version_name: str) -> str:
     return version_name.rstrip("/").split("/")[-1]
 
 
+def release_path(quoted_site: str, channel: str) -> str:
+    if channel == "live":
+        return f"/sites/{quoted_site}/releases"
+    quoted_channel = urllib.parse.quote(channel, safe="")
+    return f"/sites/{quoted_site}/channels/{quoted_channel}/releases"
+
+
+def print_preflight_plan(site: str, channel: str, files: dict[str, bytes], final_config: dict) -> None:
+    quoted_site = urllib.parse.quote(site, safe="")
+    print(f"[deploy_firebase_hosting] Preflight target site: {site}")
+    print(f"[deploy_firebase_hosting] Preflight target channel: {channel}")
+    print(f"[deploy_firebase_hosting] Preflight file count: {len(files)}")
+    print(
+        "[deploy_firebase_hosting] Preflight rewrite count: "
+        f"{len(final_config.get('rewrites', []))}"
+    )
+    print("[deploy_firebase_hosting] Planned write API requests:")
+    print(f"  - POST /sites/{quoted_site}/versions")
+    print("  - POST /{versionName}:populateFiles")
+    print("  - POST {uploadUrl}/{contentHash} for required uploads")
+    print(f"  - PATCH /sites/{quoted_site}/versions/{{versionId}}?update_mask=status,config")
+    print(f"  - POST {release_path(quoted_site, channel)}?versionName={{versionName}}")
+
+
+def probe_hosting_api(api: HostingApi, quoted_site: str, channel: str) -> None:
+    path = release_path(quoted_site, channel)
+    print(f"[deploy_firebase_hosting] Probing Hosting releases list: GET {path}")
+    api.request("GET", path, query={"pageSize": "1"})
+
+
 def deploy() -> None:
     args = parse_args()
     site = args.site or args.project
@@ -225,9 +266,21 @@ def deploy() -> None:
     hashes = {path: hashlib.sha256(content).hexdigest() for path, content in files.items()}
     print(f"[deploy_firebase_hosting] Prepared {len(files)} file(s) for site {site}")
 
+    final_config = {"rewrites": convert_rewrites(hosting_config.get("rewrites"))}
+    quoted_site = urllib.parse.quote(site, safe="")
+    if args.plan_only:
+        print_preflight_plan(site, args.channel, files, final_config)
+        print("[deploy_firebase_hosting] Plan-only preflight complete; no API requests were executed")
+        return
+
     token = run_gcloud_access_token()
     api = HostingApi(token, os.environ.get("FIREBASE_HOSTING_API_BASE_URL", DEFAULT_API_BASE))
-    quoted_site = urllib.parse.quote(site, safe="")
+
+    if args.probe_only:
+        print_preflight_plan(site, args.channel, files, final_config)
+        probe_hosting_api(api, quoted_site, args.channel)
+        print("[deploy_firebase_hosting] Probe-only preflight complete; no write API requests were executed")
+        return
 
     print(f"[deploy_firebase_hosting] Creating Hosting version for site {site}")
     create_result = api.request("POST", f"/sites/{quoted_site}/versions", {"status": "CREATED"})
@@ -255,7 +308,6 @@ def deploy() -> None:
         )
     print(f"[deploy_firebase_hosting] Uploaded {len(required_hashes)} new file(s)")
 
-    final_config = {"rewrites": convert_rewrites(hosting_config.get("rewrites"))}
     vid = version_id(name)
     print("[deploy_firebase_hosting] Finalizing Hosting version")
     api.request(
@@ -266,13 +318,9 @@ def deploy() -> None:
     )
 
     print(f"[deploy_firebase_hosting] Releasing version to channel {args.channel}")
-    if args.channel == "live":
-        release_path = f"/sites/{quoted_site}/releases"
-    else:
-        release_path = f"/sites/{quoted_site}/channels/{urllib.parse.quote(args.channel, safe='')}/releases"
     api.request(
         "POST",
-        release_path,
+        release_path(quoted_site, args.channel),
         {},
         query={"versionName": name},
     )

--- a/tests/test_firebase_hosting_deploy.py
+++ b/tests/test_firebase_hosting_deploy.py
@@ -65,16 +65,18 @@ class _HostingApiHandler(BaseHTTPRequestHandler):
         self._record()
         self._send_json({"name": "projects/-/sites/demo-project/versions/version-1"})
 
+    def do_GET(self) -> None:
+        record = self._record()
+        if record["path"] == "/v1beta1/sites/demo-project/releases":
+            self._send_json({"releases": []})
+            return
+        self.send_error(404)
+
     def log_message(self, format: str, *args: object) -> None:
         return
 
 
-def test_deploy_firebase_hosting_uses_hosting_api_and_gcloud_token(tmp_path: Path) -> None:
-    _HostingApiHandler.requests = []
-    server = HTTPServer(("127.0.0.1", 0), _HostingApiHandler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-
+def _write_hosting_fixture(tmp_path: Path) -> Path:
     public_dir = tmp_path / "dist"
     public_dir.mkdir()
     (public_dir / "index.html").write_text("<div>ok</div>", encoding="utf-8")
@@ -101,7 +103,10 @@ def test_deploy_firebase_hosting_uses_hosting_api_and_gcloud_token(tmp_path: Pat
         ),
         encoding="utf-8",
     )
+    return config_path
 
+
+def _write_fake_gcloud(tmp_path: Path, exit_status: int = 0) -> tuple[Path, Path]:
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     gcloud_log = tmp_path / "gcloud.log"
@@ -110,14 +115,30 @@ def test_deploy_firebase_hosting_uses_hosting_api_and_gcloud_token(tmp_path: Pat
         "#!/usr/bin/env bash\n"
         "printf '%s\\n' \"$*\" >> \"${GCLOUD_LOG}\"\n"
         "if [ \"$1\" = \"auth\" ] && [ \"$2\" = \"print-access-token\" ]; then\n"
-        "  printf 'fake-hosting-token\\n'\n"
-        "  exit 0\n"
+        f"  exit_status={exit_status}\n"
+        "  if [ \"$exit_status\" -eq 0 ]; then\n"
+        "    printf 'fake-hosting-token\\n'\n"
+        "  else\n"
+        "    printf 'unexpected gcloud call\\n' >&2\n"
+        "  fi\n"
+        "  exit \"$exit_status\"\n"
         "fi\n"
         "printf 'unexpected gcloud command: %s\\n' \"$*\" >&2\n"
         "exit 2\n",
         encoding="utf-8",
     )
     fake_gcloud.chmod(0o755)
+    return fake_bin, gcloud_log
+
+
+def test_deploy_firebase_hosting_uses_hosting_api_and_gcloud_token(tmp_path: Path) -> None:
+    _HostingApiHandler.requests = []
+    server = HTTPServer(("127.0.0.1", 0), _HostingApiHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    config_path = _write_hosting_fixture(tmp_path)
+    fake_bin, gcloud_log = _write_fake_gcloud(tmp_path)
 
     try:
         proc = subprocess.run(
@@ -166,3 +187,88 @@ def test_deploy_firebase_hosting_uses_hosting_api_and_gcloud_token(tmp_path: Pat
     }
     assert requests[5]["path"] == "/v1beta1/sites/demo-project/releases"
     assert requests[5]["query"] == {"versionName": ["sites/demo-project/versions/version-1"]}
+
+
+def test_deploy_firebase_hosting_plan_only_does_not_call_gcloud_or_api(tmp_path: Path) -> None:
+    config_path = _write_hosting_fixture(tmp_path)
+    fake_bin, gcloud_log = _write_fake_gcloud(tmp_path, exit_status=2)
+
+    proc = subprocess.run(
+        [
+            "python",
+            "scripts/deploy_firebase_hosting.py",
+            "--project",
+            "demo-project",
+            "--site",
+            "demo-project",
+            "--config",
+            str(config_path),
+            "--plan-only",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "GCLOUD_LOG": str(gcloud_log),
+            "FIREBASE_HOSTING_API_BASE_URL": "http://127.0.0.1:9/v1beta1",
+        },
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert not gcloud_log.exists()
+    assert "Plan-only preflight complete" in proc.stdout
+    assert "POST /sites/demo-project/versions" in proc.stdout
+    assert "PATCH /sites/demo-project/versions/{versionId}?update_mask=status,config" in proc.stdout
+
+
+def test_deploy_firebase_hosting_probe_only_uses_read_only_releases_list(tmp_path: Path) -> None:
+    _HostingApiHandler.requests = []
+    server = HTTPServer(("127.0.0.1", 0), _HostingApiHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    config_path = _write_hosting_fixture(tmp_path)
+    fake_bin, gcloud_log = _write_fake_gcloud(tmp_path)
+
+    try:
+        proc = subprocess.run(
+            [
+                "python",
+                "scripts/deploy_firebase_hosting.py",
+                "--project",
+                "demo-project",
+                "--site",
+                "demo-project",
+                "--config",
+                str(config_path),
+                "--probe-only",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env={
+                **os.environ,
+                "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                "GCLOUD_LOG": str(gcloud_log),
+                "FIREBASE_HOSTING_API_BASE_URL": f"http://127.0.0.1:{server.server_port}/v1beta1",
+            },
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert gcloud_log.read_text(encoding="utf-8").splitlines() == ["auth print-access-token --quiet"]
+    assert "Probe-only preflight complete" in proc.stdout
+    assert _HostingApiHandler.requests == [
+        {
+            "method": "GET",
+            "path": "/v1beta1/sites/demo-project/releases",
+            "query": {"pageSize": ["1"]},
+            "authorization": "Bearer fake-hosting-token",
+            "body": b"",
+        }
+    ]

--- a/tests/test_github_actions_branch_policy.py
+++ b/tests/test_github_actions_branch_policy.py
@@ -155,6 +155,7 @@ def test_production_deploy_preflight_checks_prs_without_deploying() -> None:
         [
             "Static deploy preflight",
             "Authenticated deploy read-only probe",
+            "production-deploy-preflight-${{ github.workflow }}-${{ github.event_name }}-",
             "github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'",
             "github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch'",
             "ref: ${{ github.event.pull_request.base.sha }}",

--- a/tests/test_github_actions_branch_policy.py
+++ b/tests/test_github_actions_branch_policy.py
@@ -129,3 +129,47 @@ def test_deploy_production_uses_api_based_hosting_deploy() -> None:
             "TOOL=firebase",
         ],
     )
+
+
+def test_production_deploy_preflight_checks_prs_without_deploying() -> None:
+    """
+    Contract: PRs get a non-deploying production preflight. Static checks run on
+    the PR code without secrets, while the authenticated probe uses
+    pull_request_target and trusted base code for read-only API checks.
+    """
+    yml = _read_text(".github/workflows/production-deploy-preflight.yml")
+    on_block = _extract_on_block(yml)
+
+    _assert_contains_all(
+        on_block,
+        [
+            "pull_request:",
+            "pull_request_target:",
+            "workflow_dispatch:",
+            "branches:",
+            "main",
+        ],
+    )
+    _assert_contains_all(
+        yml,
+        [
+            "Static deploy preflight",
+            "Authenticated deploy read-only probe",
+            "github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'",
+            "github.event_name == 'pull_request_target' || github.event_name == 'workflow_dispatch'",
+            "ref: ${{ github.event.pull_request.base.sha }}",
+            "--plan-only",
+            "--probe-only",
+            "deploy_cloud_run.sh \\",
+            "gcloud auth print-access-token --quiet >/dev/null",
+            "google-github-actions/auth@v2",
+            "scripts/deploy_firebase_hosting.py",
+        ],
+    )
+    _assert_contains_none(
+        yml,
+        [
+            "environment: production",
+            "firebase deploy --only hosting",
+        ],
+    )


### PR DESCRIPTION
Issue
Closes #510

変更内容
- `scripts/deploy_firebase_hosting.py` に `--plan-only` と `--probe-only` を追加し、Hosting deploy の manifest/rewrite/API path を非破壊で確認できるようにしました。
- `production-deploy-preflight.yml` を追加し、PR コードでは secrets なしの Cloud Run dry-run / frontend build / Hosting plan を実行し、`pull_request_target` では base branch の信頼済みコードだけで認証済み read-only probe を実行します。
- workflow 契約テストと Hosting deploy script の回帰テストを追加しました。
- deployment / infrastructure docs に preflight の保証範囲と限界を追記しました。

保持した既存挙動
- `deploy-production.yml` の本番デプロイ手順は変更していません。
- Hosting の通常 deploy は従来通り version create / populateFiles / finalize / release を実行します。
- PR では本番 deploy job を作らず、write API や Cloud Run 実デプロイは実行しません。

検証結果
- `PYTHONPATH=apps/backend pytest -q --no-cov tests/test_firebase_hosting_deploy.py tests/test_github_actions_branch_policy.py`
- `PYTHONPATH=apps/backend pytest -q --no-cov tests/test_github_actions_branch_policy.py`
- `python scripts/deploy_firebase_hosting.py --help`
- `python -m py_compile scripts/deploy_firebase_hosting.py`
- `.github/workflows/*.yml` の PyYAML parse
- `git diff --check`
- `npm --prefix ./apps/frontend run build`
- `python scripts/deploy_firebase_hosting.py --project ci-placeholder-project --site ci-placeholder-project --public apps/frontend/dist --plan-only`
- `shellcheck scripts/deploy_cloud_run.sh`
- `./scripts/deploy_cloud_run.sh --dry-run --env-file configs/cloud-run/ci.env --project-id ci-placeholder-project --region asia-northeast1 --service wordpack-backend` 相当をローカル venv の architecture mismatch 回避用 wrapper 経由で実行

未実行項目
- full backend pytest、frontend vitest、Playwright は未実行です。変更範囲は deploy workflow / deploy helper / docs / workflow contract tests で、対象回帰テストと workflow 実行経路の local smoke を優先しました。

残るリスク
- read-only probe は Hosting version 作成、file upload、finalize、release 作成、Firestore index 作成/更新、Cloud Run 実デプロイまでは証明しません。write 権限や quota、release 作成時の最終検証は本番 deploy または staging/canary deploy でのみ完全確認できます。
- `pull_request_target` の認証 probe は安全のため PR コードを checkout せず、base branch の信頼済みコードだけで実行します。PR 側の script 変更は static preflight とテストで検証され、merge 後の base workflow で read-only probe 対象になります。
