### PR TITLE
認証認可ポリシーとサーバー側セッション管理を強化する

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,8 +1,8 @@
-# CI 用の本番相当設定。機密情報を含まないダミー値で構成し、
-# プロダクション向けの厳格なバリデーションを安全に通過させる。
+# CI 用の本番相当設定。機密情報を含まないダミー値で構成する。
+# DISABLE_SESSION_AUTH は本番環境では起動時に拒否されるため、この env では無効化しない。
 ENVIRONMENT=production
-# RateLimit/セッション動作をシンプルにするため、CI ではセッション認証を無効化。
-DISABLE_SESSION_AUTH=true
+DISABLE_SESSION_AUTH=false
+CSRF_PROTECTION_ENABLED=true
 # FastAPI 起動時の秘密鍵バリデーションを通過させる十分な長さの固定値。
 SESSION_SECRET_KEY=CI_fixed_secret_for_security_header_tests_012345
 # TrustedHostMiddleware がワイルドカードを拒否するため、許可ホストを明示。

--- a/apps/backend/backend/app/middleware_stack.py
+++ b/apps/backend/backend/app/middleware_stack.py
@@ -8,6 +8,7 @@ from starlette.middleware.cors import CORSMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from ..middleware import (
+    CsrfProtectionMiddleware,
     GuestWriteBlockMiddleware,
     RateLimitMiddleware,
     RequestIDMiddleware,
@@ -62,8 +63,9 @@ def configure_middleware(app: FastAPI, app_settings: Any) -> None:
     _maybe_add_timeout_middleware(app, app_settings)
     app.add_middleware(RequestIDMiddleware)
     app.add_middleware(GuestWriteBlockMiddleware)
+    app.add_middleware(CsrfProtectionMiddleware)
     # Middleware stack (inner -> outer):
-    # RequestID -> GuestWriteBlock -> AccessLog -> RateLimit
+    # RequestID -> GuestWriteBlock -> CsrfProtection -> AccessLog -> RateLimit
     # -> ForwardedHostTrustedHost -> SecurityHeaders -> ProxyHeaders.
     app.add_middleware(AccessLogAndMetricsMiddleware, app_settings=app_settings)
     app.add_middleware(

--- a/apps/backend/backend/auth.py
+++ b/apps/backend/backend/auth.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
-import uuid
-from datetime import UTC, datetime
+import hashlib
+import secrets
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from fastapi import HTTPException, Request, status
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 
+from .authorization.principal import ANONYMOUS_PRINCIPAL, Principal
 from .config import settings
 from .logging import logger
 from .store import store
@@ -25,8 +29,6 @@ def _build_serializer(salt: str = _SESSION_SALT) -> URLSafeTimedSerializer:
 
 
 def _session_max_age() -> int:
-    """Return the configured session lifetime in seconds."""
-
     try:
         max_age = int(getattr(settings, "session_max_age_seconds", 0))
     except (TypeError, ValueError):  # pragma: no cover - defensive fallback
@@ -35,8 +37,6 @@ def _session_max_age() -> int:
 
 
 def _guest_session_max_age() -> int:
-    """Return the configured guest session lifetime in seconds."""
-
     try:
         max_age = int(getattr(settings, "guest_session_max_age_seconds", 0))
     except (TypeError, ValueError):  # pragma: no cover - defensive fallback
@@ -44,60 +44,233 @@ def _guest_session_max_age() -> int:
     return max(60, max_age or 60 * 60 * 24)
 
 
-def guest_session_cookie_max_age() -> int:
-    """Return the guest session cookie max-age in seconds."""
+def _session_idle_timeout(kind: str) -> int:
+    key = (
+        "guest_session_idle_timeout_seconds"
+        if kind == "guest"
+        else "session_idle_timeout_seconds"
+    )
+    fallback = _guest_session_max_age() if kind == "guest" else _session_max_age()
+    try:
+        configured = int(getattr(settings, key, fallback))
+    except (TypeError, ValueError):  # pragma: no cover - defensive fallback
+        configured = fallback
+    return max(60, configured or fallback)
 
+
+def _last_seen_update_interval() -> int:
+    try:
+        configured = int(
+            getattr(settings, "session_last_seen_update_interval_seconds", 300)
+        )
+    except (TypeError, ValueError):  # pragma: no cover - defensive fallback
+        configured = 300
+    return max(0, configured)
+
+
+def _now() -> datetime:
+    return datetime.now(UTC).replace(microsecond=0)
+
+
+def _now_iso() -> str:
+    return _now().isoformat()
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value.astimezone(UTC) if value.tzinfo else value.replace(tzinfo=UTC)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return parsed.astimezone(UTC) if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _hash_session_context(value: str | None) -> str | None:
+    if not value:
+        return None
+    pepper = settings.session_secret_key.strip()
+    material = f"{pepper}:{value}".encode("utf-8", errors="ignore")
+    return hashlib.sha256(material).hexdigest()
+
+
+def _request_user_agent_hash(request: Request | None) -> str | None:
+    if request is None:
+        return None
+    return _hash_session_context(request.headers.get("user-agent"))
+
+
+def _request_ip_hash(request: Request | None) -> str | None:
+    if request is None or request.client is None:
+        return None
+    return _hash_session_context(request.client.host)
+
+
+def guest_session_cookie_max_age() -> int:
     return _guest_session_max_age()
 
 
-def issue_session_token(google_sub: str) -> str:
-    """Generate a signed session token tied to the Google subject identifier."""
+def _create_session_record(
+    *,
+    kind: str,
+    user_id: str | None,
+    max_age_seconds: int,
+    request: Request | None,
+) -> str:
+    sid = secrets.token_urlsafe(32)
+    issued_at = _now()
+    expires_at = issued_at + timedelta(seconds=max_age_seconds)
+    payload: dict[str, Any] = {
+        "sid": sid,
+        "kind": kind,
+        "user_id": user_id,
+        "issued_at": issued_at.isoformat(),
+        "expires_at": expires_at.isoformat(),
+        "last_seen_at": issued_at.isoformat(),
+        "revoked_at": None,
+        "user_agent_hash": _request_user_agent_hash(request),
+        "created_ip_hash": _request_ip_hash(request),
+    }
+    create_session = getattr(store, "create_session", None)
+    if not callable(create_session):
+        raise RuntimeError("session store is not configured")
+    create_session(payload)
+    return sid
+
+
+def issue_session_token(google_sub: str, request: Request | None = None) -> str:
+    """Generate a signed opaque session token for an authenticated user."""
 
     serializer = _build_serializer(_SESSION_SALT)
-    payload = {
-        "sid": uuid.uuid4().hex,
-        "sub": google_sub,
-        "issued_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
-    }
-    return serializer.dumps(payload)
+    sid = _create_session_record(
+        kind="user",
+        user_id=google_sub,
+        max_age_seconds=_session_max_age(),
+        request=request,
+    )
+    return serializer.dumps({"sid": sid})
 
 
-def verify_session_token(token: str) -> dict:
-    """Decode a signed session token and return the embedded payload."""
+def issue_guest_session_token(request: Request | None = None) -> str:
+    """Generate a signed opaque guest session token for read-only browsing."""
+
+    serializer = _build_serializer(_GUEST_SESSION_SALT)
+    sid = _create_session_record(
+        kind="guest",
+        user_id=None,
+        max_age_seconds=_guest_session_max_age(),
+        request=request,
+    )
+    return serializer.dumps({"sid": sid})
+
+
+def _touch_session_if_needed(sid: str, record: Mapping[str, Any], *, now: datetime) -> None:
+    last_seen_at = _parse_dt(record.get("last_seen_at"))
+    interval = _last_seen_update_interval()
+    if last_seen_at is not None and (now - last_seen_at).total_seconds() < interval:
+        return
+    touch_session = getattr(store, "touch_session", None)
+    if callable(touch_session):
+        touch_session(sid, last_seen_at=now.isoformat())
+
+
+def _validate_session_record(
+    payload: Mapping[str, Any],
+    *,
+    expected_kind: str,
+) -> dict[str, Any]:
+    sid = str(payload.get("sid") or "").strip()
+    if not sid:
+        raise BadSignature("session id missing")
+    get_session = getattr(store, "get_session", None)
+    if not callable(get_session):
+        raise RuntimeError("session store is not configured")
+    record = get_session(sid)
+    if not isinstance(record, Mapping):
+        raise BadSignature("session record not found")
+    if record.get("kind") != expected_kind:
+        raise BadSignature("session kind mismatch")
+    if record.get("revoked_at"):
+        raise BadSignature("session revoked")
+
+    now = _now()
+    expires_at = _parse_dt(record.get("expires_at"))
+    if expires_at is None or now > expires_at:
+        raise SignatureExpired("session expired")
+    last_seen_at = _parse_dt(record.get("last_seen_at"))
+    if last_seen_at is not None:
+        idle_seconds = (now - last_seen_at).total_seconds()
+        if idle_seconds > _session_idle_timeout(expected_kind):
+            raise SignatureExpired("session idle timeout")
+
+    _touch_session_if_needed(sid, record, now=now)
+    user_id = record.get("user_id")
+    result = dict(payload)
+    result["sid"] = sid
+    result["kind"] = expected_kind
+    result["session_id"] = sid
+    if isinstance(user_id, str) and user_id:
+        result["sub"] = user_id
+        result["user_id"] = user_id
+    if expected_kind == "guest":
+        result["mode"] = "guest"
+    return result
+
+
+def verify_session_token(token: str) -> dict[str, Any]:
+    """Decode a signed user session token and validate server-side state."""
 
     serializer = _build_serializer(_SESSION_SALT)
-    return serializer.loads(token, max_age=_session_max_age())
+    payload = serializer.loads(token, max_age=_session_max_age())
+    if not isinstance(payload, Mapping):
+        raise BadSignature("invalid session payload")
+    if payload.get("sub"):
+        # Short-term compatibility for legacy signed payloads generated before
+        # server-side session records were introduced.
+        legacy = dict(payload)
+        legacy.setdefault("kind", "user")
+        legacy.setdefault("session_id", legacy.get("sid"))
+        legacy.setdefault("user_id", legacy.get("sub"))
+        return legacy
+    return _validate_session_record(payload, expected_kind="user")
 
 
-def issue_guest_session_token() -> str:
-    """Generate a signed guest session token for read-only browsing."""
+def verify_guest_session_token(token: str) -> dict[str, Any]:
+    """Decode a signed guest session token and validate server-side state."""
 
     serializer = _build_serializer(_GUEST_SESSION_SALT)
-    payload = {
-        "gid": uuid.uuid4().hex,
-        "issued_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
-        "mode": "guest",
-    }
-    return serializer.dumps(payload)
+    payload = serializer.loads(token, max_age=_guest_session_max_age())
+    if not isinstance(payload, Mapping):
+        raise BadSignature("invalid guest session payload")
+    if payload.get("mode") == "guest" and payload.get("gid"):
+        legacy = dict(payload)
+        legacy.setdefault("kind", "guest")
+        legacy.setdefault("session_id", legacy.get("gid"))
+        return legacy
+    return _validate_session_record(payload, expected_kind="guest")
 
 
-def verify_guest_session_token(token: str) -> dict:
-    """Decode a signed guest session token and return the embedded payload."""
+def revoke_session_token(token: str, *, guest: bool = False) -> bool:
+    """Best-effort server-side revocation for an incoming session token."""
 
-    serializer = _build_serializer(_GUEST_SESSION_SALT)
-    return serializer.loads(token, max_age=_guest_session_max_age())
+    try:
+        payload = verify_guest_session_token(token) if guest else verify_session_token(token)
+    except (SignatureExpired, BadSignature, RuntimeError):
+        return False
+    sid = payload.get("sid") or payload.get("session_id")
+    if not isinstance(sid, str) or not sid:
+        return False
+    revoke_session = getattr(store, "revoke_session", None)
+    if not callable(revoke_session):
+        return False
+    return bool(revoke_session(sid, revoked_at=_now_iso()))
 
 
 def _session_log_context(
     request: Request, *, reason: str, user_id: str | None
 ) -> dict[str, object]:
-    """Compose structured log context aligned with AccessLog fields.
-
-    なぜ: Cloud Run 上でセッション検証失敗を素早くフィルタできるよう、
-    AccessLog と同一キー（path/client_ip/user_agent/request_id）で
-    失敗理由を記録する。
-    """
-
     client_ip = request.client.host if request.client else "unknown"
     return {
         "user_id": user_id,
@@ -110,16 +283,8 @@ def _session_log_context(
 
 
 def read_session_cookie(request: Request, cookie_name: str) -> str | None:
-    """Robustly read the session cookie even when other cookies are non‑RFC compliant.
+    """Read a cookie even when other Cookie header entries are non-RFC values."""
 
-    なぜ: Google Identity Services が発行する `g_state` など一部の Cookie は、値に
-    JSON 文字列をそのまま含めるため `Cookie` ヘッダー全体が RFC に厳密ではなくなり、
-    Python 標準の ``SimpleCookie`` パーサが例外を投げて `request.cookies` を空にして
-    しまうケースがある。その場合でもセッションクッキーだけは確実に取得したいので、
-    まず `request.cookies` を試しつつ、失敗時は生のヘッダーを手動で分解して取得する。
-    """
-
-    # 通常ケース: Starlette が正しく Cookie を構築している場合はこちらで十分。
     try:
         value = request.cookies.get(cookie_name)  # type: ignore[assignment]
     except Exception:  # pragma: no cover - defensive guard
@@ -127,7 +292,6 @@ def read_session_cookie(request: Request, cookie_name: str) -> str | None:
     if value:
         return value  # type: ignore[return-value]
 
-    # フォールバック: Cookie ヘッダーを手動パース（`;` 区切りの単純な形式を前提）。
     raw_header = request.headers.get("cookie") or request.headers.get("Cookie")
     if not raw_header:
         return None
@@ -142,35 +306,20 @@ def read_session_cookie(request: Request, cookie_name: str) -> str | None:
 
 
 def session_cookie_names() -> tuple[str, ...]:
-    """Return ordered cookie names that should carry the session token.
-
-    なぜ: Firebase Hosting は `__session` 以外の Cookie を Cloud Run へ転送しないため、
-    既定名（wp_session など）に加えて __session も必ずミラーする。
-    """
-
     configured = (settings.session_cookie_name or "wp_session").strip()
     primary = configured or "wp_session"
     names = [primary]
     if _FIREBASE_SESSION_COOKIE not in names:
         names.append(_FIREBASE_SESSION_COOKIE)
-    # dict.fromkeys preserves insertion order while removing duplicates.
     return tuple(dict.fromkeys(names))
 
 
 def guest_session_cookie_name() -> str:
-    """Return the cookie name used for signed guest sessions."""
-
     configured = (settings.guest_session_cookie_name or "wp_guest").strip()
     return configured or "wp_guest"
 
 
 def guest_session_cookie_names() -> tuple[str, ...]:
-    """Return cookie names that may carry the signed guest session token.
-
-    Firebase Hosting forwards only `__session` to Cloud Run, so the guest token
-    must be mirrored there just like the authenticated user session token.
-    """
-
     primary = guest_session_cookie_name()
     names = [primary]
     if _FIREBASE_SESSION_COOKIE not in names:
@@ -178,9 +327,15 @@ def guest_session_cookie_names() -> tuple[str, ...]:
     return tuple(dict.fromkeys(names))
 
 
-def resolve_guest_session_cookie(request: Request) -> str | None:
-    """Return the signed guest session token when present."""
+def resolve_session_cookie(request: Request) -> tuple[str | None, str | None]:
+    for cookie_name in session_cookie_names():
+        token = read_session_cookie(request, cookie_name)
+        if token:
+            return cookie_name, token
+    return None, None
 
+
+def resolve_guest_session_cookie(request: Request) -> str | None:
     for cookie_name in guest_session_cookie_names():
         token = read_session_cookie(request, cookie_name)
         if token:
@@ -189,8 +344,6 @@ def resolve_guest_session_cookie(request: Request) -> str | None:
 
 
 def _guest_log_context(request: Request, *, reason: str) -> dict[str, object]:
-    """Compose structured log context for guest-session failures."""
-
     client_ip = request.client.host if request.client else "unknown"
     return {
         "reason": reason,
@@ -201,14 +354,36 @@ def _guest_log_context(request: Request, *, reason: str) -> dict[str, object]:
     }
 
 
-def resolve_session_cookie(request: Request) -> tuple[str | None, str | None]:
-    """Return the first available session cookie value along with its name."""
+def _principal_from_user(user: Mapping[str, str], payload: Mapping[str, Any]) -> Principal:
+    user_id = str(payload.get("sub") or payload.get("user_id") or user.get("google_sub") or "")
+    return Principal(
+        kind="user",
+        user_id=user_id or None,
+        email=user.get("email"),
+        display_name=user.get("display_name"),
+        session_id=str(payload.get("sid") or payload.get("session_id") or "") or None,
+    )
 
-    for cookie_name in session_cookie_names():
-        token = read_session_cookie(request, cookie_name)
-        if token:
-            return cookie_name, token
-    return None, None
+
+def _attach_user_state(
+    request: Request, user: Mapping[str, str], payload: Mapping[str, Any]
+) -> Principal:
+    principal = _principal_from_user(user, payload)
+    request.state.user = dict(user)
+    request.state.user_id = principal.user_id
+    request.state.principal = principal
+    request.state.guest = False
+    return principal
+
+
+def _attach_guest_state(request: Request, payload: Mapping[str, Any]) -> Principal:
+    principal = Principal(
+        kind="guest",
+        session_id=str(payload.get("sid") or payload.get("session_id") or "") or None,
+    )
+    request.state.guest = True
+    request.state.principal = principal
+    return principal
 
 
 def _resolve_authenticated_user(
@@ -217,8 +392,6 @@ def _resolve_authenticated_user(
     log_missing: bool,
     allow_invalid_session: bool = False,
 ) -> dict[str, str] | None:
-    """Resolve an authenticated user from session cookies or return None."""
-
     _cookie_name, raw_token = resolve_session_cookie(request)
     if not raw_token:
         if log_missing:
@@ -266,7 +439,7 @@ def _resolve_authenticated_user(
             detail="Session configuration error",
         ) from exc
 
-    sub = payload.get("sub") if isinstance(payload, dict) else None
+    sub = payload.get("sub") if isinstance(payload, Mapping) else None
     if not sub:
         logger.warning(
             "session_validation_failed",
@@ -277,25 +450,22 @@ def _resolve_authenticated_user(
             detail="Invalid session payload",
         )
 
-    user = store.get_user_by_google_sub(sub)
+    user = store.get_user_by_google_sub(str(sub))
     if user is None:
         logger.warning(
             "session_validation_failed",
-            **_session_log_context(request, reason="user_not_found", user_id=sub),
+            **_session_log_context(request, reason="user_not_found", user_id=str(sub)),
         )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User not found",
         )
 
-    request.state.user = user
-    request.state.user_id = sub
+    _attach_user_state(request, user, payload)
     return user
 
 
 async def get_current_user(request: Request) -> dict[str, str]:
-    """Validate session cookie and attach the authenticated user to the request state."""
-
     user = _resolve_authenticated_user(request, log_missing=True)
     if user is not None:
         return user
@@ -305,9 +475,25 @@ async def get_current_user(request: Request) -> dict[str, str]:
     )
 
 
-async def get_current_user_or_guest(request: Request) -> dict[str, str]:
-    """Allow authenticated users or signed guest sessions for read-only access."""
+async def get_current_user_principal(request: Request) -> Principal:
+    await get_current_user(request)
+    principal = getattr(request.state, "principal", None)
+    if isinstance(principal, Principal) and principal.is_user:
+        return principal
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="User session is required",
+    )
 
+
+def principal_from_request(request: Request) -> Principal:
+    if settings.disable_session_auth:
+        return Principal(kind="user", user_id="test-user")
+    principal = getattr(request.state, "principal", None)
+    return principal if isinstance(principal, Principal) else ANONYMOUS_PRINCIPAL
+
+
+async def get_current_user_or_guest(request: Request) -> dict[str, str]:
     user = _resolve_authenticated_user(
         request,
         log_missing=False,
@@ -366,7 +552,7 @@ async def get_current_user_or_guest(request: Request) -> dict[str, str]:
             detail="Guest session configuration error",
         ) from exc
 
-    if isinstance(payload, dict) and payload.get("mode") != "guest":
+    if isinstance(payload, Mapping) and payload.get("mode") != "guest":
         logger.warning(
             "guest_session_invalid",
             **_guest_log_context(request, reason="missing_guest_mode"),
@@ -376,5 +562,11 @@ async def get_current_user_or_guest(request: Request) -> dict[str, str]:
             detail="Invalid guest session payload",
         )
 
-    request.state.guest = True
+    _attach_guest_state(request, payload)
     return {"mode": "guest"}
+
+
+async def get_current_principal_or_guest(request: Request) -> Principal:
+    await get_current_user_or_guest(request)
+    principal = getattr(request.state, "principal", None)
+    return principal if isinstance(principal, Principal) else ANONYMOUS_PRINCIPAL

--- a/apps/backend/backend/authorization/__init__.py
+++ b/apps/backend/backend/authorization/__init__.py
@@ -1,0 +1,1 @@
+"""Authorization primitives shared by routers and auth dependencies."""

--- a/apps/backend/backend/authorization/dependencies.py
+++ b/apps/backend/backend/authorization/dependencies.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from fastapi import Request
+
+from ..auth import get_current_user_principal
+from ..config import settings
+from .permissions import Permission
+from .policies import ensure_user_write_allowed
+from .principal import Principal
+
+
+def require_user_permission(permission: Permission):
+    """Build a FastAPI dependency that resolves a user Principal.
+
+    The current permission enum is intentionally explicit even though all unsafe
+    writes currently share the same user-only rule. Keeping the permission at the
+    call site prevents future endpoints from silently bypassing policy review.
+    """
+
+    async def _dependency(
+        request: Request,
+    ) -> Principal:
+        _ = permission
+        if settings.disable_session_auth:
+            test_principal = Principal(kind="user", user_id="test-user")
+            request.state.principal = test_principal
+            request.state.user_id = test_principal.user_id
+            return test_principal
+        principal = await get_current_user_principal(request)
+        ensure_user_write_allowed(principal)
+        return principal
+
+    return _dependency

--- a/apps/backend/backend/authorization/errors.py
+++ b/apps/backend/backend/authorization/errors.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+
+def forbidden(detail: str = "Forbidden") -> HTTPException:
+    return HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
+
+
+def not_found(detail: str) -> HTTPException:
+    return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+
+
+def unauthorized(detail: str = "Session cookie is missing") -> HTTPException:
+    return HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=detail)

--- a/apps/backend/backend/authorization/permissions.py
+++ b/apps/backend/backend/authorization/permissions.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class Permission(StrEnum):
+    WORDPACK_READ = "wordpack:read"
+    WORDPACK_CREATE = "wordpack:create"
+    WORDPACK_UPDATE = "wordpack:update"
+    WORDPACK_DELETE = "wordpack:delete"
+    WORDPACK_GENERATE = "wordpack:generate"
+    EXAMPLE_READ = "example:read"
+    EXAMPLE_CREATE = "example:create"
+    EXAMPLE_UPDATE = "example:update"
+    EXAMPLE_DELETE = "example:delete"
+    ARTICLE_READ = "article:read"
+    ARTICLE_CREATE = "article:create"
+    ARTICLE_UPDATE = "article:update"
+    ARTICLE_DELETE = "article:delete"
+    QUIZ_READ = "quiz:read"
+    QUIZ_CREATE = "quiz:create"
+    QUIZ_UPDATE = "quiz:update"
+    QUIZ_DELETE = "quiz:delete"
+    QUIZ_ATTEMPT_WRITE = "quiz_attempt:write"
+    TTS_CREATE = "tts:create"

--- a/apps/backend/backend/authorization/policies.py
+++ b/apps/backend/backend/authorization/policies.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from ..config import settings
+from .errors import forbidden, not_found
+from .principal import Principal
+
+
+@dataclass(frozen=True)
+class ResourceVisibility:
+    """Minimal policy input for content guarded by owner and guest-public flags."""
+
+    exists: bool
+    guest_public: bool = False
+    owner_user_id: str | None = None
+    not_found_detail: str = "Resource not found"
+
+
+def owner_user_id_from_mapping(payload: Mapping[str, Any] | None) -> str | None:
+    if not isinstance(payload, Mapping):
+        return None
+    owner = payload.get("owner_user_id")
+    if isinstance(owner, str) and owner.strip():
+        return owner.strip()
+    metadata = payload.get("metadata")
+    if isinstance(metadata, Mapping):
+        nested_owner = metadata.get("owner_user_id")
+        if isinstance(nested_owner, str) and nested_owner.strip():
+            return nested_owner.strip()
+    return None
+
+
+def ensure_read_allowed(principal: Principal, visibility: ResourceVisibility) -> None:
+    """Raise 404 when a principal must not learn that the resource exists."""
+
+    if not visibility.exists:
+        raise not_found(visibility.not_found_detail)
+
+    if principal.is_guest or principal.is_anonymous:
+        if visibility.guest_public:
+            return
+        raise not_found(visibility.not_found_detail)
+
+    if principal.is_user:
+        enforce_owner = bool(getattr(settings, "enforce_owner_scoping", False))
+        owner_user_id = visibility.owner_user_id
+        if enforce_owner and owner_user_id != principal.user_id:
+            raise not_found(visibility.not_found_detail)
+        if owner_user_id and owner_user_id != principal.user_id and enforce_owner:
+            raise not_found(visibility.not_found_detail)
+        return
+
+    raise not_found(visibility.not_found_detail)
+
+
+def ensure_user_write_allowed(
+    principal: Principal,
+    *,
+    owner_user_id: str | None = None,
+    not_found_detail: str = "Resource not found",
+) -> None:
+    """Require a signed user principal and optionally enforce resource ownership."""
+
+    if principal.is_guest:
+        raise forbidden("Guest mode cannot perform write operations")
+    if not principal.is_user:
+        raise forbidden("User session is required")
+
+    enforce_owner = bool(getattr(settings, "enforce_owner_scoping", False))
+    if enforce_owner and owner_user_id != principal.user_id:
+        raise not_found(not_found_detail)

--- a/apps/backend/backend/authorization/principal.py
+++ b/apps/backend/backend/authorization/principal.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+PrincipalKind = Literal["anonymous", "guest", "user"]
+
+
+@dataclass(frozen=True)
+class Principal:
+    """Request principal resolved from signed, server-side session state."""
+
+    kind: PrincipalKind
+    user_id: str | None = None
+    email: str | None = None
+    display_name: str | None = None
+    session_id: str | None = None
+
+    @property
+    def is_user(self) -> bool:
+        return self.kind == "user" and bool(self.user_id)
+
+    @property
+    def is_guest(self) -> bool:
+        return self.kind == "guest"
+
+    @property
+    def is_anonymous(self) -> bool:
+        return self.kind == "anonymous"
+
+
+ANONYMOUS_PRINCIPAL = Principal(kind="anonymous")

--- a/apps/backend/backend/flows/article_import.py
+++ b/apps/backend/backend/flows/article_import.py
@@ -360,6 +360,9 @@ class ArticleImportFlow:
         "december",
     }
 
+    def __init__(self, *, owner_user_id: str | None = None) -> None:
+        self._owner_user_id = owner_user_id
+
     # ---- 役割別プロンプト（サブグラフ相当） ----
     def _prompt_title(self, text: str) -> str:
         return (
@@ -518,7 +521,14 @@ CEFR A1〜A2 の日常語（挨拶・カレンダー/時間語・基本動詞 ge
                 wp_id = generate_word_pack_id()
 
                 try:
-                    store.save_word_pack(wp_id, normalized, empty_word_pack.model_dump_json())
+                    store.save_word_pack(
+                        wp_id,
+                        normalized,
+                        empty_word_pack.model_dump_json(),
+                        metadata={"owner_user_id": self._owner_user_id}
+                        if self._owner_user_id
+                        else None,
+                    )
                     status = "created"
                     if lookup_error and warning_msg is None:
                         warning_msg = (
@@ -857,6 +867,7 @@ CEFR A1〜A2 の日常語（挨拶・カレンダー/時間語・基本動詞 ge
                         generation_started_at=started_at,
                         generation_completed_at=completed_at,
                         generation_duration_ms=duration_ms,
+                        owner_user_id=self._owner_user_id,
                     )
                     meta = store.get_article(article_id)
                     created_at = ""
@@ -963,6 +974,7 @@ CEFR A1〜A2 の日常語（挨拶・カレンダー/時間語・基本動詞 ge
                                 generation_started_at=started_at_db,
                                 generation_completed_at=completed_at_db,
                                 generation_duration_ms=fixed_duration,
+                                owner_user_id=self._owner_user_id,
                             )
                             s["llm_model"] = fixed_model or None
                             s["llm_params"] = fixed_params or None

--- a/apps/backend/backend/flows/category_generate_import.py
+++ b/apps/backend/backend/flows/category_generate_import.py
@@ -36,6 +36,7 @@ class CategoryGenerateAndImportFlow:
         model: Optional[str] = None,
         reasoning: Optional[dict] = None,
         text: Optional[dict] = None,
+        owner_user_id: str | None = None,
     ) -> None:
         self._llm = get_llm_provider(
             model_override=model,
@@ -54,6 +55,7 @@ class CategoryGenerateAndImportFlow:
             # ArticleImportFlow は text_opts というキー名を採用しているため、ここで変換
             "text_opts": text,
         }
+        self._owner_user_id = owner_user_id
 
     def _prompt_lemma(
         self, category: ExampleCategory, attempted: list[str], avoid_existing: list[str]
@@ -222,7 +224,14 @@ class CategoryGenerateAndImportFlow:
         with span(
             trace=None, name="category.ensure_wordpack.create", input={"lemma": lemma}
         ):
-            store.save_word_pack(wp_id, lemma, empty_word_pack.model_dump_json())
+            store.save_word_pack(
+                wp_id,
+                lemma,
+                empty_word_pack.model_dump_json(),
+                metadata={"owner_user_id": self._owner_user_id}
+                if self._owner_user_id
+                else None,
+            )
         return wp_id
 
     def _generate_two_examples(
@@ -272,7 +281,7 @@ class CategoryGenerateAndImportFlow:
         # Import each example as an article
         article_ids: list[str] = []
         failures: list[dict[str, Any]] = []
-        art_flow = ArticleImportFlow()
+        art_flow = ArticleImportFlow(owner_user_id=self._owner_user_id)
         for idx, ex in enumerate(items):
             try:
                 with span(

--- a/apps/backend/backend/flows/quiz_generate.py
+++ b/apps/backend/backend/flows/quiz_generate.py
@@ -180,9 +180,16 @@ def _stable_missing_link_id(quiz_id: str, lemma: str) -> str:
 
 
 class QuizGenerateFlow:
-    def __init__(self, *, store: object, llm: object | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        store: object,
+        llm: object | None = None,
+        owner_user_id: str | None = None,
+    ) -> None:
         self._store = store
         self._llm = llm
+        self._owner_user_id = owner_user_id
 
     def run(self, req: QuizGenerateRequest) -> Quiz:
         generation_started_at = _now_iso()
@@ -263,6 +270,7 @@ class QuizGenerateFlow:
             "generation_completed_at": generation_completed_at,
             "generation_duration_ms": duration_ms,
             "guest_public": False,
+            "owner_user_id": self._owner_user_id,
             "created_at": generation_completed_at,
             "updated_at": generation_completed_at,
         }

--- a/apps/backend/backend/infrastructure/firestore/repositories/app_store.py
+++ b/apps/backend/backend/infrastructure/firestore/repositories/app_store.py
@@ -73,6 +73,9 @@ class AppFirestoreRepository:
     def count_word_packs(self) -> int:
         return self.wordpacks.count_word_packs()
 
+    def count_owned_word_packs(self, owner_user_id: str) -> int:
+        return self.wordpacks.count_owned_word_packs(owner_user_id)
+
     def get_word_pack_metadata(self, word_pack_id: str) -> Mapping[str, Any] | None:
         return self.wordpacks.get_word_pack_metadata(word_pack_id)
 
@@ -88,6 +91,13 @@ class AppFirestoreRepository:
         self, limit: int = 50, offset: int = 0
     ) -> list[tuple[str, str, str, str, str, bool, Mapping[str, int], int, int, bool]]:
         return self.wordpacks.list_public_word_packs_with_flags(limit=limit, offset=offset)
+
+    def list_owned_word_packs_with_flags(
+        self, owner_user_id: str, limit: int = 50, offset: int = 0
+    ) -> list[tuple[str, str, str, str, str, bool, Mapping[str, int], int, int, bool]]:
+        return self.wordpacks.list_owned_word_packs_with_flags(
+            owner_user_id, limit=limit, offset=offset
+        )
 
     def delete_word_pack(self, word_pack_id: str) -> bool:
         return self.wordpacks.delete_word_pack(word_pack_id)
@@ -173,6 +183,9 @@ class AppFirestoreRepository:
             example_id, checked_increment, learned_increment
         )
 
+    def get_example_word_pack_id(self, example_id: int) -> str | None:
+        return self.examples.get_example_word_pack_id(example_id)
+
     def delete_example(self, word_pack_id: str, category: str, index: int) -> int | None:
         return self.examples.delete_example(word_pack_id, category, index)
 
@@ -256,14 +269,27 @@ class AppFirestoreRepository:
         return self.articles.get_article(article_id)
 
     def list_articles(
-        self, limit: int = 50, offset: int = 0, *, public_only: bool = False
+        self,
+        limit: int = 50,
+        offset: int = 0,
+        *,
+        public_only: bool = False,
+        owner_user_id: str | None = None,
     ) -> list[tuple[str, str, str, str, bool]]:
         return self.articles.list_articles(
-            limit=limit, offset=offset, public_only=public_only
+            limit=limit,
+            offset=offset,
+            public_only=public_only,
+            owner_user_id=owner_user_id,
         )
 
-    def count_articles(self, *, public_only: bool = False) -> int:
-        return self.articles.count_articles(public_only=public_only)
+    def count_articles(
+        self, *, public_only: bool = False, owner_user_id: str | None = None
+    ) -> int:
+        return self.articles.count_articles(
+            public_only=public_only,
+            owner_user_id=owner_user_id,
+        )
 
     def update_article_guest_public(self, article_id: str, guest_public: bool) -> bool | None:
         return self.articles.update_article_guest_public(article_id, guest_public)
@@ -292,11 +318,22 @@ class AppFirestoreRepository:
         offset: int = 0,
         *,
         public_only: bool = False,
+        owner_user_id: str | None = None,
     ) -> list[dict[str, Any]]:
-        return self.quizzes.list_quizzes(limit=limit, offset=offset, public_only=public_only)
+        return self.quizzes.list_quizzes(
+            limit=limit,
+            offset=offset,
+            public_only=public_only,
+            owner_user_id=owner_user_id,
+        )
 
-    def count_quizzes(self, *, public_only: bool = False) -> int:
-        return self.quizzes.count_quizzes(public_only=public_only)
+    def count_quizzes(
+        self, *, public_only: bool = False, owner_user_id: str | None = None
+    ) -> int:
+        return self.quizzes.count_quizzes(
+            public_only=public_only,
+            owner_user_id=owner_user_id,
+        )
 
     def delete_quiz(self, quiz_id: str) -> bool:
         return self.quizzes.delete_quiz(quiz_id)

--- a/apps/backend/backend/infrastructure/firestore/repositories/app_store.py
+++ b/apps/backend/backend/infrastructure/firestore/repositories/app_store.py
@@ -5,6 +5,7 @@ from .articles import FirestoreArticleRepository
 from .examples import FirestoreExampleRepository
 from .quizzes import FirestoreQuizRepository, QuizGenerationJobStatus
 from .regenerate_jobs import FirestoreRegenerateJobRepository, RegenerateJobStatus
+from .sessions import FirestoreSessionRepository
 from .users import FirestoreUserRepository
 from .wordpacks import FirestoreWordPackRepository
 
@@ -18,6 +19,7 @@ class AppFirestoreRepository:
     article_repository_cls = FirestoreArticleRepository
     quiz_repository_cls = FirestoreQuizRepository
     regenerate_job_repository_cls = FirestoreRegenerateJobRepository
+    session_repository_cls = FirestoreSessionRepository
 
     def __init__(self, *, client: firestore.Client | None = None) -> None:
         self._client = client or firestore.Client()
@@ -27,6 +29,7 @@ class AppFirestoreRepository:
         self.articles = self.article_repository_cls(self._client)
         self.quizzes = self.quiz_repository_cls(self._client)
         self.regenerate_jobs = self.regenerate_job_repository_cls(self._client)
+        self.sessions = self.session_repository_cls(self._client)
 
     # --- Users ---
     def record_user_login(
@@ -126,6 +129,9 @@ class AppFirestoreRepository:
             category_counts=category_counts,
             guest_public=guest_public,
         )
+
+    def get_word_pack_visibility(self, word_pack_id: str) -> Mapping[str, Any] | None:
+        return self.wordpacks.get_word_pack_visibility(word_pack_id)
 
     # --- Regenerate jobs ---
     def create_regenerate_job(
@@ -265,6 +271,9 @@ class AppFirestoreRepository:
     def delete_article(self, article_id: str) -> bool:
         return self.articles.delete_article(article_id)
 
+    def get_article_visibility(self, article_id: str) -> Mapping[str, Any] | None:
+        return self.articles.get_article_visibility(article_id)
+
     # --- Quizzes ---
     def save_quiz(
         self,
@@ -294,6 +303,9 @@ class AppFirestoreRepository:
 
     def update_quiz_guest_public(self, quiz_id: str, guest_public: bool) -> bool | None:
         return self.quizzes.update_quiz_guest_public(quiz_id, guest_public)
+
+    def get_quiz_visibility(self, quiz_id: str) -> Mapping[str, Any] | None:
+        return self.quizzes.get_quiz_visibility(quiz_id)
 
     def save_quiz_attempt(self, attempt_id: str, payload: Mapping[str, Any]) -> None:
         self.quizzes.save_quiz_attempt(attempt_id, payload)
@@ -339,6 +351,19 @@ class AppFirestoreRepository:
 
     def get_quiz_generation_job(self, job_id: str) -> Mapping[str, Any] | None:
         return self.quizzes.get_quiz_generation_job(job_id)
+
+    # --- Sessions ---
+    def create_session(self, payload: Mapping[str, Any]) -> None:
+        self.sessions.create_session(payload)
+
+    def get_session(self, sid: str) -> Mapping[str, Any] | None:
+        return self.sessions.get_session(sid)
+
+    def revoke_session(self, sid: str, *, revoked_at: str) -> bool:
+        return self.sessions.revoke_session(sid, revoked_at=revoked_at)
+
+    def touch_session(self, sid: str, *, last_seen_at: str) -> bool:
+        return self.sessions.touch_session(sid, last_seen_at=last_seen_at)
 
 
 AppFirestoreStore = AppFirestoreRepository

--- a/apps/backend/backend/infrastructure/firestore/repositories/articles.py
+++ b/apps/backend/backend/infrastructure/firestore/repositories/articles.py
@@ -45,6 +45,7 @@ class FirestoreArticleRepository(FirestoreBaseRepository):
                 else stored.get("generation_duration_ms")
             ),
             "guest_public": bool(kwargs.get("guest_public", stored.get("guest_public", False))),
+            "owner_user_id": kwargs.get("owner_user_id", stored.get("owner_user_id")),
         }
         doc_ref.set(payload, merge=True)
         if related_word_packs is not None:
@@ -162,6 +163,17 @@ class FirestoreArticleRepository(FirestoreBaseRepository):
             if data.get("article_id") == article_id:
                 link.reference.delete()
         return True
+
+    def get_article_visibility(self, article_id: str) -> dict[str, Any] | None:
+        doc = self._articles.document(article_id).get()
+        if not doc.exists:
+            return None
+        data = doc.to_dict() or {}
+        owner_raw = data.get("owner_user_id")
+        return {
+            "guest_public": bool(data.get("guest_public", False)),
+            "owner_user_id": str(owner_raw).strip() if owner_raw else None,
+        }
 
 
 FirestoreArticleStore = FirestoreArticleRepository

--- a/apps/backend/backend/infrastructure/firestore/repositories/articles.py
+++ b/apps/backend/backend/infrastructure/firestore/repositories/articles.py
@@ -118,11 +118,18 @@ class FirestoreArticleRepository(FirestoreBaseRepository):
         )
 
     def list_articles(
-        self, limit: int = 50, offset: int = 0, *, public_only: bool = False
+        self,
+        limit: int = 50,
+        offset: int = 0,
+        *,
+        public_only: bool = False,
+        owner_user_id: str | None = None,
     ) -> list[tuple[str, str, str, str, bool]]:
         query = self._articles
         if public_only:
             query = query.where("guest_public", "==", True)
+        elif owner_user_id is not None:
+            query = query.where("owner_user_id", "==", owner_user_id)
         docs = list(query.stream())
         docs.sort(key=lambda d: str((d.to_dict() or {}).get("created_at") or ""), reverse=True)
         sliced = docs[offset : offset + limit]
@@ -137,10 +144,14 @@ class FirestoreArticleRepository(FirestoreBaseRepository):
             for doc in sliced
         ]
 
-    def count_articles(self, *, public_only: bool = False) -> int:
+    def count_articles(
+        self, *, public_only: bool = False, owner_user_id: str | None = None
+    ) -> int:
         query = self._articles
         if public_only:
             query = query.where("guest_public", "==", True)
+        elif owner_user_id is not None:
+            query = query.where("owner_user_id", "==", owner_user_id)
         return sum(1 for _ in query.stream())
 
     def update_article_guest_public(self, article_id: str, guest_public: bool) -> bool | None:

--- a/apps/backend/backend/infrastructure/firestore/repositories/examples.py
+++ b/apps/backend/backend/infrastructure/firestore/repositories/examples.py
@@ -215,6 +215,11 @@ class FirestoreExampleRepository(FirestoreBaseRepository):
         pack_meta = self._wordpacks.get_word_pack_metadata(word_pack_id) or {}
         lemma_label = str(pack_meta.get("lemma_label") or "")
         sense_title = str(pack_meta.get("sense_title") or "")
+        metadata = pack_meta.get("metadata") or {}
+        owner_user_id = None
+        if isinstance(metadata, Mapping):
+            owner_raw = metadata.get("owner_user_id")
+            owner_user_id = str(owner_raw).strip() if owner_raw else None
         inserted = 0
         for item in items:
             en = str((item or {}).get("en") or "").strip()
@@ -248,6 +253,7 @@ class FirestoreExampleRepository(FirestoreBaseRepository):
                     "pack_updated_at": now,
                     "lemma": lemma_label,
                     "sense_title": sense_title,
+                    "owner_user_id": owner_user_id,
                     **self._build_search_payload(en),
                 }
             )

--- a/apps/backend/backend/infrastructure/firestore/repositories/examples.py
+++ b/apps/backend/backend/infrastructure/firestore/repositories/examples.py
@@ -144,6 +144,14 @@ class FirestoreExampleRepository(FirestoreBaseRepository):
             )
         return (str(data.get("word_pack_id") or ""), next_checked, next_learned)
 
+    def get_example_word_pack_id(self, example_id: int) -> str | None:
+        snapshot = self._examples.document(str(example_id)).get()
+        if not snapshot.exists:
+            return None
+        data = snapshot.to_dict() or {}
+        word_pack_id = str(data.get("word_pack_id") or "").strip()
+        return word_pack_id or None
+
     def delete_example(self, word_pack_id: str, category: str, index: int) -> int | None:
         if index < 0:
             return None

--- a/apps/backend/backend/infrastructure/firestore/repositories/quizzes.py
+++ b/apps/backend/backend/infrastructure/firestore/repositories/quizzes.py
@@ -65,6 +65,7 @@ class FirestoreQuizRepository(FirestoreBaseRepository):
             "generation_completed_at": payload.get("generation_completed_at"),
             "generation_duration_ms": payload.get("generation_duration_ms"),
             "guest_public": bool(payload.get("guest_public", False)),
+            "owner_user_id": payload.get("owner_user_id", stored.get("owner_user_id")),
             "created_at": payload.get("created_at") or stored.get("created_at") or now,
             "updated_at": payload.get("updated_at") or now,
         }
@@ -113,6 +114,7 @@ class FirestoreQuizRepository(FirestoreBaseRepository):
             "generation_completed_at": data.get("generation_completed_at"),
             "generation_duration_ms": data.get("generation_duration_ms"),
             "guest_public": bool(data.get("guest_public", False)),
+            "owner_user_id": data.get("owner_user_id"),
             "created_at": str(data.get("created_at") or ""),
             "updated_at": str(data.get("updated_at") or ""),
         }
@@ -168,6 +170,17 @@ class FirestoreQuizRepository(FirestoreBaseRepository):
         doc_ref.update({"guest_public": value, "updated_at": self._now_iso()})
         return value
 
+    def get_quiz_visibility(self, quiz_id: str) -> dict[str, Any] | None:
+        doc = self._quizzes.document(quiz_id).get()
+        if not doc.exists:
+            return None
+        data = doc.to_dict() or {}
+        owner_raw = data.get("owner_user_id")
+        return {
+            "guest_public": bool(data.get("guest_public", False)),
+            "owner_user_id": str(owner_raw).strip() if owner_raw else None,
+        }
+
     def save_quiz_attempt(self, attempt_id: str, payload: Mapping[str, Any]) -> None:
         now = self._now_iso()
         self._quiz_attempts.document(attempt_id).set(
@@ -181,6 +194,7 @@ class FirestoreQuizRepository(FirestoreBaseRepository):
                 "started_at": payload.get("started_at"),
                 "submitted_at": payload.get("submitted_at") or now,
                 "elapsed_ms": payload.get("elapsed_ms"),
+                "owner_user_id": payload.get("owner_user_id"),
                 "created_at": payload.get("created_at") or now,
             }
         )

--- a/apps/backend/backend/infrastructure/firestore/repositories/quizzes.py
+++ b/apps/backend/backend/infrastructure/firestore/repositories/quizzes.py
@@ -131,21 +131,36 @@ class FirestoreQuizRepository(FirestoreBaseRepository):
         offset: int = 0,
         *,
         public_only: bool = False,
+        owner_user_id: str | None = None,
     ) -> list[dict[str, Any]]:
         docs = list(self._quizzes.stream())
         if public_only:
             docs = [doc for doc in docs if bool((doc.to_dict() or {}).get("guest_public", False))]
+        elif owner_user_id is not None:
+            docs = [
+                doc
+                for doc in docs
+                if str((doc.to_dict() or {}).get("owner_user_id") or "") == owner_user_id
+            ]
         docs.sort(key=lambda d: str((d.to_dict() or {}).get("created_at") or ""), reverse=True)
         sliced = docs[max(0, offset) : max(0, offset) + max(0, limit)]
         return [self._hydrate_quiz(doc.id, doc.to_dict() or {}) for doc in sliced]
 
-    def count_quizzes(self, *, public_only: bool = False) -> int:
-        if not public_only:
-            return sum(1 for _ in self._quizzes.stream())
+    def count_quizzes(self, *, public_only: bool = False, owner_user_id: str | None = None) -> int:
+        if public_only:
+            return sum(
+                1
+                for snapshot in self._quizzes.stream()
+                if bool((snapshot.to_dict() or {}).get("guest_public", False))
+            )
+        if owner_user_id is not None:
+            return sum(
+                1
+                for snapshot in self._quizzes.stream()
+                if str((snapshot.to_dict() or {}).get("owner_user_id") or "") == owner_user_id
+            )
         return sum(
-            1
-            for snapshot in self._quizzes.stream()
-            if bool((snapshot.to_dict() or {}).get("guest_public", False))
+            1 for _ in self._quizzes.stream()
         )
 
     def delete_quiz(self, quiz_id: str) -> bool:

--- a/apps/backend/backend/infrastructure/firestore/repositories/sessions.py
+++ b/apps/backend/backend/infrastructure/firestore/repositories/sessions.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from .base import Any, FirestoreBaseRepository, Mapping, firestore
+
+
+class FirestoreSessionRepository(FirestoreBaseRepository):
+    """Server-side session records backing signed opaque cookie tokens."""
+
+    def __init__(self, client: firestore.Client):
+        super().__init__(client)
+        self._sessions = client.collection("sessions")
+
+    def create_session(self, payload: Mapping[str, Any]) -> None:
+        sid = str(payload.get("sid") or "").strip()
+        if not sid:
+            raise ValueError("sid is required")
+        self._sessions.document(sid).set(dict(payload))
+
+    def get_session(self, sid: str) -> Mapping[str, Any] | None:
+        snapshot = self._sessions.document(str(sid)).get()
+        if not snapshot.exists:
+            return None
+        return snapshot.to_dict() or {}
+
+    def revoke_session(self, sid: str, *, revoked_at: str) -> bool:
+        doc_ref = self._sessions.document(str(sid))
+        snapshot = doc_ref.get()
+        if not snapshot.exists:
+            return False
+        doc_ref.update({"revoked_at": revoked_at, "updated_at": revoked_at})
+        return True
+
+    def touch_session(self, sid: str, *, last_seen_at: str) -> bool:
+        doc_ref = self._sessions.document(str(sid))
+        snapshot = doc_ref.get()
+        if not snapshot.exists:
+            return False
+        doc_ref.update({"last_seen_at": last_seen_at, "updated_at": last_seen_at})
+        return True
+
+
+FirestoreSessionStore = FirestoreSessionRepository
+
+__all__ = ["FirestoreSessionRepository", "FirestoreSessionStore"]

--- a/apps/backend/backend/infrastructure/firestore/repositories/wordpacks.py
+++ b/apps/backend/backend/infrastructure/firestore/repositories/wordpacks.py
@@ -197,6 +197,17 @@ class FirestoreWordPackRepository(FirestoreBaseRepository):
             raise RuntimeError(msg) from exc
         return self._extract_count_from_aggregation(aggregation)
 
+    def count_owned_word_packs(self, owner_user_id: str) -> int:
+        """Return WordPack count visible to the owner-scoped strict mode."""
+
+        query = self._ordered_word_pack_query().where("metadata.owner_user_id", "==", owner_user_id)
+        try:
+            aggregation = query.count().get()
+        except AttributeError as exc:  # pragma: no cover - defensive fallback
+            msg = "Firestore client does not support aggregation queries"
+            raise RuntimeError(msg) from exc
+        return self._extract_count_from_aggregation(aggregation)
+
     def has_guest_demo_word_pack(self) -> bool:
         """ゲスト閲覧用のデモデータが存在するかを軽量クエリで確認する。"""
 
@@ -209,32 +220,40 @@ class FirestoreWordPackRepository(FirestoreBaseRepository):
         self, limit: int = 50, offset: int = 0
     ) -> list[tuple[str, str, str, str, str, bool, Mapping[str, int], int, int, bool]]:
         docs = self._fetch_word_pack_snapshots(limit, offset)
-        results: list[tuple[str, str, str, str, str, bool, Mapping[str, int], int, int, bool]] = []
-        for doc in docs:
-            data = doc.to_dict() or {}
-            counts_raw = data.get("examples_category_counts") or {}
-            counts = {cat: int(counts_raw.get(cat, 0)) for cat in EXAMPLE_CATEGORIES}
-            total = sum(counts.values())
-            checked = normalize_non_negative_int(data.get("checked_only_count"))
-            learned = normalize_non_negative_int(data.get("learned_count"))
-            metadata = data.get("metadata") or {}
-            results.append(
-                (
-                    doc.id,
-                    str(data.get("lemma_label") or ""),
-                    str(data.get("sense_title") or ""),
-                    str(data.get("created_at") or ""),
-                    str(data.get("updated_at") or ""),
-                    total == 0,
-                    counts,
-                    checked,
-                    learned,
-                    bool(metadata.get("guest_public", False))
-                    if isinstance(metadata, Mapping)
-                    else False,
-                )
-            )
-        return results
+        return [self._word_pack_list_item_with_flags(doc) for doc in docs]
+
+    def list_owned_word_packs_with_flags(
+        self, owner_user_id: str, limit: int = 50, offset: int = 0
+    ) -> list[tuple[str, str, str, str, str, bool, Mapping[str, int], int, int, bool]]:
+        query = self._ordered_word_pack_query().where("metadata.owner_user_id", "==", owner_user_id)
+        if offset:
+            query = query.offset(max(0, int(offset)))
+        query = query.limit(max(0, int(limit)))
+        return [self._word_pack_list_item_with_flags(doc) for doc in query.stream()]
+
+    def _word_pack_list_item_with_flags(
+        self, doc: firestore.DocumentSnapshot
+    ) -> tuple[str, str, str, str, str, bool, Mapping[str, int], int, int, bool]:
+        data = doc.to_dict() or {}
+        counts_raw = data.get("examples_category_counts") or {}
+        counts = {cat: int(counts_raw.get(cat, 0)) for cat in EXAMPLE_CATEGORIES}
+        total = sum(counts.values())
+        checked = normalize_non_negative_int(data.get("checked_only_count"))
+        learned = normalize_non_negative_int(data.get("learned_count"))
+        metadata = data.get("metadata") or {}
+        guest_public = bool(metadata.get("guest_public", False)) if isinstance(metadata, Mapping) else False
+        return (
+            doc.id,
+            str(data.get("lemma_label") or ""),
+            str(data.get("sense_title") or ""),
+            str(data.get("created_at") or ""),
+            str(data.get("updated_at") or ""),
+            total == 0,
+            counts,
+            checked,
+            learned,
+            guest_public,
+        )
 
     def list_public_word_packs_with_flags(
         self, limit: int = 50, offset: int = 0
@@ -243,33 +262,7 @@ class FirestoreWordPackRepository(FirestoreBaseRepository):
         if offset:
             query = query.offset(max(0, int(offset)))
         query = query.limit(max(0, int(limit)))
-        docs = list(query.stream())
-        results: list[tuple[str, str, str, str, str, bool, Mapping[str, int], int, int, bool]] = []
-        for doc in docs:
-            data = doc.to_dict() or {}
-            counts_raw = data.get("examples_category_counts") or {}
-            counts = {cat: int(counts_raw.get(cat, 0)) for cat in EXAMPLE_CATEGORIES}
-            total = sum(counts.values())
-            checked = normalize_non_negative_int(data.get("checked_only_count"))
-            learned = normalize_non_negative_int(data.get("learned_count"))
-            metadata = data.get("metadata") or {}
-            results.append(
-                (
-                    doc.id,
-                    str(data.get("lemma_label") or ""),
-                    str(data.get("sense_title") or ""),
-                    str(data.get("created_at") or ""),
-                    str(data.get("updated_at") or ""),
-                    total == 0,
-                    counts,
-                    checked,
-                    learned,
-                    bool(metadata.get("guest_public", False))
-                    if isinstance(metadata, Mapping)
-                    else False,
-                )
-            )
-        return results
+        return [self._word_pack_list_item_with_flags(doc) for doc in query.stream()]
 
     def is_word_pack_guest_public(self, word_pack_id: str) -> bool:
         payload = self.get_word_pack_metadata(word_pack_id) or {}

--- a/apps/backend/backend/infrastructure/firestore/repositories/wordpacks.py
+++ b/apps/backend/backend/infrastructure/firestore/repositories/wordpacks.py
@@ -100,6 +100,10 @@ class FirestoreWordPackRepository(FirestoreBaseRepository):
                 if isinstance(existing_metadata, Mapping)
                 else dict(metadata)
             )
+        owner_user_id = None
+        if isinstance(metadata_payload, Mapping):
+            owner_raw = metadata_payload.get("owner_user_id")
+            owner_user_id = str(owner_raw).strip() if owner_raw else None
         created_at = (
             str(existing_data.get("created_at") or now) if existing.exists else now
         )
@@ -111,6 +115,7 @@ class FirestoreWordPackRepository(FirestoreBaseRepository):
             updated_at=now,
             existing_example_total=existing_examples_total,
             is_total_confident=counts_confident,
+            owner_user_id=owner_user_id,
         )
         payload = {
             "lemma_id": lemma_id,
@@ -424,6 +429,7 @@ class FirestoreWordPackRepository(FirestoreBaseRepository):
         updated_at: str,
         existing_example_total: int | None = None,
         is_total_confident: bool = False,
+        owner_user_id: str | None = None,
     ) -> dict[str, int]:
         # 例文数が 0 だと確実に分かっている場合のみ削除クエリを省略し、それ以外では安全側に倒す。
         should_delete_existing = not is_total_confident or existing_example_total not in (None, 0)
@@ -471,6 +477,7 @@ class FirestoreWordPackRepository(FirestoreBaseRepository):
                     "pack_updated_at": updated_at,
                     "lemma": lemma,
                     "sense_title": sense_title,
+                    "owner_user_id": owner_user_id,
                     **self._build_search_payload(en),
                 }
             )
@@ -600,6 +607,22 @@ class FirestoreWordPackRepository(FirestoreBaseRepository):
         if not snapshot.exists:
             return None
         return snapshot.to_dict() or {}
+
+    def get_word_pack_visibility(self, word_pack_id: str) -> Mapping[str, Any] | None:
+        payload = self.get_word_pack_metadata(word_pack_id)
+        if not isinstance(payload, Mapping):
+            return None
+        metadata = payload.get("metadata") or {}
+        owner_user_id = None
+        guest_public = False
+        if isinstance(metadata, Mapping):
+            owner_raw = metadata.get("owner_user_id")
+            owner_user_id = str(owner_raw).strip() if owner_raw else None
+            guest_public = bool(metadata.get("guest_public", False))
+        return {
+            "guest_public": guest_public,
+            "owner_user_id": owner_user_id,
+        }
 
     def _upsert_lemma(
         self,

--- a/apps/backend/backend/infrastructure/llm/quiz_generator.py
+++ b/apps/backend/backend/infrastructure/llm/quiz_generator.py
@@ -8,6 +8,9 @@ from ...models.quiz import Quiz, QuizGenerateRequest
 
 
 class QuizGenerateFlowAdapter(QuizGenerator):
+    def __init__(self, *, owner_user_id: str | None = None) -> None:
+        self._owner_user_id = owner_user_id
+
     async def generate(self, req: QuizGenerateRequest, store: object) -> Quiz:
-        flow = QuizGenerateFlow(store=store)
+        flow = QuizGenerateFlow(store=store, owner_user_id=self._owner_user_id)
         return await anyio.to_thread.run_sync(flow.run, req)

--- a/apps/backend/backend/middleware/__init__.py
+++ b/apps/backend/backend/middleware/__init__.py
@@ -20,6 +20,7 @@ from ..auth import (
 )
 from ..config import settings
 from ..logging import logger
+from .csrf import CsrfProtectionMiddleware
 
 # Forwarded host validation middleware lives in a dedicated module to keep
 # host header handling isolated from other cross-cutting middleware concerns.
@@ -31,6 +32,7 @@ __all__ = [
     "RequestIDMiddleware",
     "RateLimitMiddleware",
     "GuestWriteBlockMiddleware",
+    "CsrfProtectionMiddleware",
 ]
 
 
@@ -344,13 +346,15 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             )
             return self._anon_bucket_key, False
 
-        sub = payload.get("sub") if isinstance(payload, dict) else None
-        if isinstance(sub, str) and sub:
-            return sub, True
+        if isinstance(payload, dict):
+            for key in ("sub", "user_id", "session_id", "sid"):
+                value = payload.get(key)
+                if isinstance(value, str) and value:
+                    return value, True
 
         logger.debug(
             "rate_limit_session_invalid",
-            reason="missing_sub",
+            reason="missing_session_identity",
             client_ip=client_ip,
         )
         return self._anon_bucket_key, False

--- a/apps/backend/backend/middleware/csrf.py
+++ b/apps/backend/backend/middleware/csrf.py
@@ -32,12 +32,14 @@ class CsrfProtectionMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         sec_fetch_site = (request.headers.get("sec-fetch-site") or "").lower()
+        origin = request.headers.get("origin")
+        if origin:
+            if not self._is_allowed_origin(request, origin):
+                return self._reject(request, reason="origin_mismatch", origin=origin)
+            return await call_next(request)
+
         if sec_fetch_site == "cross-site":
             return self._reject(request, reason="fetch_metadata_cross_site")
-
-        origin = request.headers.get("origin")
-        if origin and not self._is_allowed_origin(request, origin):
-            return self._reject(request, reason="origin_mismatch", origin=origin)
 
         return await call_next(request)
 

--- a/apps/backend/backend/middleware/csrf.py
+++ b/apps/backend/backend/middleware/csrf.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+from urllib.parse import urlsplit
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse, Response
+
+from ..config import settings
+from ..logging import logger
+
+
+class CsrfProtectionMiddleware(BaseHTTPMiddleware):
+    """Block browser cross-site unsafe requests before auth cookies are used."""
+
+    _unsafe_methods = {"POST", "PUT", "PATCH", "DELETE"}
+    _local_dev_origins = {
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        "http://testserver",
+    }
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:  # type: ignore[override]
+        if not getattr(settings, "csrf_protection_enabled", True):
+            return await call_next(request)
+        if request.method.upper() not in self._unsafe_methods:
+            return await call_next(request)
+
+        sec_fetch_site = (request.headers.get("sec-fetch-site") or "").lower()
+        if sec_fetch_site == "cross-site":
+            return self._reject(request, reason="fetch_metadata_cross_site")
+
+        origin = request.headers.get("origin")
+        if origin and not self._is_allowed_origin(request, origin):
+            return self._reject(request, reason="origin_mismatch", origin=origin)
+
+        return await call_next(request)
+
+    def _is_allowed_origin(self, request: Request, origin: str) -> bool:
+        normalized = _normalize_origin(origin)
+        if not normalized:
+            return False
+        allowed = {
+            *_normalized_origins(getattr(settings, "csrf_trusted_origins", ())),
+            *_normalized_origins(getattr(settings, "allowed_cors_origins", ())),
+            *self._local_dev_origins,
+            _normalize_origin(str(request.base_url).rstrip("/")),
+        }
+        return normalized in allowed
+
+    @staticmethod
+    def _reject(request: Request, *, reason: str, origin: str | None = None) -> JSONResponse:
+        logger.warning(
+            "csrf_request_denied",
+            path=request.url.path,
+            method=request.method,
+            reason=reason,
+            origin=origin,
+            sec_fetch_site=request.headers.get("sec-fetch-site"),
+            request_id=getattr(request.state, "request_id", None),
+        )
+        return JSONResponse(status_code=403, content={"detail": "CSRF check failed"})
+
+
+def _normalize_origin(origin: str | None) -> str | None:
+    if not origin:
+        return None
+    parsed = urlsplit(origin.strip())
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}"
+
+
+def _normalized_origins(values: object) -> set[str]:
+    result: set[str] = set()
+    try:
+        candidates = list(values or ())
+    except TypeError:
+        candidates = [str(values)]
+    for value in candidates:
+        normalized = _normalize_origin(str(value))
+        if normalized:
+            result.add(normalized)
+    return result

--- a/apps/backend/backend/routers/article.py
+++ b/apps/backend/backend/routers/article.py
@@ -12,6 +12,15 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request, sta
 from fastapi.exceptions import RequestValidationError
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
+from ..auth import principal_from_request
+from ..authorization.dependencies import require_user_permission
+from ..authorization.permissions import Permission
+from ..authorization.policies import (
+    ResourceVisibility,
+    ensure_read_allowed,
+    ensure_user_write_allowed,
+)
+from ..authorization.principal import Principal
 from ..config import settings
 from ..domain.article.lemma_filter import STOP_LEMMAS, filter_article_lemmas
 from ..flows.article_import import ArticleImportFlow
@@ -32,7 +41,6 @@ from ..models.word import ExampleCategory
 from ..observability import request_trace, span
 from ..store import store as _default_store
 from ..store.proxy import CurrentStoreProxy
-from .word.dependencies import require_authenticated_user
 
 
 router = APIRouter(tags=["article"])
@@ -96,11 +104,14 @@ def _validate_import_request(payload: dict[str, Any]) -> ArticleImportRequest:
 @router.post(
     "/import", response_model=ArticleDetailResponse, response_model_exclude_none=True
 )
-async def import_article(payload: dict[str, Any] = Body(...)) -> ArticleDetailResponse:
+async def import_article(
+    payload: dict[str, Any] = Body(...),
+    principal: Principal = Depends(require_user_permission(Permission.ARTICLE_CREATE)),
+) -> ArticleDetailResponse:
     """文章インポートを受け付け、文字数超過は 413 で通知する。"""
 
     req = _validate_import_request(payload)
-    flow = ArticleImportFlow()
+    flow = ArticleImportFlow(owner_user_id=principal.user_id)
     # ルータ層は薄く、Langfuse の親スパンを貼ってフローを呼び出す
     from ..observability import request_trace
 
@@ -164,9 +175,18 @@ async def _get_article_response(request: Request, article_id: str) -> ArticleDet
         guest_public,
         links,
     ) = result
-    is_guest = bool(getattr(request.state, "guest", False))
-    if is_guest and not guest_public:
-        raise HTTPException(status_code=404, detail="Article not found")
+    principal = principal_from_request(request)
+    visibility = store.get_article_visibility(article_id) or {}
+    ensure_read_allowed(
+        principal,
+        ResourceVisibility(
+            exists=True,
+            guest_public=bool(guest_public),
+            owner_user_id=visibility.get("owner_user_id"),
+            not_found_detail="Article not found",
+        ),
+    )
+    is_guest = principal.is_guest
     duration_value = (
         int(generation_duration_ms)
         if isinstance(generation_duration_ms, (int, float))
@@ -234,8 +254,16 @@ async def get_article(request: Request, article_id: str) -> ArticleDetailRespons
 async def update_article_guest_public(
     article_id: str,
     req: ArticleGuestPublicUpdateRequest,
-    _user: dict[str, str] = Depends(require_authenticated_user),
+    principal: Principal = Depends(require_user_permission(Permission.ARTICLE_UPDATE)),
 ) -> ArticleGuestPublicUpdateResponse:
+    visibility = store.get_article_visibility(article_id)
+    if visibility is None:
+        raise HTTPException(status_code=404, detail="Article not found")
+    ensure_user_write_allowed(
+        principal,
+        owner_user_id=visibility.get("owner_user_id"),
+        not_found_detail="Article not found",
+    )
     updated = store.update_article_guest_public(article_id, req.guest_public)
     if updated is None:
         raise HTTPException(status_code=404, detail="Article not found")
@@ -246,7 +274,18 @@ async def update_article_guest_public(
 
 
 @router.delete("/{article_id}")
-async def delete_article(article_id: str) -> dict[str, str]:
+async def delete_article(
+    article_id: str,
+    principal: Principal = Depends(require_user_permission(Permission.ARTICLE_DELETE)),
+) -> dict[str, str]:
+    visibility = store.get_article_visibility(article_id)
+    if visibility is None:
+        raise HTTPException(status_code=404, detail="Article not found")
+    ensure_user_write_allowed(
+        principal,
+        owner_user_id=visibility.get("owner_user_id"),
+        not_found_detail="Article not found",
+    )
     ok = store.delete_article(article_id)
     if not ok:
         raise HTTPException(status_code=404, detail="Article not found")
@@ -268,6 +307,7 @@ class CategoryGenerateImportRequest(BaseModel):
 @router.post("/generate_and_import")
 async def generate_and_import_examples(
     req: CategoryGenerateImportRequest,
+    principal: Principal = Depends(require_user_permission(Permission.ARTICLE_CREATE)),
 ) -> dict[str, object]:
     """選択カテゴリに関連する語を1つ生成し、空のWordPackを作成、
     当該カテゴリの例文を2件生成して保存し、それぞれを文章インポートに渡して記事化する。
@@ -276,6 +316,7 @@ async def generate_and_import_examples(
         model=getattr(req, "model", None),
         reasoning=getattr(req, "reasoning", None),
         text=getattr(req, "text", None),
+        owner_user_id=principal.user_id,
     )
     with request_trace(
         name="CategoryGenerateAndImportFlow",

--- a/apps/backend/backend/routers/article.py
+++ b/apps/backend/backend/routers/article.py
@@ -130,8 +130,19 @@ async def list_articles(
     request: Request,
     limit: int = Query(default=50, ge=1, le=100), offset: int = Query(default=0, ge=0)
 ) -> ArticleListResponse:
-    public_only = bool(getattr(request.state, "guest", False))
-    items_raw = store.list_articles(limit=limit, offset=offset, public_only=public_only)
+    principal = principal_from_request(request)
+    public_only = principal.is_guest
+    owner_user_id = (
+        principal.user_id
+        if principal.is_user and getattr(settings, "enforce_owner_scoping", False)
+        else None
+    )
+    items_raw = store.list_articles(
+        limit=limit,
+        offset=offset,
+        public_only=public_only,
+        owner_user_id=owner_user_id,
+    )
     items = [
         ArticleListItem(
             id=i[0],
@@ -142,7 +153,7 @@ async def list_articles(
         )
         for i in items_raw
     ]
-    total = store.count_articles(public_only=public_only)
+    total = store.count_articles(public_only=public_only, owner_user_id=owner_user_id)
     return ArticleListResponse(items=items, total=total, limit=limit, offset=offset)
 
 

--- a/apps/backend/backend/routers/auth.py
+++ b/apps/backend/backend/routers/auth.py
@@ -16,6 +16,8 @@ from ..auth import (
     guest_session_cookie_names,
     issue_guest_session_token,
     issue_session_token,
+    read_session_cookie,
+    revoke_session_token,
     resolve_guest_session_cookie,
     resolve_session_cookie,
     session_cookie_names,
@@ -31,9 +33,18 @@ _google_request = google_requests.Request()
 
 
 class GoogleAuthRequest(BaseModel):
-    """Payload containing a Google-issued ID token from the frontend."""
+    """Payload containing Google Identity Services credential fields."""
 
-    id_token: str = Field(..., description="Google ID token generated on the client")
+    id_token: str | None = Field(default=None, description="Legacy Google ID token")
+    credential: str | None = Field(
+        default=None, description="Google Identity Services credential"
+    )
+    g_csrf_token: str | None = Field(
+        default=None, description="Google Identity Services CSRF token"
+    )
+
+    def token_value(self) -> str | None:
+        return self.credential or self.id_token
 
 
 class GoogleAuthResponse(BaseModel):
@@ -88,11 +99,35 @@ async def authenticate_with_google(payload: GoogleAuthRequest, request: Request)
             detail="Session secret key is not configured",
         )
 
+    token = payload.token_value()
+    if not token:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail="Google credential is required",
+        )
+
+    if payload.credential is not None or payload.g_csrf_token is not None:
+        cookie_csrf_token = read_session_cookie(request, "g_csrf_token")
+        if (
+            not payload.g_csrf_token
+            or not cookie_csrf_token
+            or payload.g_csrf_token != cookie_csrf_token
+        ):
+            logger.warning(
+                "google_auth_failed",
+                user_id=None,
+                reason="csrf_token_mismatch",
+            )
+            raise HTTPException(
+                status_code=HTTPStatus.FORBIDDEN,
+                detail="Google CSRF token mismatch",
+            )
+
     try:
         # 許容する時計ずれ（nbf/iat/exp の境界緩和）。古い google-auth 互換のため TypeError 時は従来呼び出しにフォールバック。
         _skew = max(0, int(getattr(settings, "google_clock_skew_seconds", 0) or 0))
         id_info = _verify_google_id_token(
-            payload.id_token,
+            token,
             settings.google_client_id,
             _skew,
         )
@@ -110,6 +145,7 @@ async def authenticate_with_google(payload: GoogleAuthRequest, request: Request)
     display_name = id_info.get("name") or id_info.get("email")
     hosted_domain = id_info.get("hd") or id_info.get("hostedDomain")
     email_hash = _hash_for_log(email)
+    user_id_hash = _hash_for_log(str(google_sub) if google_sub else None)
     email_verified = id_info.get("email_verified")
 
     missing_claims = [
@@ -121,7 +157,7 @@ async def authenticate_with_google(payload: GoogleAuthRequest, request: Request)
     if not google_sub or not email or not display_name:
         logger.warning(
             "google_auth_failed",
-            user_id=google_sub,
+            user_id_hash=user_id_hash,
             reason="missing_claims",
             missing_claims=missing_claims,
             email_hash=email_hash,
@@ -133,7 +169,7 @@ async def authenticate_with_google(payload: GoogleAuthRequest, request: Request)
     if email_verified is not True:
         logger.warning(
             "google_auth_denied",
-            user_id=google_sub,
+            user_id_hash=user_id_hash,
             reason="email_unverified",
             email_hash=email_hash,
         )
@@ -146,7 +182,7 @@ async def authenticate_with_google(payload: GoogleAuthRequest, request: Request)
     if allowed_hd and hosted_domain != allowed_hd:
         logger.warning(
             "google_auth_denied",
-            user_id=google_sub,
+            user_id_hash=user_id_hash,
             reason="domain_mismatch",
             hosted_domain=hosted_domain,
             allowed_domain=allowed_hd,
@@ -161,7 +197,7 @@ async def authenticate_with_google(payload: GoogleAuthRequest, request: Request)
         if normalised_email not in allowlisted_emails:
             logger.warning(
                 "google_auth_denied",
-                user_id=google_sub,
+                user_id_hash=user_id_hash,
                 reason="email_not_allowlisted",
                 hosted_domain=hosted_domain,
                 email_hash=email_hash,
@@ -178,7 +214,7 @@ async def authenticate_with_google(payload: GoogleAuthRequest, request: Request)
         display_name=display_name,
         login_at=datetime.now(UTC),
     )
-    session_token = issue_session_token(google_sub)
+    session_token = issue_session_token(google_sub, request=request)
 
     response = JSONResponse(status_code=HTTPStatus.OK, content={"user": user})
     for cookie_name in session_cookie_names():
@@ -212,7 +248,7 @@ async def authenticate_as_guest(request: Request) -> JSONResponse:
             detail="Session secret key is not configured",
         )
 
-    guest_token = issue_guest_session_token()
+    guest_token = issue_guest_session_token(request=request)
     response = JSONResponse(status_code=HTTPStatus.OK, content={"mode": "guest"})
     for cookie_name in guest_session_cookie_names():
         response.set_cookie(
@@ -241,6 +277,7 @@ async def logout(request: Request, response: Response) -> Response:
     HttpOnly Cookie を使うため、このハンドラーで通常セッションと同じように失効させる。"""
 
     user_id, logout_mode = _resolve_logout_context(request)
+    _revoke_all_present_sessions(request)
 
     response.status_code = HTTPStatus.NO_CONTENT
     for cookie_name in dict.fromkeys((*session_cookie_names(), *guest_session_cookie_names())):
@@ -252,10 +289,24 @@ async def logout(request: Request, response: Response) -> Response:
         )
     logger.info(
         "logout_completed",
-        user_id=user_id,
+        user_id_hash=_hash_for_log(user_id),
         reason=logout_mode,
     )
     return response
+
+
+def _revoke_all_present_sessions(request: Request) -> None:
+    seen: set[tuple[str, str]] = set()
+    for cookie_name in session_cookie_names():
+        token = read_session_cookie(request, cookie_name)
+        if token and ("user", token) not in seen:
+            seen.add(("user", token))
+            revoke_session_token(token)
+    for cookie_name in guest_session_cookie_names():
+        token = read_session_cookie(request, cookie_name)
+        if token and ("guest", token) not in seen:
+            seen.add(("guest", token))
+            revoke_session_token(token, guest=True)
 
 
 def _resolve_logout_context(request: Request) -> tuple[str | None, str]:
@@ -269,6 +320,7 @@ def _resolve_logout_context(request: Request) -> tuple[str | None, str]:
         except (SignatureExpired, BadSignature, RuntimeError):
             session_invalid = True
         else:
+            revoke_session_token(session_token)
             sub = payload.get("sub") if isinstance(payload, dict) else None
             if not sub:
                 session_invalid = True
@@ -283,6 +335,7 @@ def _resolve_logout_context(request: Request) -> tuple[str | None, str]:
             return None, "guest_logout_invalid"
         if not isinstance(payload, dict) or payload.get("mode") != "guest":
             return None, "guest_logout_invalid"
+        revoke_session_token(guest_token, guest=True)
         request.state.guest = True
         return None, "guest_logout"
 
@@ -330,7 +383,7 @@ def _log_google_auth_success(
 
     logger.info(
         "google_auth_succeeded",
-        user_id=user_id,
+        user_id_hash=_hash_for_log(user_id),
         reason="authenticated",
         email_hash=_hash_for_log(email),
         display_name_hash=_hash_for_log(display_name),

--- a/apps/backend/backend/routers/quiz.py
+++ b/apps/backend/backend/routers/quiz.py
@@ -15,6 +15,7 @@ from ..authorization.policies import (
     ensure_user_write_allowed,
 )
 from ..authorization.principal import Principal
+from ..config import settings
 from ..infrastructure.llm.quiz_generator import QuizGenerateFlowAdapter
 from ..infrastructure.runtime import AsyncioTaskScheduler, PrefixedUuidGenerator, SystemClock
 from ..models.quiz import (
@@ -135,9 +136,23 @@ async def list_quizzes(
     offset: int = Query(default=0, ge=0),
 ) -> QuizListResponse:
     repository = get_store()
-    public_only = principal_from_request(request).is_guest
-    rows = repository.list_quizzes(limit=limit, offset=offset, public_only=public_only)
-    total = repository.count_quizzes(public_only=public_only)
+    principal = principal_from_request(request)
+    public_only = principal.is_guest
+    owner_user_id = (
+        principal.user_id
+        if principal.is_user and getattr(settings, "enforce_owner_scoping", False)
+        else None
+    )
+    rows = repository.list_quizzes(
+        limit=limit,
+        offset=offset,
+        public_only=public_only,
+        owner_user_id=owner_user_id,
+    )
+    total = repository.count_quizzes(
+        public_only=public_only,
+        owner_user_id=owner_user_id,
+    )
     items = [_list_item_from_quiz(Quiz.model_validate(row)) for row in rows]
     return QuizListResponse(items=items, total=total, limit=limit, offset=offset)
 
@@ -224,7 +239,16 @@ async def submit_quiz_attempt(
     req: QuizAttemptRequest,
     principal: Principal = Depends(require_user_permission(Permission.QUIZ_ATTEMPT_WRITE)),
 ) -> QuizAttemptResponse:
-    row = get_store().get_quiz(quiz_id)
+    repository = get_store()
+    visibility = repository.get_quiz_visibility(quiz_id)
+    if visibility is None:
+        raise HTTPException(status_code=404, detail="Quiz not found")
+    ensure_user_write_allowed(
+        principal,
+        owner_user_id=visibility.get("owner_user_id"),
+        not_found_detail="Quiz not found",
+    )
+    row = repository.get_quiz(quiz_id)
     if row is None:
         raise HTTPException(status_code=404, detail="Quiz not found")
     quiz = Quiz.model_validate(row)
@@ -243,7 +267,7 @@ async def submit_quiz_attempt(
         submitted_at=submitted_at,
         elapsed_ms=req.elapsed_ms,
     )
-    get_store().save_quiz_attempt(
+    repository.save_quiz_attempt(
         attempt_id,
         {
             "quiz_id": quiz_id,
@@ -271,9 +295,16 @@ async def list_quiz_attempts(
     quiz_id: str,
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
-    _principal: Principal = Depends(require_user_permission(Permission.QUIZ_READ)),
+    principal: Principal = Depends(require_user_permission(Permission.QUIZ_READ)),
 ) -> list[QuizAttemptResponse]:
-    if get_store().get_quiz(quiz_id) is None:
+    repository = get_store()
+    visibility = repository.get_quiz_visibility(quiz_id)
+    if visibility is None:
         raise HTTPException(status_code=404, detail="Quiz not found")
-    rows = get_store().list_quiz_attempts(quiz_id, limit=limit, offset=offset)
+    ensure_user_write_allowed(
+        principal,
+        owner_user_id=visibility.get("owner_user_id"),
+        not_found_detail="Quiz not found",
+    )
+    rows = repository.list_quiz_attempts(quiz_id, limit=limit, offset=offset)
     return [QuizAttemptResponse.model_validate(row) for row in rows]

--- a/apps/backend/backend/routers/quiz.py
+++ b/apps/backend/backend/routers/quiz.py
@@ -6,6 +6,15 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
 from ..application.quiz.generation_jobs import enqueue_quiz_generation_job, get_quiz_generation_job
 from ..application.quiz.scoring import score_quiz_attempt
+from ..auth import principal_from_request
+from ..authorization.dependencies import require_user_permission
+from ..authorization.permissions import Permission
+from ..authorization.policies import (
+    ResourceVisibility,
+    ensure_read_allowed,
+    ensure_user_write_allowed,
+)
+from ..authorization.principal import Principal
 from ..infrastructure.llm.quiz_generator import QuizGenerateFlowAdapter
 from ..infrastructure.runtime import AsyncioTaskScheduler, PrefixedUuidGenerator, SystemClock
 from ..models.quiz import (
@@ -20,7 +29,7 @@ from ..models.quiz import (
     QuizListResponse,
     QuizWordPackLink,
 )
-from .word.dependencies import get_store, require_authenticated_user
+from .word.dependencies import get_store
 
 router = APIRouter(tags=["quiz"])
 
@@ -88,12 +97,12 @@ def _rehydrate_related_word_pack_links(repository: object, quiz: Quiz) -> Quiz:
 )
 async def create_quiz_generation_job(
     req: QuizGenerateRequest,
-    _user: dict[str, str] = Depends(require_authenticated_user),
+    principal: Principal = Depends(require_user_permission(Permission.QUIZ_CREATE)),
 ) -> QuizGenerationJobResponse:
     return await enqueue_quiz_generation_job(
         req,
         get_store(),
-        generator=QuizGenerateFlowAdapter(),
+        generator=QuizGenerateFlowAdapter(owner_user_id=principal.user_id),
         scheduler=AsyncioTaskScheduler(),
         id_generator=PrefixedUuidGenerator("quiz-job:"),
         clock=SystemClock(),
@@ -107,7 +116,7 @@ async def create_quiz_generation_job(
 )
 async def get_quiz_generation_job_status(
     job_id: str,
-    _user: dict[str, str] = Depends(require_authenticated_user),
+    _principal: Principal = Depends(require_user_permission(Permission.QUIZ_READ)),
 ) -> QuizGenerationJobResponse:
     job = await get_quiz_generation_job(job_id, get_store(), clock=SystemClock())
     if job is None:
@@ -126,7 +135,7 @@ async def list_quizzes(
     offset: int = Query(default=0, ge=0),
 ) -> QuizListResponse:
     repository = get_store()
-    public_only = bool(getattr(request.state, "guest", False))
+    public_only = principal_from_request(request).is_guest
     rows = repository.list_quizzes(limit=limit, offset=offset, public_only=public_only)
     total = repository.count_quizzes(public_only=public_only)
     items = [_list_item_from_quiz(Quiz.model_validate(row)) for row in rows]
@@ -144,8 +153,16 @@ async def get_quiz(request: Request, quiz_id: str) -> Quiz:
     if row is None:
         raise HTTPException(status_code=404, detail="Quiz not found")
     quiz = Quiz.model_validate(row)
-    if bool(getattr(request.state, "guest", False)) and not quiz.guest_public:
-        raise HTTPException(status_code=404, detail="Quiz not found")
+    visibility = repository.get_quiz_visibility(quiz_id) or {}
+    ensure_read_allowed(
+        principal_from_request(request),
+        ResourceVisibility(
+            exists=True,
+            guest_public=bool(quiz.guest_public),
+            owner_user_id=visibility.get("owner_user_id"),
+            not_found_detail="Quiz not found",
+        ),
+    )
     return _rehydrate_related_word_pack_links(repository, quiz)
 
 
@@ -157,9 +174,18 @@ async def get_quiz(request: Request, quiz_id: str) -> Quiz:
 async def update_quiz_guest_public(
     quiz_id: str,
     req: QuizGuestPublicUpdateRequest,
-    _user: dict[str, str] = Depends(require_authenticated_user),
+    principal: Principal = Depends(require_user_permission(Permission.QUIZ_UPDATE)),
 ) -> QuizGuestPublicUpdateResponse:
-    updated = get_store().update_quiz_guest_public(quiz_id, req.guest_public)
+    repository = get_store()
+    visibility = repository.get_quiz_visibility(quiz_id)
+    if visibility is None:
+        raise HTTPException(status_code=404, detail="Quiz not found")
+    ensure_user_write_allowed(
+        principal,
+        owner_user_id=visibility.get("owner_user_id"),
+        not_found_detail="Quiz not found",
+    )
+    updated = repository.update_quiz_guest_public(quiz_id, req.guest_public)
     if updated is None:
         raise HTTPException(status_code=404, detail="Quiz not found")
     return QuizGuestPublicUpdateResponse(quiz_id=quiz_id, guest_public=updated)
@@ -171,9 +197,18 @@ async def update_quiz_guest_public(
 )
 async def delete_quiz(
     quiz_id: str,
-    _user: dict[str, str] = Depends(require_authenticated_user),
+    principal: Principal = Depends(require_user_permission(Permission.QUIZ_DELETE)),
 ) -> dict[str, str]:
-    success = get_store().delete_quiz(quiz_id)
+    repository = get_store()
+    visibility = repository.get_quiz_visibility(quiz_id)
+    if visibility is None:
+        raise HTTPException(status_code=404, detail="Quiz not found")
+    ensure_user_write_allowed(
+        principal,
+        owner_user_id=visibility.get("owner_user_id"),
+        not_found_detail="Quiz not found",
+    )
+    success = repository.delete_quiz(quiz_id)
     if not success:
         raise HTTPException(status_code=404, detail="Quiz not found")
     return {"message": "Quiz deleted successfully"}
@@ -187,7 +222,7 @@ async def delete_quiz(
 async def submit_quiz_attempt(
     quiz_id: str,
     req: QuizAttemptRequest,
-    _user: dict[str, str] = Depends(require_authenticated_user),
+    principal: Principal = Depends(require_user_permission(Permission.QUIZ_ATTEMPT_WRITE)),
 ) -> QuizAttemptResponse:
     row = get_store().get_quiz(quiz_id)
     if row is None:
@@ -220,6 +255,7 @@ async def submit_quiz_attempt(
             "started_at": req.started_at,
             "submitted_at": submitted_at,
             "elapsed_ms": req.elapsed_ms,
+            "owner_user_id": principal.user_id,
             "created_at": submitted_at,
         },
     )
@@ -235,7 +271,7 @@ async def list_quiz_attempts(
     quiz_id: str,
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
-    _user: dict[str, str] = Depends(require_authenticated_user),
+    _principal: Principal = Depends(require_user_permission(Permission.QUIZ_READ)),
 ) -> list[QuizAttemptResponse]:
     if get_store().get_quiz(quiz_id) is None:
         raise HTTPException(status_code=404, detail="Quiz not found")

--- a/apps/backend/backend/routers/tts.py
+++ b/apps/backend/backend/routers/tts.py
@@ -5,12 +5,15 @@ import threading
 import time
 from typing import Any, Iterator
 
-from fastapi import APIRouter, Body, HTTPException, Request, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ValidationError, constr
 
 from ..config import settings
+from ..authorization.dependencies import require_user_permission
+from ..authorization.permissions import Permission
+from ..authorization.principal import Principal
 from ..logging import logger
 
 try:
@@ -136,7 +139,11 @@ def _map_openai_exception(exc: Exception) -> tuple[int, str, str]:
 
 
 @router.post("", response_class=StreamingResponse)
-def synth(request: Request, payload: dict[str, Any] = Body(...)) -> StreamingResponse:
+def synth(
+    request: Request,
+    payload: dict[str, Any] = Body(...),
+    _principal: Principal = Depends(require_user_permission(Permission.TTS_CREATE)),
+) -> StreamingResponse:
     """Synthesize speech using OpenAI TTS and stream MP3 audio to the client."""
     t0 = time.perf_counter()
     request_id = _loggable_request_id(request)

--- a/apps/backend/backend/routers/word/dependencies.py
+++ b/apps/backend/backend/routers/word/dependencies.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from importlib import import_module
+from collections.abc import Mapping
 from typing import Any, Awaitable, Callable
 
 from fastapi import Request
@@ -48,3 +49,32 @@ def next_word_pack_id() -> str:
 def get_run_wordpack_flow() -> Callable[..., Awaitable[Any]]:
     package = _word_router_package()
     return getattr(package, "run_wordpack_flow", run_wordpack_flow)
+
+
+def get_word_pack_visibility(repository: Any, word_pack_id: str) -> Mapping[str, Any] | None:
+    resolver = getattr(repository, "get_word_pack_visibility", None)
+    if callable(resolver):
+        return resolver(word_pack_id)
+
+    get_word_pack = getattr(repository, "get_word_pack", None)
+    if callable(get_word_pack) and get_word_pack(word_pack_id) is None:
+        return None
+
+    guest_public = False
+    is_guest_public = getattr(repository, "is_word_pack_guest_public", None)
+    if callable(is_guest_public):
+        guest_public = bool(is_guest_public(word_pack_id))
+
+    owner_user_id = None
+    get_metadata = getattr(repository, "get_word_pack_metadata", None)
+    metadata_payload = get_metadata(word_pack_id) if callable(get_metadata) else None
+    metadata = (
+        metadata_payload.get("metadata")
+        if isinstance(metadata_payload, Mapping)
+        else None
+    )
+    if isinstance(metadata, Mapping):
+        owner_raw = metadata.get("owner_user_id")
+        owner_user_id = str(owner_raw).strip() if owner_raw else None
+
+    return {"guest_public": guest_public, "owner_user_id": owner_user_id}

--- a/apps/backend/backend/routers/word/example_routes.py
+++ b/apps/backend/backend/routers/word/example_routes.py
@@ -5,6 +5,10 @@ from typing import Any, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from ...application.wordpack.errors import handle_flow_runtime_error
+from ...authorization.dependencies import require_user_permission
+from ...authorization.permissions import Permission
+from ...authorization.policies import ensure_user_write_allowed
+from ...authorization.principal import Principal
 from ...config import settings
 from ...infrastructure.llm.wordpack_generator import build_llm_info, get_override_value
 from ...flows.word_pack import WordPackFlow
@@ -18,7 +22,7 @@ from ...models.word import (
     ExampleTranscriptionTypingResponse,
 )
 from ...providers import get_llm_provider
-from .dependencies import get_store, require_authenticated_user
+from .dependencies import get_store, get_word_pack_visibility
 from .error_mapping import example_error_mapping
 from .schemas import ExamplesGenerateRequest
 
@@ -34,6 +38,7 @@ async def delete_example_from_word_pack(
     word_pack_id: str,
     category: ExampleCategory,
     index: int,
+    principal: Principal = Depends(require_user_permission(Permission.EXAMPLE_DELETE)),
 ) -> dict[str, object]:
     """保存済みWordPackから個々の例文を削除する（正規化テーブルを直接操作）。"""
 
@@ -41,6 +46,12 @@ async def delete_example_from_word_pack(
     wp = repository.get_word_pack(word_pack_id)
     if wp is None:
         raise HTTPException(status_code=404, detail="WordPack not found")
+    visibility = get_word_pack_visibility(repository, word_pack_id) or {}
+    ensure_user_write_allowed(
+        principal,
+        owner_user_id=visibility.get("owner_user_id"),
+        not_found_detail="WordPack not found",
+    )
 
     remaining = repository.delete_example(word_pack_id, category.value, index)
     if remaining is None:
@@ -62,7 +73,7 @@ async def generate_examples_for_word_pack(
     word_pack_id: str,
     category: ExampleCategory,
     req: ExamplesGenerateRequest | None = None,
-    _user: dict[str, str] = Depends(require_authenticated_user),
+    principal: Principal = Depends(require_user_permission(Permission.EXAMPLE_CREATE)),
 ) -> dict[str, Any]:
     """保存済みWordPackに、指定カテゴリの例文を2件追加生成して保存する。"""
 
@@ -70,6 +81,12 @@ async def generate_examples_for_word_pack(
     result = repository.get_word_pack(word_pack_id)
     if result is None:
         raise HTTPException(status_code=404, detail="WordPack not found")
+    visibility = get_word_pack_visibility(repository, word_pack_id) or {}
+    ensure_user_write_allowed(
+        principal,
+        owner_user_id=visibility.get("owner_user_id"),
+        not_found_detail="WordPack not found",
+    )
     lemma, _, _, _ = result
 
     req = req or ExamplesGenerateRequest()
@@ -200,6 +217,7 @@ async def list_examples(
 )
 async def bulk_delete_examples(
     req: ExamplesBulkDeleteRequest,
+    _principal: Principal = Depends(require_user_permission(Permission.EXAMPLE_DELETE)),
 ) -> ExamplesBulkDeleteResponse:
     """例文IDのリストを受け取り、一括で削除する。"""
 
@@ -213,7 +231,9 @@ async def bulk_delete_examples(
     summary="例文の文字起こし練習入力を記録",
 )
 async def update_example_transcription_typing(
-    example_id: int, req: ExampleTranscriptionTypingRequest
+    example_id: int,
+    req: ExampleTranscriptionTypingRequest,
+    _principal: Principal = Depends(require_user_permission(Permission.EXAMPLE_UPDATE)),
 ) -> ExampleTranscriptionTypingResponse:
     """入力長の妥当性を確認しつつ文字起こしカウントを加算する。"""
 

--- a/apps/backend/backend/routers/word/generation_routes.py
+++ b/apps/backend/backend/routers/word/generation_routes.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 
+from ...authorization.dependencies import require_user_permission
+from ...authorization.permissions import Permission
+from ...authorization.principal import Principal
 from ...logging import logger
 from ...models.word import GeneratedWordPackResponse, WordPackRequest
-from .dependencies import get_run_wordpack_flow, get_store, next_word_pack_id, require_authenticated_user
+from .dependencies import get_run_wordpack_flow, get_store, next_word_pack_id
 from .error_mapping import generation_error_mapping
 
 router = APIRouter()
@@ -19,7 +22,7 @@ router = APIRouter()
 )
 async def generate_word_pack(
     req: WordPackRequest,
-    _user: dict[str, str] = Depends(require_authenticated_user),
+    principal: Principal = Depends(require_user_permission(Permission.WORDPACK_GENERATE)),
 ) -> GeneratedWordPackResponse:
     """Generate a new word pack using LangGraph flow."""
 
@@ -38,7 +41,12 @@ async def generate_word_pack(
         )
 
         word_pack_id = next_word_pack_id()
-        get_store().save_word_pack(word_pack_id, req.lemma, word_pack.model_dump_json())
+        get_store().save_word_pack(
+            word_pack_id,
+            req.lemma,
+            word_pack.model_dump_json(),
+            metadata={"owner_user_id": principal.user_id},
+        )
 
         logger.info(
             "wordpack_generate_response",

--- a/apps/backend/backend/routers/word/guest_public_routes.py
+++ b/apps/backend/backend/routers/word/guest_public_routes.py
@@ -7,10 +7,14 @@ from ...application.wordpack.guest_public import (
     UpdateWordPackGuestPublicCommand,
     update_guest_public_flag,
 )
+from ...authorization.dependencies import require_user_permission
+from ...authorization.permissions import Permission
+from ...authorization.policies import ensure_user_write_allowed
+from ...authorization.principal import Principal
 from ...infrastructure.runtime import SystemClock
 from ...logging import logger
 from ...models.word import WordPackGuestPublicRequest, WordPackGuestPublicResponse
-from .dependencies import get_store, require_authenticated_user
+from .dependencies import get_store, get_word_pack_visibility
 
 router = APIRouter()
 
@@ -24,7 +28,7 @@ async def update_word_pack_guest_public(
     request: Request,
     word_pack_id: str,
     req: WordPackGuestPublicRequest,
-    _user: dict[str, str] = Depends(require_authenticated_user),
+    principal: Principal = Depends(require_user_permission(Permission.WORDPACK_UPDATE)),
 ) -> WordPackGuestPublicResponse:
     """WordPack単位のゲスト公開フラグを更新する。"""
 
@@ -33,8 +37,17 @@ async def update_word_pack_guest_public(
         guest_public=req.guest_public,
         updated_at=SystemClock().now_iso(),
     )
+    repository = get_store()
+    visibility = get_word_pack_visibility(repository, word_pack_id)
+    if visibility is None:
+        raise HTTPException(status_code=404, detail="WordPack not found")
+    ensure_user_write_allowed(
+        principal,
+        owner_user_id=visibility.get("owner_user_id"),
+        not_found_detail="WordPack not found",
+    )
     try:
-        result = update_guest_public_flag(repository=get_store(), command=command)
+        result = update_guest_public_flag(repository=repository, command=command)
     except NotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 

--- a/apps/backend/backend/routers/word/lookup_routes.py
+++ b/apps/backend/backend/routers/word/lookup_routes.py
@@ -3,17 +3,18 @@ from __future__ import annotations
 import json
 
 from fastapi import APIRouter, HTTPException, Query, Request
-from itsdangerous import BadSignature, SignatureExpired
 
+from ...auth import principal_from_request
 from ...application.wordpack.lookup_wordpack import (
     WordLookupResponse,
     build_lookup_response,
 )
-from ...auth import resolve_guest_session_cookie, verify_guest_session_token
+from ...authorization.policies import ResourceVisibility, ensure_read_allowed
 from ...models.word import WordPackRequest, _validate_lemma
 from .dependencies import (
     get_run_wordpack_flow,
     get_store,
+    get_word_pack_visibility,
     next_word_pack_id,
     run_wordpack_flow as default_run_wordpack_flow,
 )
@@ -44,9 +45,16 @@ async def lookup_word(
         if packed is None:
             raise HTTPException(status_code=404, detail="word pack not found")
 
-        if bool(getattr(request.state, "guest", False)):
-            if not repository.is_word_pack_guest_public(word_pack_id):
-                raise HTTPException(status_code=404, detail="word pack not found")
+        visibility = get_word_pack_visibility(repository, word_pack_id) or {}
+        ensure_read_allowed(
+            principal_from_request(request),
+            ResourceVisibility(
+                exists=True,
+                guest_public=bool(visibility.get("guest_public", False)),
+                owner_user_id=visibility.get("owner_user_id"),
+                not_found_detail="word pack not found",
+            ),
+        )
 
         lemma_from_store, data_json, created_at, updated_at = packed
         try:
@@ -62,17 +70,8 @@ async def lookup_word(
             updated_at=updated_at,
         )
 
-    is_guest = bool(getattr(request.state, "guest", False))
-    if not is_guest:
-        guest_token = resolve_guest_session_cookie(request)
-        if guest_token:
-            try:
-                verify_guest_session_token(guest_token)
-            except (SignatureExpired, BadSignature, RuntimeError):
-                pass
-            else:
-                is_guest = True
-    if is_guest:
+    principal = principal_from_request(request)
+    if principal.is_guest:
         raise HTTPException(
             status_code=403, detail="Guest mode cannot generate WordPack"
         )
@@ -91,7 +90,12 @@ async def lookup_word(
         http_error_mapping=generation_error_mapping(),
     )
     word_pack_id = next_word_pack_id()
-    repository.save_word_pack(word_pack_id, normalized_lemma, word_pack.model_dump_json())
+    repository.save_word_pack(
+        word_pack_id,
+        normalized_lemma,
+        word_pack.model_dump_json(),
+        metadata={"owner_user_id": principal.user_id},
+    )
 
     packed = repository.get_word_pack(word_pack_id)
     if packed is not None:

--- a/apps/backend/backend/routers/word/pack_routes.py
+++ b/apps/backend/backend/routers/word/pack_routes.py
@@ -13,6 +13,7 @@ from ...authorization.policies import (
     ensure_user_write_allowed,
 )
 from ...authorization.principal import Principal
+from ...config import settings
 from ...application.wordpack.create_empty_wordpack import build_empty_wordpack
 from ...infrastructure.llm.empty_wordpack_title import (
     EmptyWordPackTitleGenerationError,
@@ -88,6 +89,13 @@ async def list_word_packs(
             limit=limit, offset=offset
         )
         total = repository.count_public_word_packs()
+    elif principal.is_user and getattr(settings, "enforce_owner_scoping", False):
+        items_with_flags = repository.list_owned_word_packs_with_flags(
+            principal.user_id or "",
+            limit=limit,
+            offset=offset,
+        )
+        total = repository.count_owned_word_packs(principal.user_id or "")
     else:
         items_with_flags = repository.list_word_packs_with_flags(
             limit=limit, offset=offset

--- a/apps/backend/backend/routers/word/pack_routes.py
+++ b/apps/backend/backend/routers/word/pack_routes.py
@@ -4,6 +4,15 @@ import json
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from ...auth import principal_from_request
+from ...authorization.dependencies import require_user_permission
+from ...authorization.permissions import Permission
+from ...authorization.policies import (
+    ResourceVisibility,
+    ensure_read_allowed,
+    ensure_user_write_allowed,
+)
+from ...authorization.principal import Principal
 from ...application.wordpack.create_empty_wordpack import build_empty_wordpack
 from ...infrastructure.llm.empty_wordpack_title import (
     EmptyWordPackTitleGenerationError,
@@ -15,7 +24,7 @@ from ...models.word import (
     WordPackListItem,
     WordPackListResponse,
 )
-from .dependencies import get_store, next_word_pack_id, require_authenticated_user
+from .dependencies import get_store, get_word_pack_visibility, next_word_pack_id
 
 router = APIRouter()
 
@@ -28,7 +37,7 @@ router = APIRouter()
 )
 async def create_empty_word_pack(
     req: WordPackCreateRequest,
-    _user: dict[str, str] = Depends(require_authenticated_user),
+    principal: Principal = Depends(require_user_permission(Permission.WORDPACK_CREATE)),
 ) -> dict:
     """空のWordPackを作成・保存する（sense_title は短い日本語をLLMで生成）。"""
 
@@ -49,7 +58,12 @@ async def create_empty_word_pack(
         ) from exc
     empty_word_pack = build_empty_wordpack(lemma, generated_title=generated_title)
     word_pack_id = next_word_pack_id()
-    get_store().save_word_pack(word_pack_id, lemma, empty_word_pack.model_dump_json())
+    get_store().save_word_pack(
+        word_pack_id,
+        lemma,
+        empty_word_pack.model_dump_json(),
+        metadata={"owner_user_id": principal.user_id},
+    )
 
     return {"id": word_pack_id}
 
@@ -68,8 +82,8 @@ async def list_word_packs(
     """保存済みWordPackの一覧を取得する。"""
 
     repository = get_store()
-    is_guest = bool(getattr(request.state, "guest", False))
-    if is_guest:
+    principal = principal_from_request(request)
+    if principal.is_guest:
         items_with_flags = repository.list_public_word_packs_with_flags(
             limit=limit, offset=offset
         )
@@ -131,9 +145,17 @@ async def get_word_pack(request: Request, word_pack_id: str) -> WordPack:
         raise HTTPException(status_code=404, detail="WordPack not found")
 
     _lemma, data, _created_at, _updated_at = result
-    guest_public = repository.is_word_pack_guest_public(word_pack_id)
-    if bool(getattr(request.state, "guest", False)) and not guest_public:
-        raise HTTPException(status_code=404, detail="WordPack not found")
+    visibility = get_word_pack_visibility(repository, word_pack_id) or {}
+    guest_public = bool(visibility.get("guest_public", False))
+    ensure_read_allowed(
+        principal_from_request(request),
+        ResourceVisibility(
+            exists=True,
+            guest_public=guest_public,
+            owner_user_id=visibility.get("owner_user_id"),
+            not_found_detail="WordPack not found",
+        ),
+    )
     try:
         word_pack_dict = json.loads(data)
         word_pack_dict["guest_public"] = guest_public
@@ -147,10 +169,22 @@ async def get_word_pack(request: Request, word_pack_id: str) -> WordPack:
     summary="WordPackを削除",
     response_description="指定されたIDのWordPackを削除します",
 )
-async def delete_word_pack(word_pack_id: str) -> dict[str, str]:
+async def delete_word_pack(
+    word_pack_id: str,
+    principal: Principal = Depends(require_user_permission(Permission.WORDPACK_DELETE)),
+) -> dict[str, str]:
     """保存済みWordPackを削除する。"""
 
-    success = get_store().delete_word_pack(word_pack_id)
+    repository = get_store()
+    visibility = get_word_pack_visibility(repository, word_pack_id)
+    if visibility is None:
+        raise HTTPException(status_code=404, detail="WordPack not found")
+    ensure_user_write_allowed(
+        principal,
+        owner_user_id=visibility.get("owner_user_id"),
+        not_found_detail="WordPack not found",
+    )
+    success = repository.delete_word_pack(word_pack_id)
     if not success:
         raise HTTPException(status_code=404, detail="WordPack not found")
 

--- a/apps/backend/backend/routers/word/regeneration_routes.py
+++ b/apps/backend/backend/routers/word/regeneration_routes.py
@@ -13,9 +13,13 @@ from ...application.wordpack.regenerate_jobs import (
     enqueue_regenerate_job,
     get_regenerate_job,
 )
+from ...authorization.dependencies import require_user_permission
+from ...authorization.permissions import Permission
+from ...authorization.policies import ensure_user_write_allowed
+from ...authorization.principal import Principal
 from ...infrastructure.runtime import AsyncioTaskScheduler, UuidHexGenerator
 from ...models.word import WordPack, WordPackRegenerateRequest
-from .dependencies import get_run_wordpack_flow, get_store, require_authenticated_user
+from .dependencies import get_run_wordpack_flow, get_store, get_word_pack_visibility
 from .error_mapping import regeneration_error_mapping
 
 router = APIRouter()
@@ -41,7 +45,7 @@ def _sync_legacy_regenerate_job_registry() -> None:
 async def regenerate_word_pack(
     word_pack_id: str,
     req: WordPackRegenerateRequest,
-    _user: dict[str, str] = Depends(require_authenticated_user),
+    principal: Principal = Depends(require_user_permission(Permission.WORDPACK_UPDATE)),
 ) -> WordPack:
     """既存のWordPackを再生成する。"""
 
@@ -49,6 +53,12 @@ async def regenerate_word_pack(
     result = repository.get_word_pack(word_pack_id)
     if result is None:
         raise HTTPException(status_code=404, detail="WordPack not found")
+    visibility = get_word_pack_visibility(repository, word_pack_id) or {}
+    ensure_user_write_allowed(
+        principal,
+        owner_user_id=visibility.get("owner_user_id"),
+        not_found_detail="WordPack not found",
+    )
 
     lemma, _, _, _ = result
 
@@ -60,7 +70,12 @@ async def regenerate_word_pack(
             error_mapping=regeneration_error_mapping(),
         )
 
-        repository.save_word_pack(word_pack_id, lemma, word_pack.model_dump_json())
+        repository.save_word_pack(
+            word_pack_id,
+            lemma,
+            word_pack.model_dump_json(),
+            metadata={"owner_user_id": principal.user_id},
+        )
         return word_pack
     except RuntimeError:
         # run_wordpack_flow 内で HTTPException へ変換済み。それ以外は既定処理へ委譲。
@@ -76,16 +91,25 @@ async def regenerate_word_pack(
 async def enqueue_regenerate_word_pack(
     word_pack_id: str,
     req: WordPackRegenerateRequest,
-    _user: dict[str, str] = Depends(require_authenticated_user),
+    principal: Principal = Depends(require_user_permission(Permission.WORDPACK_UPDATE)),
 ) -> RegenerateJob:
     """Enqueue an async regenerate job and return job ID immediately."""
 
     _sync_legacy_regenerate_job_registry()
+    repository = get_store()
+    visibility = get_word_pack_visibility(repository, word_pack_id)
+    if visibility is None:
+        raise HTTPException(status_code=404, detail="WordPack not found")
+    ensure_user_write_allowed(
+        principal,
+        owner_user_id=visibility.get("owner_user_id"),
+        not_found_detail="WordPack not found",
+    )
     try:
         return await enqueue_regenerate_job(
             word_pack_id,
             req,
-            repository=get_store(),
+            repository=repository,
             flow=get_run_wordpack_flow(),
             scheduler=AsyncioTaskScheduler(),
             id_generator=UuidHexGenerator(),

--- a/apps/backend/backend/routers/word/study_progress_routes.py
+++ b/apps/backend/backend/routers/word/study_progress_routes.py
@@ -5,13 +5,14 @@ from fastapi import APIRouter, Depends, HTTPException
 from ...application.wordpack.study_progress import study_progress_increments
 from ...authorization.dependencies import require_user_permission
 from ...authorization.permissions import Permission
+from ...authorization.policies import ensure_user_write_allowed
 from ...authorization.principal import Principal
 from ...models.word import (
     ExampleStudyProgressResponse,
     StudyProgressRequest,
     WordPackStudyProgressResponse,
 )
-from .dependencies import get_store
+from .dependencies import get_store, get_word_pack_visibility
 
 router = APIRouter()
 
@@ -24,12 +25,21 @@ router = APIRouter()
 async def update_word_pack_study_progress(
     word_pack_id: str,
     req: StudyProgressRequest,
-    _principal: Principal = Depends(require_user_permission(Permission.WORDPACK_UPDATE)),
+    principal: Principal = Depends(require_user_permission(Permission.WORDPACK_UPDATE)),
 ) -> WordPackStudyProgressResponse:
     """WordPack単位の確認/学習済みカウントを更新する。"""
 
+    store = get_store()
+    visibility = get_word_pack_visibility(store, word_pack_id)
+    if visibility is None:
+        raise HTTPException(status_code=404, detail="WordPack not found")
+    ensure_user_write_allowed(
+        principal,
+        owner_user_id=visibility.get("owner_user_id"),
+        not_found_detail="WordPack not found",
+    )
     checked_increment, learned_increment = study_progress_increments(req.kind)
-    result = get_store().update_word_pack_study_progress(
+    result = store.update_word_pack_study_progress(
         word_pack_id, checked_increment, learned_increment
     )
     if result is None:
@@ -49,12 +59,24 @@ async def update_word_pack_study_progress(
 async def update_example_study_progress(
     example_id: int,
     req: StudyProgressRequest,
-    _principal: Principal = Depends(require_user_permission(Permission.EXAMPLE_UPDATE)),
+    principal: Principal = Depends(require_user_permission(Permission.EXAMPLE_UPDATE)),
 ) -> ExampleStudyProgressResponse:
     """例文単位の確認/学習済みカウントを更新する。"""
 
+    store = get_store()
+    word_pack_id = store.get_example_word_pack_id(example_id)
+    if word_pack_id is None:
+        raise HTTPException(status_code=404, detail="Example not found")
+    visibility = get_word_pack_visibility(store, word_pack_id)
+    if visibility is None:
+        raise HTTPException(status_code=404, detail="Example not found")
+    ensure_user_write_allowed(
+        principal,
+        owner_user_id=visibility.get("owner_user_id"),
+        not_found_detail="Example not found",
+    )
     checked_increment, learned_increment = study_progress_increments(req.kind)
-    result = get_store().update_example_study_progress(
+    result = store.update_example_study_progress(
         example_id, checked_increment, learned_increment
     )
     if result is None:

--- a/apps/backend/backend/routers/word/study_progress_routes.py
+++ b/apps/backend/backend/routers/word/study_progress_routes.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
 from ...application.wordpack.study_progress import study_progress_increments
+from ...authorization.dependencies import require_user_permission
+from ...authorization.permissions import Permission
+from ...authorization.principal import Principal
 from ...models.word import (
     ExampleStudyProgressResponse,
     StudyProgressRequest,
@@ -21,6 +24,7 @@ router = APIRouter()
 async def update_word_pack_study_progress(
     word_pack_id: str,
     req: StudyProgressRequest,
+    _principal: Principal = Depends(require_user_permission(Permission.WORDPACK_UPDATE)),
 ) -> WordPackStudyProgressResponse:
     """WordPack単位の確認/学習済みカウントを更新する。"""
 
@@ -45,6 +49,7 @@ async def update_word_pack_study_progress(
 async def update_example_study_progress(
     example_id: int,
     req: StudyProgressRequest,
+    _principal: Principal = Depends(require_user_permission(Permission.EXAMPLE_UPDATE)),
 ) -> ExampleStudyProgressResponse:
     """例文単位の確認/学習済みカウントを更新する。"""
 

--- a/apps/backend/backend/settings/base.py
+++ b/apps/backend/backend/settings/base.py
@@ -128,6 +128,20 @@ class Settings(BaseSettings):
         default=60 * 60 * 24 * 14,
         description="Session lifetime in seconds / セッションの寿命（秒）",
     )
+    session_idle_timeout_seconds: int = Field(
+        default=60 * 60 * 24 * 7,
+        description=(
+            "Idle timeout for authenticated server-side sessions / "
+            "認証済みサーバー側セッションのアイドルタイムアウト（秒）"
+        ),
+    )
+    session_last_seen_update_interval_seconds: int = Field(
+        default=300,
+        description=(
+            "Minimum interval for updating session last_seen_at / "
+            "セッション last_seen_at 更新の最小間隔（秒）"
+        ),
+    )
     guest_session_cookie_name: str = Field(
         default="wp_guest",
         description="Guest session cookie name / ゲストセッションCookie名",
@@ -135,6 +149,31 @@ class Settings(BaseSettings):
     guest_session_max_age_seconds: int = Field(
         default=60 * 60 * 24,
         description="Guest session lifetime in seconds / ゲストセッションの寿命（秒）",
+    )
+    guest_session_idle_timeout_seconds: int = Field(
+        default=60 * 60 * 24,
+        description=(
+            "Idle timeout for guest server-side sessions / "
+            "ゲストサーバー側セッションのアイドルタイムアウト（秒）"
+        ),
+    )
+    csrf_protection_enabled: bool = Field(
+        default=True,
+        description="Enable Fetch Metadata / Origin CSRF guard / CSRF ガードを有効化",
+    )
+    csrf_trusted_origins: Annotated[tuple[str, ...], NoDecode] = Field(
+        default=(),
+        description=(
+            "Comma separated origins allowed for unsafe cookie requests / "
+            "Cookie を伴う unsafe request を許可する Origin 一覧"
+        ),
+    )
+    enforce_owner_scoping: bool = Field(
+        default=False,
+        description=(
+            "Enforce owner_user_id checks for legacy-owned content / "
+            "owner_user_id による所有者スコープを強制する"
+        ),
     )
     llm_provider: str = Field(
         default="openai",
@@ -414,7 +453,7 @@ class Settings(BaseSettings):
 
         return tuple(normalised)
 
-    @field_validator("allowed_cors_origins", mode="before")
+    @field_validator("allowed_cors_origins", "csrf_trusted_origins", mode="before")
     @classmethod
     def _normalise_allowed_cors_origins(
         cls, raw_origins: object
@@ -614,6 +653,16 @@ class Settings(BaseSettings):
         if environment_name == "production" and not self.admin_email_allowlist:
             raise ValueError(
                 "ADMIN_EMAIL_ALLOWLIST must specify allowed admin emails in production"
+            )
+
+        if environment_name == "production" and self.disable_session_auth:
+            raise ValueError(
+                "DISABLE_SESSION_AUTH must not be enabled in production"
+            )
+
+        if environment_name == "production" and not self.csrf_protection_enabled:
+            raise ValueError(
+                "CSRF_PROTECTION_ENABLED must not be disabled in production"
             )
 
         is_trusted_proxy_explicit = "trusted_proxy_ips" in self.model_fields_set

--- a/apps/backend/backend/store/firestore_store.py
+++ b/apps/backend/backend/store/firestore_store.py
@@ -81,7 +81,7 @@ class FirestoreRegenerateJobStore(_LegacyClockMixin, FirestoreRegenerateJobRepos
     """Legacy import path for the regenerate job repository."""
 
 
-class FirestoreSessionStore(_LegacyClockMixin, FirestoreSessionRepository):
+class FirestoreSessionStore(FirestoreSessionRepository):
     """Legacy import path for the session repository."""
 
 

--- a/apps/backend/backend/store/firestore_store.py
+++ b/apps/backend/backend/store/firestore_store.py
@@ -16,6 +16,7 @@ from ..infrastructure.firestore.repositories.base import (
 from ..infrastructure.firestore.repositories.examples import FirestoreExampleRepository
 from ..infrastructure.firestore.repositories.quizzes import FirestoreQuizRepository
 from ..infrastructure.firestore.repositories.regenerate_jobs import FirestoreRegenerateJobRepository
+from ..infrastructure.firestore.repositories.sessions import FirestoreSessionRepository
 from ..infrastructure.firestore.repositories.users import FirestoreUserRepository
 from ..infrastructure.firestore.repositories.wordpacks import FirestoreWordPackRepository
 
@@ -80,6 +81,10 @@ class FirestoreRegenerateJobStore(_LegacyClockMixin, FirestoreRegenerateJobRepos
     """Legacy import path for the regenerate job repository."""
 
 
+class FirestoreSessionStore(_LegacyClockMixin, FirestoreSessionRepository):
+    """Legacy import path for the session repository."""
+
+
 class AppFirestoreStore(AppFirestoreRepository):
     """Legacy facade that composes Firestore concrete repositories."""
 
@@ -89,6 +94,7 @@ class AppFirestoreStore(AppFirestoreRepository):
     article_repository_cls = FirestoreArticleStore
     quiz_repository_cls = FirestoreQuizStore
     regenerate_job_repository_cls = FirestoreRegenerateJobStore
+    session_repository_cls = FirestoreSessionStore
 
 
 __all__ = [
@@ -98,6 +104,7 @@ __all__ = [
     "FirestoreExampleStore",
     "FirestoreQuizStore",
     "FirestoreRegenerateJobStore",
+    "FirestoreSessionStore",
     "FirestoreUserStore",
     "FirestoreWordPackStore",
     "firestore",

--- a/configs/cloud-run/ci.env
+++ b/configs/cloud-run/ci.env
@@ -5,6 +5,7 @@ CLOUD_RUN_SERVICE=wordpack-backend
 ARTIFACT_REPOSITORY=wordpack/backend
 SESSION_SECRET_KEY=ci-only-secret-please-override-immediately-1234567890
 CORS_ALLOWED_ORIGINS=https://ci.wordpack.dev
+CSRF_PROTECTION_ENABLED=true
 TRUSTED_PROXY_IPS=35.191.0.0/16,130.211.0.0/22
 ALLOWED_HOSTS=ci-wordpack.a.run.app,api-ci.wordpack.dev
 GOOGLE_CLIENT_ID=1234567890-ci.apps.googleusercontent.com

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -16,13 +16,22 @@ frontend が Google login 設定などを取得します。
 
 ### `POST /api/auth/google`
 
-Google Identity Services の ID token を backend に渡し、通常セッション Cookie を発行します。
+Google Identity Services の ID token または `credential` を backend に渡し、通常セッション Cookie を発行します。Cookie には署名済みの opaque `sid` のみを入れ、session 実体は backend の server-side store で検証します。
 
 Request:
 
 ```json
 {
   "id_token": "<google-id-token>"
+}
+```
+
+GIS `credential` 形式:
+
+```json
+{
+  "credential": "<google-credential>",
+  "g_csrf_token": "<csrf-token-from-g_csrf_token-cookie>"
 }
 ```
 
@@ -53,7 +62,7 @@ Response:
 
 ### `POST /api/auth/logout`
 
-通常ログインまたはゲスト閲覧のセッション Cookie を失効させ、匿名状態へ戻します。
+通常ログインまたはゲスト閲覧のセッション Cookie を削除し、server-side session を revoke して匿名状態へ戻します。
 
 ## WordPack
 
@@ -101,7 +110,7 @@ Response:
 
 ### `GET /api/word/packs/{id}`
 
-指定 WordPack の詳細を返します。ゲスト閲覧では非公開 WordPack は 404 です。
+指定 WordPack の詳細を返します。ゲスト閲覧では非公開 WordPack は 404 です。ログイン済みユーザーは既定で legacy shared data を閲覧できますが、`ENFORCE_OWNER_SCOPING=true` では `owner_user_id` の一致を要求します。
 
 ### `DELETE /api/word/packs/{id}`
 
@@ -211,7 +220,7 @@ Quiz API は保存済み WordPack や lemma から長文読解 Quiz を生成、
 
 ### `GET /api/quiz/{id}`
 
-指定 Quiz の詳細を返します。ゲスト閲覧では非公開 Quiz は 404 です。
+指定 Quiz の詳細を返します。ゲスト閲覧では非公開 Quiz は 404 です。Attempt 保存はログイン済みユーザーのみ利用できます。
 
 ### `POST /api/quiz/{id}/guest-public`
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -5,10 +5,11 @@
 ## 構成
 
 - frontend は Google Identity Services で ID token を取得します。
-- backend は `/api/auth/google` で ID token を検証し、HttpOnly の署名付きセッション Cookie を発行します。
+- backend は `/api/auth/google` で ID token または GIS `credential` を検証し、HttpOnly の署名付きセッション Cookie を発行します。
 - frontend は ID token を長期保存しません。再読み込み時は Cookie と `/api/config` の応答から認証状態を再構築します。
 - ゲスト閲覧は `/api/auth/guest` で署名付きゲスト Cookie を発行し、読み取り専用 API だけを許可します。
 - ログアウトは `/api/auth/logout` で通常セッションとゲストセッションを失効させます。
+- Cookie の署名 payload は opaque な `sid` のみで、ユーザー ID やゲスト状態は Firestore の `sessions/{sid}` で検証します。
 
 ## Google OAuth クライアント作成
 
@@ -41,10 +42,11 @@ VITE_GOOGLE_CLIENT_ID=12345-abcdefgh.apps.googleusercontent.com
 
 1. ユーザーが「Googleでログイン」を押します。
 2. Google の popup で account を選びます。
-3. frontend が Google から受け取った credential を `id_token` として `/api/auth/google` へ送ります。
+3. frontend が Google から受け取った credential を `/api/auth/google` へ送ります。既存互換として `{ "id_token": "..." }` も受け付けます。
 4. backend が token、audience、email、email verification、hosted domain、allowlist を検証します。
-5. 成功時、backend が通常セッション Cookie を発行します。
-6. frontend はユーザー表示情報だけを local storage に保存します。
+5. GIS の `credential` と `g_csrf_token` を使う場合は、body と `g_csrf_token` Cookie の値が一致しないリクエストを拒否します。
+6. 成功時、backend が Firestore に server-side session を作成し、Cookie には署名済み `sid` だけを入れて返します。
+7. frontend はユーザー表示情報だけを local storage に保存します。
 
 `ADMIN_EMAIL_ALLOWLIST` が空の場合、開発/テストでは許可リストによる制限は無効です。本番では空のまま起動しないよう設定バリデーションで止めます。
 
@@ -65,17 +67,28 @@ VITE_GOOGLE_CLIENT_ID=12345-abcdefgh.apps.googleusercontent.com
 
 - `SESSION_COOKIE_NAME` の既定は `wp_session`
 - Firebase Hosting rewrite 経由でも届くよう、同じ token を `__session` にも配信します。
+- `wp_session` と `__session` の両方がある場合は通常セッションを優先します。
 
 ゲストセッション:
 
 - `GUEST_SESSION_COOKIE_NAME` の既定は `wp_guest`
 - 同じく `__session` にも配信します。
+- ログイン後に `wp_guest` が残っても、通常セッションが有効ならゲスト扱いにはしません。
 
 共通:
 
 - Cookie は HttpOnly です。
 - `SESSION_COOKIE_SECURE` は本番 HTTPS では true を指定します。
-- ログアウト時は通常セッション、ゲストセッション、`__session` を失効させます。
+- ログアウト時は通常セッション、ゲストセッション、`__session` を削除し、対応する server-side session を revoke します。
+- 絶対期限に加えて idle timeout を検証し、`last_seen_at` は設定された間隔より頻繁には更新しません。
+
+## CSRF 防御
+
+- unsafe method (`POST`, `PUT`, `PATCH`, `DELETE`) では Fetch Metadata (`Sec-Fetch-Site`) と `Origin` を確認します。
+- 明示的な cross-site unsafe request は 403 です。
+- `Origin` がある場合は、同一 origin、`CORS_ALLOWED_ORIGINS`、または `CSRF_TRUSTED_ORIGINS` に含まれる origin だけを許可します。
+- `CSRF_PROTECTION_ENABLED=false` は本番環境では起動時に拒否されます。
+- ブラウザ外のクライアントや TestClient のように `Origin` がない unsafe request は、Fetch Metadata で cross-site と示されない限り許可します。
 
 ## 認証失敗時の確認
 
@@ -89,6 +102,7 @@ VITE_GOOGLE_CLIENT_ID=12345-abcdefgh.apps.googleusercontent.com
 | 403 email unverified | Google アカウントのメール確認が済んでいるか |
 | domain mismatch | `GOOGLE_ALLOWED_HD` と ID token の hosted domain が一致するか |
 | session が復元されない | Cookie 名、Secure 属性、Hosting rewrite、`__session`、ブラウザ Cookie 設定 |
+| 403 CSRF check failed | `Origin`, `Sec-Fetch-Site`, `CORS_ALLOWED_ORIGINS`, `CSRF_TRUSTED_ORIGINS` |
 
 ## 構造化ログキー
 
@@ -113,4 +127,5 @@ Google 認証まわりでは次の key を確認します。
 - `change-me` など既知のサンプル値は使いません。
 - Google OAuth client secret、service account JSON、Cookie、ID token はリポジトリへコミットしません。
 - 本番では `CORS_ALLOWED_ORIGINS` と `ALLOWED_HOSTS` を明示し、ワイルドカードのままにしません。
+- 本番では `DISABLE_SESSION_AUTH=true` と `CSRF_PROTECTION_ENABLED=false` は起動時に拒否されます。
 - 認証エラー調査では token 原文、Cookie、request ID の実値を公開文書や PR 本文へ書きません。

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -47,6 +47,7 @@ cp env.deploy.example .env.deploy
 - `SESSION_SECRET_KEY`
 - `ADMIN_EMAIL_ALLOWLIST`
 - `CORS_ALLOWED_ORIGINS`
+- `CSRF_PROTECTION_ENABLED=true`
 - `TRUSTED_PROXY_IPS`
 - `ALLOWED_HOSTS`
 - `GOOGLE_CLIENT_ID`
@@ -67,7 +68,7 @@ cp env.deploy.example .env.deploy
   --service wordpack-backend
 ```
 
-この段階で Pydantic 設定、必須環境変数、Cloud Run 向け env 変換を確認します。`ENVIRONMENT=production` で `ADMIN_EMAIL_ALLOWLIST`、`TRUSTED_PROXY_IPS`、`ALLOWED_HOSTS` などが不足している場合は、gcloud 実行前に失敗します。
+この段階で Pydantic 設定、必須環境変数、Cloud Run 向け env 変換を確認します。`ENVIRONMENT=production` で `ADMIN_EMAIL_ALLOWLIST`、`TRUSTED_PROXY_IPS`、`ALLOWED_HOSTS` などが不足している場合、または `DISABLE_SESSION_AUTH=true` / `CSRF_PROTECTION_ENABLED=false` が指定されている場合は、gcloud 実行前に失敗します。
 
 ## Cloud Run デプロイ
 

--- a/docs/guest_public_api.md
+++ b/docs/guest_public_api.md
@@ -10,6 +10,10 @@
 - **更新**: ログイン済みユーザーのみ許可（ゲスト/匿名は拒否）。
 - **閲覧（ゲスト）**: `guest_public=true` の WordPack / Reader 記事 / Quiz と、公開 WordPack に紐づく例文のみ返却。
 - **終了（ゲスト）**: `POST /api/auth/logout` でゲストセッション Cookie を失効し、匿名状態へ戻します。
+- **非公開詳細**: ゲストが非公開 WordPack / Reader 記事 / Quiz を直接指定した場合は 404 を返し、存在有無を隠します。
+- **未登録 lemma**: ゲストが未登録 lemma を検索しても WordPack は生成せず、403 を返します。
+- **書き込み**: ゲストの unsafe request は 403 です。公開 Quiz のローカル採点表示は frontend 側で可能ですが、Attempt 保存 API はログイン済みユーザーのみ許可します。
+- **所有者**: 新規作成される WordPack / Reader 記事 / Quiz / Quiz Attempt は `owner_user_id` を保存します。既存データの `owner_user_id` が空の場合は既定で legacy shared data として扱い、`ENFORCE_OWNER_SCOPING=true` のときだけ所有者一致を強制します。
 
 ## API
 

--- a/docs/環境変数の意味.md
+++ b/docs/環境変数の意味.md
@@ -82,10 +82,10 @@
 
 ---
 
-### 1.6) SESSION_SECRET_KEY / SESSION_COOKIE_NAME / SESSION_COOKIE_SECURE / SESSION_MAX_AGE_SECONDS / GUEST_SESSION_COOKIE_NAME / GUEST_SESSION_MAX_AGE_SECONDS
+### 1.6) SESSION_SECRET_KEY / SESSION_COOKIE_NAME / SESSION_COOKIE_SECURE / SESSION_MAX_AGE_SECONDS / SESSION_IDLE_TIMEOUT_SECONDS / SESSION_LAST_SEEN_UPDATE_INTERVAL_SECONDS / GUEST_SESSION_COOKIE_NAME / GUEST_SESSION_MAX_AGE_SECONDS / GUEST_SESSION_IDLE_TIMEOUT_SECONDS
 - 用途: 署名付きセッショントークンとゲストセッションの生成・検証、Cookie 名称・寿命の制御。
-- 既定値: env.example=`SESSION_SECRET_KEY=`（空なので利用者が乱数値を必ず入力する）、`SESSION_COOKIE_NAME=wp_session`, `# SESSION_COOKIE_SECURE=true`, `# SESSION_MAX_AGE_SECONDS=1209600`, `GUEST_SESSION_COOKIE_NAME=wp_guest`, `# GUEST_SESSION_MAX_AGE_SECONDS=86400`。コード既定は `session_secret_key=""`, `session_cookie_name="wp_session"`, `session_cookie_secure=(environment == "production")`, `session_max_age_seconds=1209600`, `guest_session_cookie_name="wp_guest"`, `guest_session_max_age_seconds=86400`。
-- 使われ方: セッションシリアライザの初期化と HTTP 応答での Set-Cookie 設定に利用されます。Firebase Hosting が `__session` 以外の Cookie を Cloud Run へ転送しない制約に備え、FastAPI 側ではログイン用の `SESSION_COOKIE_NAME` とゲスト閲覧用の `GUEST_SESSION_COOKIE_NAME` に加えて、どちらも `__session` へ同一トークンを配信します。ゲスト閲覧用の Cookie は読み取り専用 API を許可する用途に限定されます。
+- 既定値: env.example=`SESSION_SECRET_KEY=`（空なので利用者が乱数値を必ず入力する）、`SESSION_COOKIE_NAME=wp_session`, `# SESSION_COOKIE_SECURE=true`, `# SESSION_MAX_AGE_SECONDS=1209600`, `# SESSION_IDLE_TIMEOUT_SECONDS=604800`, `# SESSION_LAST_SEEN_UPDATE_INTERVAL_SECONDS=300`, `GUEST_SESSION_COOKIE_NAME=wp_guest`, `# GUEST_SESSION_MAX_AGE_SECONDS=86400`, `# GUEST_SESSION_IDLE_TIMEOUT_SECONDS=86400`。コード既定は `session_secret_key=""`, `session_cookie_name="wp_session"`, `session_cookie_secure=(environment == "production")`, `session_max_age_seconds=1209600`, `session_idle_timeout_seconds=604800`, `session_last_seen_update_interval_seconds=300`, `guest_session_cookie_name="wp_guest"`, `guest_session_max_age_seconds=86400`, `guest_session_idle_timeout_seconds=86400`。
+- 使われ方: セッションシリアライザの初期化、server-side session record、HTTP 応答での Set-Cookie 設定に利用されます。Firebase Hosting が `__session` 以外の Cookie を Cloud Run へ転送しない制約に備え、FastAPI 側ではログイン用の `SESSION_COOKIE_NAME` とゲスト閲覧用の `GUEST_SESSION_COOKIE_NAME` に加えて、どちらも `__session` へ同一トークンを配信します。Cookie payload は opaque な `sid` のみで、ユーザー ID・ゲスト種別・失効状態・期限は Firestore の `sessions/{sid}` で検証します。ゲスト閲覧用の Cookie は読み取り専用 API を許可する用途に限定されます。
 ```21:44:apps/backend/backend/auth.py
 def _build_serializer() -> URLSafeTimedSerializer:
     secret = settings.session_secret_key.strip()
@@ -119,13 +119,37 @@ for cookie_name in guest_session_cookie_names():
   - `SESSION_SECRET_KEY` が空、`change-me` などの既知プレースホルダー、32 文字未満の短い値、あるいは過去に公開したサンプル値（ハッシュ照合）に該当すると初期化時に例外が発生し、アプリケーションは起動しません。実運用では `openssl rand -base64 48 | tr -d '\n'` などで生成した乱数文字列を設定してください。
   - `SESSION_COOKIE_SECURE` は ENVIRONMENT が `production` のときのみ既定で True。`development`/`staging` などでは False なので HTTP での Cookie 配信が可能です。本番で HTTPS を使う場合は `.env` または環境変数で `true` を明示してください。
   - `SESSION_MAX_AGE_SECONDS` は整数で指定。負数や文字列の場合は既定の 14 日間にフォールバックします。
+  - `SESSION_IDLE_TIMEOUT_SECONDS` は通常セッションの idle timeout です。`last_seen_at` からこの秒数を超えると期限切れとして扱います。
+  - `SESSION_LAST_SEEN_UPDATE_INTERVAL_SECONDS` は `last_seen_at` の更新間隔です。短くしすぎると Firestore write が増えます。
   - `GUEST_SESSION_MAX_AGE_SECONDS` は整数で指定。負数や文字列の場合は既定の 24 時間にフォールバックします。
+  - `GUEST_SESSION_IDLE_TIMEOUT_SECONDS` はゲストセッションの idle timeout です。
+  - `ENVIRONMENT=production` では `DISABLE_SESSION_AUTH=true` は起動時に拒否されます。
 - 設定例:
   - `SESSION_SECRET_KEY=$(openssl rand -base64 48 | tr -d '\n')`
   - `SESSION_COOKIE_NAME=wp_session`
   - 本番 HTTPS 運用: `SESSION_COOKIE_SECURE=true`
   - 有効期限を 7 日に短縮: `SESSION_MAX_AGE_SECONDS=604800`
+  - idle timeout を 12 時間に短縮: `SESSION_IDLE_TIMEOUT_SECONDS=43200`
   - ゲスト Cookie を別名にする: `GUEST_SESSION_COOKIE_NAME=wp_guest_preview`
+
+---
+
+#### 1.6.1) CSRF_PROTECTION_ENABLED / CSRF_TRUSTED_ORIGINS / ENFORCE_OWNER_SCOPING
+- 用途:
+  - `CSRF_PROTECTION_ENABLED`: unsafe method に対する Fetch Metadata / Origin ガードの有効化。
+  - `CSRF_TRUSTED_ORIGINS`: `CORS_ALLOWED_ORIGINS` とは別に unsafe request を許可する origin の一覧。
+  - `ENFORCE_OWNER_SCOPING`: `owner_user_id` による所有者チェックを強制するか。
+- 既定値: env.example=`# CSRF_PROTECTION_ENABLED=true`, `# CSRF_TRUSTED_ORIGINS=...`, `# ENFORCE_OWNER_SCOPING=false`。コード既定は `csrf_protection_enabled=True`, `csrf_trusted_origins=()`, `enforce_owner_scoping=False`。
+- 使われ方:
+  - `Sec-Fetch-Site: cross-site` の unsafe request は 403。
+  - `Origin` がある unsafe request は、同一 origin、`CORS_ALLOWED_ORIGINS`、または `CSRF_TRUSTED_ORIGINS` と一致する場合だけ許可。
+  - 新規作成する WordPack / Reader 記事 / Quiz / Quiz Attempt には `owner_user_id` を保存。既存データで `owner_user_id` が空の場合は既定で legacy shared data として扱い、`ENFORCE_OWNER_SCOPING=true` の場合だけ所有者一致を要求。
+- 未設定/誤設定:
+  - `ENVIRONMENT=production` で `CSRF_PROTECTION_ENABLED=false` を指定すると起動時に拒否されます。
+  - `CSRF_TRUSTED_ORIGINS` は origin 単位で指定します。path は指定しません。
+- 設定例:
+  - `CSRF_TRUSTED_ORIGINS=https://app.example.com,https://admin.example.com`
+  - 既存データ移行後に所有者を強制: `ENFORCE_OWNER_SCOPING=true`
 
 ---
 

--- a/env.deploy.example
+++ b/env.deploy.example
@@ -25,6 +25,12 @@ GOOGLE_ALLOWED_HD=example.com
 ADMIN_EMAIL_ALLOWLIST=admin@example.com,owner@example.com
 # フロントエンドのアクセス元をカンマ区切りで列挙します。HTTPS 本番ドメインを指定してください。
 CORS_ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
+# unsafe method の CSRF ガード。本番では false にできません。
+CSRF_PROTECTION_ENABLED=true
+# CORS とは別に unsafe request を許可する origin があれば指定します。
+# CSRF_TRUSTED_ORIGINS=https://app.example.com,https://admin.example.com
+# 本番では true にできません。
+DISABLE_SESSION_AUTH=false
 # Cloud Load Balancing/プロキシで信頼する CIDR をカンマ区切りで記載します。
 TRUSTED_PROXY_IPS=35.191.0.0/16,130.211.0.0/22
 # Cloud Run サービス URL や独自ドメインなど、API を公開するホスト名を列挙します。
@@ -37,6 +43,12 @@ SESSION_SECRET_KEY=replace-this-with-a-secure-random-string
 # ゲスト閲覧モード用 Cookie を明示したい場合は以下を設定します。
 # GUEST_SESSION_COOKIE_NAME=wp_guest
 # GUEST_SESSION_MAX_AGE_SECONDS=86400
+# GUEST_SESSION_IDLE_TIMEOUT_SECONDS=86400
+# 通常セッション idle timeout と last_seen_at 更新間隔。
+# SESSION_IDLE_TIMEOUT_SECONDS=604800
+# SESSION_LAST_SEEN_UPDATE_INTERVAL_SECONDS=300
+# owner_user_id 移行後に true にすると所有者一致を強制します。
+# ENFORCE_OWNER_SCOPING=false
 
 # --- LLM 設定（ローカル .env と揃えておくと挙動が一致します） ---
 # 必要に応じてモデル名やトークン上限を調整してください。

--- a/env.example
+++ b/env.example
@@ -21,9 +21,18 @@ SESSION_COOKIE_NAME=wp_session
 # Firebase Hosting rewrite 経由でも認証できるよう、バックエンド側で `__session` も自動的に同じ値へミラーします。
 # SESSION_COOKIE_SECURE=true
 # SESSION_MAX_AGE_SECONDS=1209600
+# SESSION_IDLE_TIMEOUT_SECONDS=604800
+# SESSION_LAST_SEEN_UPDATE_INTERVAL_SECONDS=300
 # ゲスト閲覧モードのセッション Cookie（署名付き）。必要に応じて Cookie 名と寿命を調整します。
 GUEST_SESSION_COOKIE_NAME=wp_guest
 # GUEST_SESSION_MAX_AGE_SECONDS=86400
+# GUEST_SESSION_IDLE_TIMEOUT_SECONDS=86400
+# unsafe method の Fetch Metadata / Origin CSRF ガード。本番では無効化できません。
+# CSRF_PROTECTION_ENABLED=true
+# CORS_ALLOWED_ORIGINS と別に unsafe request を許可する origin があれば指定します。
+# CSRF_TRUSTED_ORIGINS=http://127.0.0.1:5173,http://localhost:5173
+# true にすると owner_user_id が一致しない既存データを 404 として隠します。
+# ENFORCE_OWNER_SCOPING=false
 
 # LLM providers: openai | local
 LLM_PROVIDER=openai

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -21,6 +21,15 @@
       "collectionGroup": "word_packs",
       "queryScope": "COLLECTION",
       "fields": [
+        { "fieldPath": "metadata.owner_user_id", "order": "ASCENDING" },
+        { "fieldPath": "created_at", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "word_packs",
+      "queryScope": "COLLECTION",
+      "fields": [
         { "fieldPath": "lemma_label_lower", "order": "ASCENDING" },
         { "fieldPath": "updated_at", "order": "DESCENDING" },
         { "fieldPath": "__name__", "order": "DESCENDING" }

--- a/scripts/deploy_cloud_run.sh
+++ b/scripts/deploy_cloud_run.sh
@@ -124,6 +124,7 @@ RUN_TIMEOUT_ARG=""
 MIN_INSTANCES_ARG=""
 NO_CPU_THROTTLING=false
 declare -a EXTRA_BUILD_ARGS=()
+declare -a CONFIG_PYTHON_CMD=()
 
 declare -A DEPLOY_ENV_KEYS=()
 declare -a IGNORE_DEPLOY_KEYS=(PROJECT_ID REGION CLOUD_RUN_SERVICE ARTIFACT_REPOSITORY IMAGE_TAG MACHINE_TYPE BUILD_TIMEOUT CLOUD_RUN_MIN_INSTANCES)
@@ -138,6 +139,23 @@ validate_min_instances() {
   fi
   err "Cloud Run minimum instances must be a non-negative integer or 'default'"
   exit 1
+}
+
+select_config_python_cmd() {
+  CONFIG_PYTHON_CMD=(python)
+
+  local is_apple_silicon current_arch
+  is_apple_silicon="$(sysctl -n hw.optional.arm64 2>/dev/null || true)"
+  [[ "$is_apple_silicon" == "1" ]] || return 0
+
+  current_arch="$(python -c 'import platform; print(platform.machine())' 2>/dev/null || true)"
+  [[ "$current_arch" == "x86_64" ]] || return 0
+
+  if command -v arch >/dev/null 2>&1 \
+    && arch -arm64 python -c 'import platform; raise SystemExit(0 if platform.machine() == "arm64" else 1)' >/dev/null 2>&1; then
+    CONFIG_PYTHON_CMD=(arch -arm64 python)
+    log "Detected x86_64 python on Apple Silicon; validating backend settings with native arm64 python"
+  fi
 }
 
 # コマンドライン引数のパース。
@@ -352,8 +370,9 @@ IMAGE_URI="${REGION}-docker.pkg.dev/${PROJECT_ID}/${ARTIFACT_REPOSITORY}:${IMAGE
 # Python 側の設定（Pydantic モデル）を一度ロードして、値が正しいかチェックします。
 # ここで失敗すれば Cloud Build へ進まないため、「壊れた設定で本番デプロイ」は防げます。
 require_cmd python
-log "Validating backend settings via python -m apps.backend.backend.config"
-PYTHONPATH="$REPO_ROOT" python -m apps.backend.backend.config >/dev/null
+select_config_python_cmd
+log "Validating backend settings via ${CONFIG_PYTHON_CMD[*]} -m apps.backend.backend.config"
+PYTHONPATH="$REPO_ROOT" "${CONFIG_PYTHON_CMD[@]}" -m apps.backend.backend.config >/dev/null
 log "Backend configuration validated successfully"
 
 # dry-run モードでは Cloud Build / Cloud Run には触らず、

--- a/tests/backend/test_auth_google.py
+++ b/tests/backend/test_auth_google.py
@@ -131,6 +131,9 @@ def test_google_auth_success_flow(
     expected_hash = hashlib.sha256("user@example.com".lower().encode("utf-8")).hexdigest()[:12]
     assert latest["email_hash"] == expected_hash
     assert "email" not in latest
+    expected_user_hash = hashlib.sha256("sub-123".lower().encode("utf-8")).hexdigest()[:12]
+    assert latest["user_id_hash"] == expected_user_hash
+    assert "user_id" not in latest
     expected_display_hash = hashlib.sha256("Example User".lower().encode("utf-8")).hexdigest()[:12]
     assert latest["display_name_hash"] == expected_display_hash
     assert "display_name" not in latest
@@ -263,7 +266,9 @@ def test_google_auth_rejects_unverified_email(
     log = matching[-1]
     expected_hash = hashlib.sha256("pending@example.com".lower().encode("utf-8")).hexdigest()[:12]
     assert log["email_hash"] == expected_hash
-    assert log.get("user_id") == "sub-unverified"
+    expected_user_hash = hashlib.sha256("sub-unverified".lower().encode("utf-8")).hexdigest()[:12]
+    assert log["user_id_hash"] == expected_user_hash
+    assert "user_id" not in log
 
 
 def test_google_auth_invalid_signature(

--- a/tests/backend/test_auth_session_store.py
+++ b/tests/backend/test_auth_session_store.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+import sys
+
+import pytest
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "apps" / "backend"))
+
+from backend.config import settings
+from backend.store import AppFirestoreStore
+from tests.firestore_fakes import ensure_firestore_test_env, use_fake_firestore_client
+
+
+@pytest.fixture()
+def session_store(monkeypatch: pytest.MonkeyPatch) -> AppFirestoreStore:
+    ensure_firestore_test_env(monkeypatch)
+    store_instance = AppFirestoreStore(client=use_fake_firestore_client(monkeypatch))
+
+    import backend.auth as auth_module
+
+    monkeypatch.setattr(auth_module, "store", store_instance)
+    monkeypatch.setattr(settings, "session_secret_key", "session-store-secret")
+    monkeypatch.setattr(settings, "session_max_age_seconds", 3600)
+    monkeypatch.setattr(settings, "guest_session_max_age_seconds", 1800)
+    monkeypatch.setattr(settings, "session_idle_timeout_seconds", 3600)
+    monkeypatch.setattr(settings, "guest_session_idle_timeout_seconds", 1800)
+    monkeypatch.setattr(settings, "session_last_seen_update_interval_seconds", 0)
+    return store_instance
+
+
+def _decode_user_cookie(token: str) -> dict:
+    serializer = URLSafeTimedSerializer(settings.session_secret_key, salt="wordpack.session")
+    return serializer.loads(token, max_age=3600)
+
+
+def _decode_guest_cookie(token: str) -> dict:
+    serializer = URLSafeTimedSerializer(settings.session_secret_key, salt="wordpack.guest_session")
+    return serializer.loads(token, max_age=1800)
+
+
+def test_user_session_cookie_contains_only_opaque_sid(session_store: AppFirestoreStore) -> None:
+    import backend.auth as auth_module
+
+    token = auth_module.issue_session_token("google-sub-1")
+    cookie_payload = _decode_user_cookie(token)
+
+    assert set(cookie_payload) == {"sid"}
+    record = session_store.get_session(cookie_payload["sid"])
+    assert record is not None
+    assert record["kind"] == "user"
+    assert record["user_id"] == "google-sub-1"
+
+    verified = auth_module.verify_session_token(token)
+    assert verified["sub"] == "google-sub-1"
+    assert verified["sid"] == cookie_payload["sid"]
+
+
+def test_guest_session_cookie_contains_only_opaque_sid(session_store: AppFirestoreStore) -> None:
+    import backend.auth as auth_module
+
+    token = auth_module.issue_guest_session_token()
+    cookie_payload = _decode_guest_cookie(token)
+
+    assert set(cookie_payload) == {"sid"}
+    record = session_store.get_session(cookie_payload["sid"])
+    assert record is not None
+    assert record["kind"] == "guest"
+    assert record["user_id"] is None
+
+    verified = auth_module.verify_guest_session_token(token)
+    assert verified["mode"] == "guest"
+    assert verified["sid"] == cookie_payload["sid"]
+
+
+def test_revoked_user_session_is_rejected(session_store: AppFirestoreStore) -> None:
+    import backend.auth as auth_module
+
+    token = auth_module.issue_session_token("google-sub-2")
+    assert auth_module.revoke_session_token(token) is True
+
+    with pytest.raises(BadSignature):
+        auth_module.verify_session_token(token)
+
+
+def test_idle_timeout_is_enforced(session_store: AppFirestoreStore) -> None:
+    import backend.auth as auth_module
+
+    token = auth_module.issue_session_token("google-sub-3")
+    sid = _decode_user_cookie(token)["sid"]
+    old_seen = datetime.now(UTC) - timedelta(seconds=7200)
+    session_store.touch_session(sid, last_seen_at=old_seen.replace(microsecond=0).isoformat())
+
+    with pytest.raises(SignatureExpired):
+        auth_module.verify_session_token(token)

--- a/tests/backend/test_authorization_policies.py
+++ b/tests/backend/test_authorization_policies.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from backend.authorization.policies import (
+    ResourceVisibility,
+    ensure_read_allowed,
+    ensure_user_write_allowed,
+)
+from backend.authorization.principal import Principal
+from backend.config import settings
+
+
+def test_guest_can_read_guest_public_resource() -> None:
+    principal = Principal(kind="guest", session_id="guest-session")
+
+    ensure_read_allowed(
+        principal,
+        ResourceVisibility(exists=True, guest_public=True, not_found_detail="Not found"),
+    )
+
+
+def test_guest_private_read_is_hidden_as_404() -> None:
+    principal = Principal(kind="guest", session_id="guest-session")
+
+    with pytest.raises(HTTPException) as exc_info:
+        ensure_read_allowed(
+            principal,
+            ResourceVisibility(
+                exists=True,
+                guest_public=False,
+                not_found_detail="WordPack not found",
+            ),
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "WordPack not found"
+
+
+def test_owner_scope_defaults_to_legacy_shared_for_users(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "enforce_owner_scoping", False)
+    principal = Principal(kind="user", user_id="user-a")
+
+    ensure_read_allowed(
+        principal,
+        ResourceVisibility(exists=True, guest_public=False, owner_user_id=None),
+    )
+
+
+def test_owner_scope_can_hide_foreign_resources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "enforce_owner_scoping", True)
+    principal = Principal(kind="user", user_id="user-a")
+
+    with pytest.raises(HTTPException) as exc_info:
+        ensure_read_allowed(
+            principal,
+            ResourceVisibility(
+                exists=True,
+                guest_public=False,
+                owner_user_id="user-b",
+                not_found_detail="Quiz not found",
+            ),
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Quiz not found"
+
+
+def test_guest_write_is_forbidden() -> None:
+    principal = Principal(kind="guest", session_id="guest-session")
+
+    with pytest.raises(HTTPException) as exc_info:
+        ensure_user_write_allowed(principal)
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Guest mode cannot perform write operations"

--- a/tests/backend/test_config_admin_email_allowlist.py
+++ b/tests/backend/test_config_admin_email_allowlist.py
@@ -27,10 +27,11 @@ def test_production_requires_allowlist() -> None:
 
     with pytest.raises(ValueError):
         Settings(
-            environment="production",
-            allowed_hosts=(_CLOUD_RUN_HOST,),
-            _env_file=None,
-        )
+        environment="production",
+        allowed_hosts=(_CLOUD_RUN_HOST,),
+        disable_session_auth=False,
+        _env_file=None,
+    )
 
 
 def test_production_accepts_non_empty_allowlist() -> None:
@@ -40,6 +41,7 @@ def test_production_accepts_non_empty_allowlist() -> None:
         environment="production",
         allowed_hosts=(_CLOUD_RUN_HOST,),
         admin_email_allowlist=("admin@example.com", "owner@example.com"),
+        disable_session_auth=False,
         _env_file=None,
     )
 
@@ -64,6 +66,7 @@ def test_allowlist_accepts_comma_separated_env(monkeypatch: pytest.MonkeyPatch) 
         environment="production",
         allowed_hosts=(_CLOUD_RUN_HOST,),
         session_secret_key=_SAFE_SECRET,
+        disable_session_auth=False,
         _env_file=None,
     )
 

--- a/tests/backend/test_config_allowed_hosts.py
+++ b/tests/backend/test_config_allowed_hosts.py
@@ -31,6 +31,7 @@ def test_production_rejects_wildcard_hosts() -> None:
         Settings(
             environment="production",
             admin_email_allowlist=("admin@example.com",),
+            disable_session_auth=False,
             _env_file=None,
         )
 
@@ -39,6 +40,7 @@ def test_production_rejects_wildcard_hosts() -> None:
             environment="production",
             allowed_hosts=("*", _CLOUD_RUN_HOST),
             admin_email_allowlist=("admin@example.com",),
+            disable_session_auth=False,
             _env_file=None,
         )
 
@@ -51,6 +53,7 @@ def test_production_rejects_empty_hosts() -> None:
             environment="production",
             allowed_hosts=(),
             admin_email_allowlist=("admin@example.com",),
+            disable_session_auth=False,
             _env_file=None,
         )
 
@@ -62,6 +65,7 @@ def test_production_allows_explicit_hosts() -> None:
         environment="production",
         allowed_hosts=(_CLOUD_RUN_HOST, "api.example.com"),
         admin_email_allowlist=("admin@example.com",),
+        disable_session_auth=False,
         _env_file=None,
     )
 

--- a/tests/backend/test_config_session_cookie.py
+++ b/tests/backend/test_config_session_cookie.py
@@ -37,6 +37,7 @@ def test_session_cookie_secure_defaults_to_true_in_production() -> None:
         environment="production",
         allowed_hosts=(_CLOUD_RUN_HOST,),
         admin_email_allowlist=("admin@example.com",),
+        disable_session_auth=False,
         _env_file=None,
     )
     assert config.session_cookie_secure is True
@@ -50,6 +51,34 @@ def test_session_cookie_secure_respects_explicit_override() -> None:
         session_cookie_secure=False,
         allowed_hosts=(_CLOUD_RUN_HOST,),
         admin_email_allowlist=("admin@example.com",),
+        disable_session_auth=False,
         _env_file=None,
     )
     assert config.session_cookie_secure is False
+
+
+def test_production_rejects_disabled_session_auth() -> None:
+    """本番環境ではセッション認証無効化を拒否する。"""
+
+    with pytest.raises(ValueError, match="DISABLE_SESSION_AUTH"):
+        Settings(
+            environment="production",
+            allowed_hosts=(_CLOUD_RUN_HOST,),
+            admin_email_allowlist=("admin@example.com",),
+            disable_session_auth=True,
+            _env_file=None,
+        )
+
+
+def test_production_rejects_disabled_csrf_protection() -> None:
+    """本番環境では CSRF ガード無効化を拒否する。"""
+
+    with pytest.raises(ValueError, match="CSRF_PROTECTION_ENABLED"):
+        Settings(
+            environment="production",
+            allowed_hosts=(_CLOUD_RUN_HOST,),
+            admin_email_allowlist=("admin@example.com",),
+            disable_session_auth=False,
+            csrf_protection_enabled=False,
+            _env_file=None,
+        )

--- a/tests/backend/test_config_trusted_proxy.py
+++ b/tests/backend/test_config_trusted_proxy.py
@@ -31,6 +31,7 @@ def test_production_defaults_to_cloud_run_ranges() -> None:
         environment="production",
         allowed_hosts=(_CLOUD_RUN_HOST,),
         admin_email_allowlist=("admin@example.com",),
+        disable_session_auth=False,
         _env_file=None,
     )
     assert config.trusted_proxy_ips == ("35.191.0.0/16", "130.211.0.0/22")
@@ -45,6 +46,7 @@ def test_production_requires_explicit_proxy_when_overridden() -> None:
             trusted_proxy_ips=(),
             allowed_hosts=(_CLOUD_RUN_HOST,),
             admin_email_allowlist=("admin@example.com",),
+            disable_session_auth=False,
             _env_file=None,
         )
 

--- a/tests/backend/test_csrf_middleware.py
+++ b/tests/backend/test_csrf_middleware.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.config import settings
+from backend.middleware.csrf import CsrfProtectionMiddleware
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.add_middleware(CsrfProtectionMiddleware)
+
+    @app.post("/unsafe")
+    async def unsafe() -> dict[str, bool]:
+        return {"ok": True}
+
+    return TestClient(app)
+
+
+def test_fetch_metadata_cross_site_unsafe_request_is_blocked(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "csrf_protection_enabled", True)
+    response = _client().post("/unsafe", headers={"sec-fetch-site": "cross-site"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "CSRF check failed"
+
+
+def test_origin_mismatch_unsafe_request_is_blocked(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "csrf_protection_enabled", True)
+    monkeypatch.setattr(settings, "csrf_trusted_origins", ("https://app.example",))
+
+    response = _client().post("/unsafe", headers={"origin": "https://evil.example"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "CSRF check failed"
+
+
+def test_trusted_origin_unsafe_request_is_allowed(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "csrf_protection_enabled", True)
+    monkeypatch.setattr(settings, "csrf_trusted_origins", ("https://app.example",))
+
+    response = _client().post("/unsafe", headers={"origin": "https://app.example"})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_missing_browser_origin_is_allowed_for_non_browser_clients(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "csrf_protection_enabled", True)
+
+    response = _client().post("/unsafe")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}

--- a/tests/backend/test_csrf_middleware.py
+++ b/tests/backend/test_csrf_middleware.py
@@ -46,6 +46,22 @@ def test_trusted_origin_unsafe_request_is_allowed(monkeypatch) -> None:
     assert response.json() == {"ok": True}
 
 
+def test_trusted_origin_can_satisfy_cross_site_fetch_metadata(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "csrf_protection_enabled", True)
+    monkeypatch.setattr(settings, "csrf_trusted_origins", ("https://app.example",))
+
+    response = _client().post(
+        "/unsafe",
+        headers={
+            "origin": "https://app.example",
+            "sec-fetch-site": "cross-site",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
 def test_missing_browser_origin_is_allowed_for_non_browser_clients(monkeypatch) -> None:
     monkeypatch.setattr(settings, "csrf_protection_enabled", True)
 

--- a/tests/backend/test_flow_firestore_store_mock.py
+++ b/tests/backend/test_flow_firestore_store_mock.py
@@ -42,7 +42,7 @@ def test_category_flow_operates_with_firestore_store(
     monkeypatch.setattr(category_module, "get_llm_provider", lambda **_: dummy_llm)
 
     article_stub = SimpleNamespace(run=lambda req: SimpleNamespace(id="article-from-stub"))
-    monkeypatch.setattr(category_module, "ArticleImportFlow", lambda: article_stub)
+    monkeypatch.setattr(category_module, "ArticleImportFlow", lambda **_: article_stub)
 
     class DummyCategoryFlow(CategoryGenerateAndImportFlow):
         """LLM 依存部を固定化したテスト専用フロー。"""

--- a/tests/backend/test_guest_mode_middleware.py
+++ b/tests/backend/test_guest_mode_middleware.py
@@ -507,7 +507,7 @@ def test_guest_public_update_is_denied(
 
 
 def test_authenticated_user_not_treated_as_guest_when_cookie_lingers(
-    monkeypatch: pytest.MonkeyPatch,
+    guest_test_client: tuple[TestClient, AppFirestoreStore],
 ) -> None:
     """認証済みユーザーがゲスト Cookie を持っていてもゲスト扱いされないことを確認する。
     
@@ -515,23 +515,30 @@ def test_authenticated_user_not_treated_as_guest_when_cookie_lingers(
     ゲスト Cookie が残存していても認証済みとして扱われる。
     未登録語を要求した場合、403 (ゲスト拒否) ではなく 404 (未登録) を返すべき。
     
-    なぜ: 本来はセッション Cookie とゲスト Cookie の両方が存在する状況をテストすべきだが、
-          テスト環境で完全な認証フローをシミュレートするのは複雑なため、
-          request.state.user をモックして認証済み状態を再現する簡易的な検証を行う。
-    
-    注: この検証はユニットテストの限界を超えるため、E2E テストで補完することを推奨する。
-          ここでは、コードロジックが認証済みユーザーを優先することを確認する。
+    なぜ: Firebase Hosting 経由では __session が user/guest どちらの alias にもなるため、
+          ログイン後に wp_guest が残っても user の __session が優先される必要がある。
     """
-    # このテストはミドルウェアの順序やセッション認証の複雑な相互作用を伴うため、
-    # 現在のテストフレームワークでは適切にシミュレートできない。
-    # 代わりに、以下の検証を行う：
-    # 1. コードレビューで、認証済みユーザーのチェックが先に行われることを確認（Done）
-    # 2. E2E テストで、実際のログインフローでゲスト Cookie が残存する場合の挙動を検証（推奨）
-    
-    # この関数は後続の統合テストまたは E2E テストで実装する方針とし、
-    # ここではコードロジックのレビューによる検証で代替する。
-    pytest.skip(
-        "Authenticated user with lingering guest cookie requires full auth flow simulation. "
-        "Code logic has been updated to prioritize authenticated user check. "
-        "Will be covered in E2E integration test."
+    client, store = guest_test_client
+
+    guest_response = client.post("/api/auth/guest")
+    assert guest_response.status_code == HTTPStatus.OK
+    guest_cookie_name = settings.guest_session_cookie_name
+    assert client.cookies.get(guest_cookie_name)
+
+    user_id = "sub-cookie-lingers"
+    store.record_user_login(
+        google_sub=user_id,
+        email="linger@example.com",
+        display_name="Lingering Guest Cookie",
     )
+
+    import backend.auth as auth_module
+
+    user_token = auth_module.issue_session_token(user_id)
+    client.cookies.set(settings.session_cookie_name or "wp_session", user_token)
+    client.cookies.set("__session", user_token)
+    assert client.cookies.get(guest_cookie_name)
+
+    lookup = client.get("/api/word/", params={"lemma": "missing-authenticated"})
+    assert lookup.status_code == HTTPStatus.NOT_FOUND
+    assert lookup.json()["detail"] == "WordPack not found"

--- a/tests/backend/test_owner_scoping.py
+++ b/tests/backend/test_owner_scoping.py
@@ -26,6 +26,26 @@ def test_wordpack_owner_visibility_is_stored(store: AppFirestoreStore) -> None:
     assert visibility == {"guest_public": False, "owner_user_id": "user-owner"}
 
 
+def test_owned_wordpack_list_filters_by_owner(store: AppFirestoreStore) -> None:
+    store.save_word_pack(
+        "wp-owner-a",
+        "owner-a",
+        json.dumps({"lemma": "owner-a", "examples": {}}),
+        metadata={"owner_user_id": "user-a"},
+    )
+    store.save_word_pack(
+        "wp-owner-b",
+        "owner-b",
+        json.dumps({"lemma": "owner-b", "examples": {}}),
+        metadata={"owner_user_id": "user-b"},
+    )
+
+    rows = store.list_owned_word_packs_with_flags("user-a")
+
+    assert [row[0] for row in rows] == ["wp-owner-a"]
+    assert store.count_owned_word_packs("user-a") == 1
+
+
 def test_article_owner_visibility_is_stored(store: AppFirestoreStore) -> None:
     store.save_article(
         "art-owner",
@@ -38,6 +58,30 @@ def test_article_owner_visibility_is_stored(store: AppFirestoreStore) -> None:
 
     visibility = store.get_article_visibility("art-owner")
     assert visibility == {"guest_public": False, "owner_user_id": "user-owner"}
+
+
+def test_owned_article_list_filters_by_owner(store: AppFirestoreStore) -> None:
+    store.save_article(
+        "art-owner-a",
+        title_en="Owned A",
+        body_en="Body A",
+        body_ja="本文A",
+        notes_ja=None,
+        owner_user_id="user-a",
+    )
+    store.save_article(
+        "art-owner-b",
+        title_en="Owned B",
+        body_en="Body B",
+        body_ja="本文B",
+        notes_ja=None,
+        owner_user_id="user-b",
+    )
+
+    rows = store.list_articles(owner_user_id="user-a")
+
+    assert [row[0] for row in rows] == ["art-owner-a"]
+    assert store.count_articles(owner_user_id="user-a") == 1
 
 
 def test_quiz_owner_visibility_and_attempt_owner_are_stored(store: AppFirestoreStore) -> None:
@@ -61,3 +105,43 @@ def test_quiz_owner_visibility_and_attempt_owner_are_stored(store: AppFirestoreS
     visibility = store.get_quiz_visibility("quiz-owner")
     assert visibility == {"guest_public": False, "owner_user_id": "user-owner"}
     assert store._client._data["quiz_attempts"]["attempt-owner"]["owner_user_id"] == "user-owner"
+
+
+def test_owned_quiz_list_filters_by_owner(store: AppFirestoreStore) -> None:
+    payload = {
+        "title_en": "Owned quiz",
+        "format_profile": "single_passage",
+        "generation_domain": "technical",
+        "domain_intensity": "standard",
+        "difficulty": "medium",
+        "passages": [{"id": "p1", "body_en": "Body", "body_ja": "本文"}],
+        "sections": [{"id": "s1", "questions": []}],
+        "related_word_packs": [],
+    }
+    store.save_quiz("quiz-owner-a", {**payload, "owner_user_id": "user-a"}, [])
+    store.save_quiz("quiz-owner-b", {**payload, "owner_user_id": "user-b"}, [])
+
+    rows = store.list_quizzes(owner_user_id="user-a")
+
+    assert [row["id"] for row in rows] == ["quiz-owner-a"]
+    assert store.count_quizzes(owner_user_id="user-a") == 1
+
+
+def test_example_parent_wordpack_id_is_available_before_study_progress_update(
+    store: AppFirestoreStore,
+) -> None:
+    store.save_word_pack(
+        "wp-example-owner",
+        "example-owner",
+        json.dumps({"lemma": "example-owner", "examples": {}}),
+        metadata={"owner_user_id": "user-owner"},
+    )
+    added_count = store.append_examples(
+        "wp-example-owner",
+        "Dev",
+        [{"en": "Hello.", "ja": "こんにちは。"}],
+    )
+    example_id = int(next(iter(store._client._data["examples"].keys())))
+
+    assert added_count == 1
+    assert store.get_example_word_pack_id(example_id) == "wp-example-owner"

--- a/tests/backend/test_owner_scoping.py
+++ b/tests/backend/test_owner_scoping.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.store import AppFirestoreStore
+from tests.firestore_fakes import ensure_firestore_test_env, use_fake_firestore_client
+
+
+@pytest.fixture()
+def store(monkeypatch: pytest.MonkeyPatch) -> AppFirestoreStore:
+    ensure_firestore_test_env(monkeypatch)
+    return AppFirestoreStore(client=use_fake_firestore_client(monkeypatch))
+
+
+def test_wordpack_owner_visibility_is_stored(store: AppFirestoreStore) -> None:
+    store.save_word_pack(
+        "wp-owner",
+        "owner",
+        json.dumps({"lemma": "owner", "examples": {}}),
+        metadata={"owner_user_id": "user-owner"},
+    )
+
+    visibility = store.get_word_pack_visibility("wp-owner")
+    assert visibility == {"guest_public": False, "owner_user_id": "user-owner"}
+
+
+def test_article_owner_visibility_is_stored(store: AppFirestoreStore) -> None:
+    store.save_article(
+        "art-owner",
+        title_en="Owned",
+        body_en="Owned body",
+        body_ja="所有された本文",
+        notes_ja=None,
+        owner_user_id="user-owner",
+    )
+
+    visibility = store.get_article_visibility("art-owner")
+    assert visibility == {"guest_public": False, "owner_user_id": "user-owner"}
+
+
+def test_quiz_owner_visibility_and_attempt_owner_are_stored(store: AppFirestoreStore) -> None:
+    payload = {
+        "title_en": "Owned quiz",
+        "format_profile": "single_passage",
+        "generation_domain": "technical",
+        "domain_intensity": "standard",
+        "difficulty": "medium",
+        "passages": [{"id": "p1", "body_en": "Body", "body_ja": "本文"}],
+        "sections": [{"id": "s1", "questions": []}],
+        "related_word_packs": [],
+        "owner_user_id": "user-owner",
+    }
+    store.save_quiz("quiz-owner", payload, [])
+    store.save_quiz_attempt(
+        "attempt-owner",
+        {"quiz_id": "quiz-owner", "owner_user_id": "user-owner"},
+    )
+
+    visibility = store.get_quiz_visibility("quiz-owner")
+    assert visibility == {"guest_public": False, "owner_user_id": "user-owner"}
+    assert store._client._data["quiz_attempts"]["attempt-owner"]["owner_user_id"] == "user-owner"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 
 # Disable session authentication by default so API tests can call endpoints without
 # provisioning cookies. Individual tests can override this via monkeypatch when needed.
+os.environ.setdefault("ENVIRONMENT", "test")
 os.environ.setdefault("DISABLE_SESSION_AUTH", "true")
 # Provide a deterministic yet secure-length session secret for tests to satisfy
 # 起動時バリデーション。実運用では `.env` で個別に乱数値を設定すること。


### PR DESCRIPTION
## Issue
Closes #526

## 変更内容
- Principal / Permission / policy layer を追加し、読み取り認可とユーザー書き込み認可を名前付きで整理。
- unsafe endpoint の通常ユーザー限定を permission dependency として明示し、GuestWriteBlockMiddleware は safety net として維持。
- WordPack / Example / Article / Quiz の guest_public 読み取り認可を policy 経由へ寄せ、private resource は guest に 404 を返す方針を固定。
- owner_user_id を backward compatible に保存・判定できるようにし、strict owner scoping フラグと owner-scoped list/count/update guard を追加。
- Firestore backed session store を追加し、Cookie payload を opaque sid 化、logout revoke、idle timeout、absolute timeout、__session alias を実装。
- unsafe method の Fetch Metadata / Origin guard と Google Identity Services の credential + g_csrf_token 互換を追加。
- production で DISABLE_SESSION_AUTH / CSRF_PROTECTION_ENABLED=false を拒否する設定 guard を追加。
- 認証/認可仕様、環境変数、API 仕様、deploy dry-run のローカル Apple Silicon 判定、Firestore index を文書・スクリプト・設定に反映。

## 保持した既存挙動
- Google ログインと legacy id_token payload 互換。
- wp_session / wp_guest / __session alias。
- Firebase Hosting 経由の __session-only user / guest 解決。
- guest_public=true のゲスト閲覧。
- 非公開 resource の guest 404 隠蔽。
- ゲスト書き込み 403。
- 認証済みユーザーの既存主要操作。

## 検証
- [x] FIRESTORE_EMULATOR_HOST=localhost:8080 FIRESTORE_PROJECT_ID=test-project GCP_PROJECT_ID=test-project OPENAI_API_KEY= PYTHONPATH=apps/backend pytest
  - 284 passed, 1 skipped, coverage 81.52%
- [x] FIRESTORE_EMULATOR_HOST=localhost:8080 FIRESTORE_PROJECT_ID=test-project GCP_PROJECT_ID=test-project PYTHONPATH=apps/backend pytest -q --no-cov tests/test_security_headers.py
  - 2 passed
- [x] cd apps/frontend && npx tsc -p tsconfig.json
- [x] cd apps/frontend && npm test -- --coverage --silent
  - 188 passed, 1 skipped test file
- [x] npx playwright test -c tests/e2e/playwright.config.ts tests/e2e/auth.spec.ts tests/e2e/guest.spec.ts tests/e2e/wordpack.spec.ts --reporter=line
  - 9 passed
- [x] shellcheck scripts/deploy_cloud_run.sh
- [x] ./scripts/deploy_cloud_run.sh --dry-run --env-file configs/cloud-run/ci.env --project-id ci-placeholder-project --region asia-northeast1 --service wordpack-backend
- [x] python -m json.tool firestore.indexes.json >/dev/null
- [x] git diff --check

## 未実行項目
- Signed double-submit CSRF token はこの PR では未実装。添付指示書 H3 の許容どおり別 slice とし、#527 で追跡。

## 残るリスク
- 旧 signed cookie payload は短期互換として受け入れるため、完全な server-side session 強制は互換期間後の削除判断が必要。
- owner scoping は既定では legacy shared model 互換を優先し、厳密分離は ENFORCE_OWNER_SCOPING 有効化時に適用。
- Signed double-submit CSRF は #527 の後続対応まで Fetch Metadata / Origin guard と Google g_csrf_token による段階防御。

## 公開セキュリティ確認
- token / cookie / request id / 本番ログ原文 / 実 secret は docs、tests、PR 本文に含めていない。
- CI 用 env の SESSION_SECRET_KEY は ci-only / test-only のダミー値であり、本番 secret ではない。
- 認証ログは email / display_name / user_id をハッシュ化し、session validation error で token / cookie を記録しない。