### PR TITLE
Backend CIでPython 3.14互換性とpytest失敗検知を追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       ENABLE_FIRESTORE_EMULATOR: "true"
     strategy:
       matrix:
-        python-version: ['3.13']
+        python-version: ['3.13', '3.14']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,13 +57,19 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Set up Java for Firebase Emulator
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
       - name: Cache pip
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          key: ${{ runner.os }}-python-${{ matrix.python-version }}-pip-${{ hashFiles('requirements.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ${{ runner.os }}-python-${{ matrix.python-version }}-pip-
 
       - name: Install dependencies
         run: |
@@ -77,10 +83,54 @@ jobs:
         run: |
           if [ "${ENABLE_FIRESTORE_EMULATOR}" = "true" ]; then
             npm install -g firebase-tools@15.22.0
-            FIRESTORE_EMULATOR_HOST="127.0.0.1:${FIRESTORE_EMULATOR_PORT}" FIRESTORE_PROJECT_ID="${FIRESTORE_PROJECT_ID}" firebase emulators:exec --only firestore --project "${FIRESTORE_PROJECT_ID}" --config firebase.json "pytest" | cat
+            FIRESTORE_EMULATOR_HOST="127.0.0.1:${FIRESTORE_EMULATOR_PORT}" FIRESTORE_PROJECT_ID="${FIRESTORE_PROJECT_ID}" firebase emulators:exec --only firestore --project "${FIRESTORE_PROJECT_ID}" --config firebase.json "python -m pytest"
           else
-            pytest | cat
+            python -m pytest
           fi
+
+  backend_container:
+    name: Backend container smoke (Python 3.14)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Build Python 3.14 backend image
+        run: docker build --build-arg PYTHON_VERSION=3.14 -f Dockerfile.backend -t wordpack-backend:python-3.14 .
+
+      - name: Start backend container
+        run: |
+          docker run --detach \
+            --name wordpack-backend-python314-smoke \
+            --env-file .env.ci \
+            --env FIRESTORE_PROJECT_ID=wordpack-ci \
+            --env GCP_PROJECT_ID=wordpack-ci \
+            --env FIRESTORE_EMULATOR_HOST=127.0.0.1:8081 \
+            --publish 127.0.0.1:8080:8080 \
+            wordpack-backend:python-3.14
+
+      - name: Verify backend health
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 30); do
+            if curl --fail --silent --show-error --header 'Host: localhost' http://127.0.0.1:8080/healthz; then
+              exit 0
+            fi
+            if [ "$(docker inspect --format='{{.State.Running}}' wordpack-backend-python314-smoke)" != "true" ]; then
+              docker logs wordpack-backend-python314-smoke
+              exit 1
+            fi
+            sleep 1
+          done
+          docker logs wordpack-backend-python314-smoke
+          exit 1
+
+      - name: Remove backend smoke container
+        if: ${{ always() }}
+        run: docker rm --force wordpack-backend-python314-smoke || true
 
   security_headers:
     name: Security headers tests (pytest)

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1
-FROM python:3.13-slim
+ARG PYTHON_VERSION=3.13
+FROM python:${PYTHON_VERSION}-slim
 
 # Cloud Run / GKE 等でも `docker build --build-arg ENVIRONMENT=staging` のように
 # 実行時環境を切り替えられるようにしておく。
@@ -22,6 +23,5 @@ COPY . .
 
 EXPOSE 8080
 CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8080", "--app-dir", "apps/backend"]
-
 
 

--- a/docs/testing/index.md
+++ b/docs/testing/index.md
@@ -17,6 +17,16 @@
 | Playwright smoke | `npx playwright test -c tests/e2e/playwright.config.ts tests/e2e/auth.spec.ts tests/e2e/guest.spec.ts tests/e2e/wordpack.spec.ts` | [playwright-e2e.md](./playwright-e2e.md) |
 | Visual regression | `E2E_BASE_URL=http://127.0.0.1:5173 npx playwright test -c tests/e2e/playwright.config.ts tests/e2e/visual.spec.ts` | [visual-regression.md](./visual-regression.md) |
 
+Firestore Emulator を使う Backend CI は Java 21 を前提とし、Python 3.13 と 3.14 の両方で同じ pytest suite を実行します。さらに `Dockerfile.backend` を Python 3.14 でビルドし、コンテナの `/healthz` まで確認します。ローカルで同じ suite を実行する場合は、Java 21 と Firebase CLI を用意したうえで次を使います。
+
+```bash
+FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 \
+FIRESTORE_PROJECT_ID=wordpack-ci \
+GCP_PROJECT_ID=wordpack-ci \
+PYTHONPATH=apps/backend \
+firebase emulators:exec --only firestore --project wordpack-ci --config firebase.json "python -m pytest"
+```
+
 ## 種別ごとの正本
 
 - Backend performance: [docs/testing/backend-performance.md](./backend-performance.md)

--- a/tests/backend/test_word_router_package.py
+++ b/tests/backend/test_word_router_package.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from fastapi import FastAPI
+
 from backend.routers import word
 
 
@@ -14,7 +16,9 @@ def test_word_router_keeps_legacy_exports() -> None:
 
 
 def test_word_router_paths_are_registered_in_split_package() -> None:
-    paths = {getattr(route, "path", None) for route in word.router.routes}
+    app = FastAPI()
+    app.include_router(word.router)
+    paths = set(app.openapi()["paths"])
 
     assert "/" in paths
     assert "/pack" in paths

--- a/tests/test_github_actions_branch_policy.py
+++ b/tests/test_github_actions_branch_policy.py
@@ -65,7 +65,40 @@ def test_deploy_dry_run_is_main_only() -> None:
     )
     assert "develop" not in yml, "deploy-dry-run must not run on develop"
     # Sanity: ensure this workflow is actually the one touching GCP.
-    _assert_contains_all(yml, ["google-github-actions/auth@v2", "setup-gcloud@v2"])
+    _assert_contains_all(yml, ["google-github-actions/auth@v2", "setup-gcloud@v3"])
+
+
+def test_backend_ci_runs_real_pytest_on_supported_python_versions() -> None:
+    """Contract: backend CI must run pytest with Java 21 and propagate failures."""
+    yml = _read_text(".github/workflows/ci.yml")
+
+    _assert_contains_all(
+        yml,
+        [
+            "python-version: ['3.13', '3.14']",
+            "actions/setup-java@v5",
+            "distribution: temurin",
+            "java-version: '21'",
+            'firebase emulators:exec --only firestore --project "${FIRESTORE_PROJECT_ID}" --config firebase.json "python -m pytest"',
+        ],
+    )
+    _assert_contains_none(yml, ["pytest | cat", '"pytest" | cat'])
+
+
+def test_backend_ci_builds_and_health_checks_python_314_container() -> None:
+    """Contract: Python 3.14 compatibility includes the production Docker path."""
+    yml = _read_text(".github/workflows/ci.yml")
+
+    _assert_contains_all(
+        yml,
+        [
+            "backend_container:",
+            "--build-arg PYTHON_VERSION=3.14",
+            "-f Dockerfile.backend",
+            "--env FIRESTORE_PROJECT_ID=wordpack-ci",
+            "http://127.0.0.1:8080/healthz",
+        ],
+    )
 
 
 def test_ci_does_not_embed_production_deploy_job() -> None:


### PR DESCRIPTION
## Issue

Refs #533

## 原因

Backend CI は Firebase Emulator CLI が Java 21 未満を理由に終了しても、`firebase emulators:exec ... "pytest" | cat` のパイプが終了コードを隠していました。そのため、pytest が収集・実行されていない main CI も成功表示になっていました。

false greenを解消した最初のCIでは、FastAPI 0.139以降がinclude済みrouterを遅延表現する変更により、内部の `router.routes[*].path` を直接読むテストも失敗しました。APIの公開契約は維持されていたため、OpenAPI生成結果でpath登録を確認するテストへ変更しました。

## 変更内容

- Backend CI に Temurin Java 21 を明示
- pytest を `python -m pytest` で直接実行し、失敗終了コードを伝播
- Backend matrix を Python 3.13 / 3.14 に拡張
- pip cache を Python version ごとに分離
- `Dockerfile.backend` に既定値 3.13 の `PYTHON_VERSION` build arg を追加
- Python 3.14 image のbuild、起動、`/healthz` を確認するCI jobを追加
- router登録テストをFastAPI内部表現ではなくOpenAPI公開契約へ変更
- workflow契約テストを現行 `setup-gcloud@v3` と新しいCI契約へ整合
- Java 21、Python matrix、ローカル再現コマンドをテスト文書へ追記

## 保持した既存挙動

- 本番Dockerの既定PythonはこのPRでは3.13のまま
- Cloud Runデプロイ、API、UI、Firestoreの公開契約は変更しない
- Firebase Emulatorを使うBackend suite自体は変更しない

## Local verification

- Python 3.14 + Java 21 + Firestore Emulator: 全290テスト成功
- FastAPI 0.139.2 / Starlette 1.3.1コンテナでrouter/workflow契約テスト: 成功
- Python 3.14 Docker image build: 成功
- Python 3.14コンテナ `GET /healthz`: `{"status":"ok"}`
- `python3 scripts/security_scan_text.py`: 成功
- `git diff --check`: 成功

## CI result

最新head `83a9a4e` で全check成功。

- Backend tests: Python 3.13 / 3.14 ともに実pytest 290件成功
- Backend container smoke (Python 3.14): 成功
- Playwright smoke、Frontend、Security headers、Cloud Run guard、CodeQL、Dependency review、Production preflight: 成功

## Code review result

- Codex自動review: 投稿なし
- 未解決review thread: 0件
- Cursor Bugbotはアカウント設定上無効の案内のみで、コード指摘なし

## 未実行項目

- `actionlint` はローカル未導入。GitHub Actionsがworkflowを受理し、全job成功したことで代替確認
- Frontend / Playwrightはローカル未実行。GitHub Actions上では成功

## 残るリスクと後続

- 本番既定値の3.14切替、関連workflow/README/deployment文書の整合、段階的Cloud Run rolloutは #533 の後続PRで行う
