### PR TITLE
WordPack生成の空白要素を正規化してstrict mode失敗を防ぐ

### DIFF
--- a/apps/backend/backend/flows/word_pack.py
+++ b/apps/backend/backend/flows/word_pack.py
@@ -12,6 +12,8 @@ from . import create_state_graph
 from ..infrastructure.llm.generated_contracts import (
     GeneratedWordPackPayload,
     has_required_wordpack_text,
+    normalize_generated_wordpack_payload,
+    required_wordpack_text_issues,
 )
 from ..infrastructure.llm.json_response_parser import parse_json_response
 from ..infrastructure.llm.prompts.examples import (
@@ -156,8 +158,31 @@ class WordPackFlow:
                         if isinstance(llm_data, dict):
                             try:
                                 validated = GeneratedWordPackPayload.model_validate(llm_data)
+                                normalization = normalize_generated_wordpack_payload(
+                                    validated
+                                )
+                                validated = normalization.payload
+                                llm_data = validated.model_dump(by_alias=True)
                                 schema_valid = True
                                 application_valid = has_required_wordpack_text(validated)
+                                if normalization.changed_items:
+                                    logger.info(
+                                        "wordpack_llm_output_normalized",
+                                        reason_code="WHITESPACE_NORMALIZED",
+                                        changed_items=normalization.changed_items,
+                                        removed_items=normalization.removed_items,
+                                        field_categories=list(
+                                            normalization.field_categories
+                                        ),
+                                    )
+                                if not application_valid:
+                                    logger.info(
+                                        "wordpack_llm_application_validation_failed",
+                                        reason_code="BLANK_REQUIRED_TEXT",
+                                        field_categories=list(
+                                            required_wordpack_text_issues(validated)
+                                        ),
+                                    )
                             except ValidationError:
                                 logger.info(
                                     "wordpack_llm_schema_validation_failed",

--- a/apps/backend/backend/flows/word_pack.py
+++ b/apps/backend/backend/flows/word_pack.py
@@ -162,7 +162,9 @@ class WordPackFlow:
                                     validated
                                 )
                                 validated = normalization.payload
-                                llm_data = validated.model_dump(by_alias=True)
+                                llm_data = validated.model_dump(
+                                    mode="json", by_alias=True
+                                )
                                 schema_valid = True
                                 application_valid = has_required_wordpack_text(validated)
                                 if normalization.changed_items:

--- a/apps/backend/backend/infrastructure/llm/generated_contracts.py
+++ b/apps/backend/backend/infrastructure/llm/generated_contracts.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from pydantic import BaseModel, ConfigDict, Field
 
 from ...models.quiz import (
@@ -65,6 +67,191 @@ class GeneratedWordPackPayload(BaseModel):
     etymology: GeneratedEtymologyPayload
     study_card: str = Field(min_length=1)
     pronunciation: GeneratedPronunciationPayload
+
+
+@dataclass(frozen=True)
+class GeneratedWordPackNormalization:
+    """意味を補完せずに正規化した生成結果と安全な観測情報。"""
+
+    payload: GeneratedWordPackPayload
+    changed_items: int
+    removed_items: int
+    field_categories: tuple[str, ...]
+
+
+def normalize_generated_wordpack_payload(
+    payload: GeneratedWordPackPayload,
+) -> GeneratedWordPackNormalization:
+    """空白を整え、意味を持たないコレクション要素だけを除去する。"""
+
+    changed_items = 0
+    removed_items = 0
+    field_categories: set[str] = set()
+
+    def clean_required(value: str, category: str) -> str:
+        nonlocal changed_items
+        cleaned = value.strip()
+        if cleaned != value:
+            changed_items += 1
+            field_categories.add(category)
+        return cleaned
+
+    def clean_optional(value: str | None, category: str) -> str | None:
+        nonlocal changed_items
+        if value is None:
+            return None
+        cleaned = value.strip()
+        normalized = cleaned or None
+        if normalized != value:
+            changed_items += 1
+            field_categories.add(category)
+        return normalized
+
+    def clean_list(values: list[str], category: str) -> list[str]:
+        nonlocal changed_items, removed_items
+        normalized: list[str] = []
+        for value in values:
+            cleaned = value.strip()
+            if not cleaned:
+                changed_items += 1
+                removed_items += 1
+                field_categories.add(category)
+                continue
+            if cleaned != value:
+                changed_items += 1
+                field_categories.add(category)
+            normalized.append(cleaned)
+        return normalized
+
+    senses: list[GeneratedSensePayload] = []
+    for sense in payload.senses:
+        senses.append(
+            sense.model_copy(
+                update={
+                    "id": clean_required(sense.id, "sense.required_text"),
+                    "gloss_ja": clean_required(
+                        sense.gloss_ja, "sense.required_text"
+                    ),
+                    "definition_ja": clean_required(
+                        sense.definition_ja, "sense.required_text"
+                    ),
+                    "nuances_ja": clean_required(
+                        sense.nuances_ja, "sense.required_text"
+                    ),
+                    "patterns": clean_list(sense.patterns, "sense.patterns"),
+                    "synonyms": clean_list(sense.synonyms, "sense.synonyms"),
+                    "antonyms": clean_list(sense.antonyms, "sense.antonyms"),
+                    "register_": clean_required(
+                        sense.register_, "sense.required_text"
+                    ),
+                    "notes_ja": clean_required(
+                        sense.notes_ja, "sense.required_text"
+                    ),
+                    "term_overview_ja": clean_optional(
+                        sense.term_overview_ja, "sense.optional_text"
+                    ),
+                    "term_core_ja": clean_optional(
+                        sense.term_core_ja, "sense.optional_text"
+                    ),
+                }
+            )
+        )
+
+    def clean_collocation_group(
+        group: GeneratedCollocationListsPayload, category: str
+    ) -> GeneratedCollocationListsPayload:
+        return group.model_copy(
+            update={
+                "verb_object": clean_list(group.verb_object, category),
+                "adj_noun": clean_list(group.adj_noun, category),
+                "prep_noun": clean_list(group.prep_noun, category),
+            }
+        )
+
+    contrast: list[ContrastItem] = []
+    for item in payload.contrast:
+        with_text = item.with_.strip()
+        diff_text = item.diff_ja.strip()
+        if not with_text or not diff_text:
+            changed_items += 1
+            removed_items += 1
+            field_categories.add("contrast")
+            continue
+        if with_text != item.with_ or diff_text != item.diff_ja:
+            changed_items += 1
+            field_categories.add("contrast")
+        contrast.append(
+            item.model_copy(update={"with_": with_text, "diff_ja": diff_text})
+        )
+
+    normalized = payload.model_copy(
+        update={
+            "senses": senses,
+            "sense_title": clean_required(
+                payload.sense_title, "wordpack.required_text"
+            ),
+            "collocations": payload.collocations.model_copy(
+                update={
+                    "general": clean_collocation_group(
+                        payload.collocations.general, "collocations.general"
+                    ),
+                    "academic": clean_collocation_group(
+                        payload.collocations.academic, "collocations.academic"
+                    ),
+                }
+            ),
+            "contrast": contrast,
+            "etymology": payload.etymology.model_copy(
+                update={
+                    "note": clean_required(payload.etymology.note, "etymology.note")
+                }
+            ),
+            "study_card": clean_required(
+                payload.study_card, "wordpack.required_text"
+            ),
+            "pronunciation": payload.pronunciation.model_copy(
+                update={
+                    "ipa_RP": clean_required(
+                        payload.pronunciation.ipa_RP, "pronunciation.ipa_RP"
+                    )
+                }
+            ),
+        }
+    )
+    return GeneratedWordPackNormalization(
+        payload=normalized,
+        changed_items=changed_items,
+        removed_items=removed_items,
+        field_categories=tuple(sorted(field_categories)),
+    )
+
+
+def required_wordpack_text_issues(
+    payload: GeneratedWordPackPayload,
+) -> tuple[str, ...]:
+    """安全に補完できない空白文字列のフィールド種別を返す。"""
+
+    issues: set[str] = set()
+    if not payload.sense_title.strip() or not payload.study_card.strip():
+        issues.add("wordpack.required_text")
+    if not payload.etymology.note.strip():
+        issues.add("etymology.note")
+    if not payload.pronunciation.ipa_RP.strip():
+        issues.add("pronunciation.ipa_RP")
+    if any(
+        not value.strip()
+        for sense in payload.senses
+        for value in (
+            sense.id,
+            sense.gloss_ja,
+            sense.definition_ja,
+            sense.nuances_ja,
+            sense.register_,
+            sense.notes_ja,
+        )
+    ):
+        issues.add("sense.required_text")
+    return tuple(sorted(issues))
 
 
 def has_required_wordpack_text(payload: GeneratedWordPackPayload) -> bool:
@@ -164,5 +351,8 @@ class GeneratedQuizPayload(BaseModel):
 __all__ = [
     "GeneratedQuizPayload",
     "GeneratedWordPackPayload",
+    "GeneratedWordPackNormalization",
+    "normalize_generated_wordpack_payload",
+    "required_wordpack_text_issues",
     "has_required_wordpack_text",
 ]

--- a/docs/llmops/privacy-and-operations.md
+++ b/docs/llmops/privacy-and-operations.md
@@ -23,6 +23,8 @@ Langfuse を使わない場合は `LANGFUSE_ENABLED=false` とします。初期
 4. `validation` と input / output hash で parse、schema、application のどこで失敗したかを絞ります。
 5. 本番ログや実データを未確認なら、コード上の仮説として扱い、原因を断定しません。
 
+WordPack 生成では、型検証後に文字列の前後空白を除き、空白だけの配列要素と不完全な比較要素を保存前に除去します。意味上必須の本文が空白だけの場合は application validation 失敗を維持します。正規化・拒否ログは件数、reason code、フィールド種別だけを記録し、raw output は記録しません。Live Evaluation も同じ正規化境界を使います。
+
 ## 本番問題を fixture へ還流する
 
 1. private な証跡から再現に必要な構造だけを抽出します。

--- a/scripts/llmops/live_eval.py
+++ b/scripts/llmops/live_eval.py
@@ -124,6 +124,7 @@ def main(*, provider_factory=None) -> int:
     from backend.infrastructure.llm.generated_contracts import (
         GeneratedWordPackPayload,
         has_required_wordpack_text,
+        normalize_generated_wordpack_payload,
     )
     from backend.infrastructure.llm.json_response_parser import parse_json_response
     from backend.infrastructure.llm.prompts.examples import (
@@ -203,6 +204,11 @@ def main(*, provider_factory=None) -> int:
                 if isinstance(parsed_wordpack, GeneratedWordPackPayload)
                 else None
             )
+            if generated_wordpack is not None:
+                generated_wordpack = normalize_generated_wordpack_payload(
+                    generated_wordpack
+                ).payload
+                payload = generated_wordpack.model_dump(by_alias=True)
             application_ok = bool(
                 generated_wordpack
                 and has_required_wordpack_text(generated_wordpack)

--- a/scripts/llmops/live_eval.py
+++ b/scripts/llmops/live_eval.py
@@ -208,7 +208,7 @@ def main(*, provider_factory=None) -> int:
                 generated_wordpack = normalize_generated_wordpack_payload(
                     generated_wordpack
                 ).payload
-                payload = generated_wordpack.model_dump(by_alias=True)
+                payload = generated_wordpack.model_dump(mode="json", by_alias=True)
             application_ok = bool(
                 generated_wordpack
                 and has_required_wordpack_text(generated_wordpack)

--- a/tests/llmops/test_call_and_write_baselines.py
+++ b/tests/llmops/test_call_and_write_baselines.py
@@ -10,6 +10,7 @@ from backend.config import settings
 from backend.flows.word_pack import WordPackFlow
 from backend.infrastructure.firestore.repositories.app_store import AppFirestoreStore
 from backend.logging import configure_logging
+from backend.models.common import ConfidenceLevel
 from backend.models.word import ExampleCategory
 from tests.firestore_fakes import FakeFirestoreClient
 
@@ -176,6 +177,7 @@ def test_wordpack_strict_mode_normalizes_blank_collection_items(
     assert [(item.with_, item.diff_ja) for item in pack.contrast] == [
         ("diverge", "方向が反対です。")
     ]
+    assert pack.etymology.confidence is ConfidenceLevel.medium
     assert pack.generation_provenance[0]["validation"] == {
         "parse": True,
         "schema": True,

--- a/tests/llmops/test_call_and_write_baselines.py
+++ b/tests/llmops/test_call_and_write_baselines.py
@@ -9,6 +9,7 @@ import pytest
 from backend.config import settings
 from backend.flows.word_pack import WordPackFlow
 from backend.infrastructure.firestore.repositories.app_store import AppFirestoreStore
+from backend.logging import configure_logging
 from backend.models.word import ExampleCategory
 from tests.firestore_fakes import FakeFirestoreClient
 
@@ -54,6 +55,18 @@ def _fixture() -> dict[str, object]:
         Path("evals/fixtures/wordpack_converge.json").read_text(encoding="utf-8")
     )
     return fixture["wordpack"]
+
+
+def _structlog_events(raw_logs: str, event: str) -> list[dict[str, object]]:
+    matches: list[dict[str, object]] = []
+    for raw in raw_logs.splitlines():
+        try:
+            payload = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if isinstance(payload, dict) and payload.get("event") == event:
+            matches.append(payload)
+    return matches
 
 
 def test_wordpack_and_five_initial_example_categories_keep_separate_provenance() -> None:
@@ -134,6 +147,77 @@ def test_wordpack_provenance_rejects_senses_with_only_blank_glosses(
         "schema": True,
         "application": False,
     }
+
+
+def test_wordpack_strict_mode_normalizes_blank_collection_items(
+    monkeypatch,
+    capsys,
+) -> None:
+    configure_logging()
+    monkeypatch.setattr(settings, "strict_mode", True)
+    payload = _fixture()
+    payload["senses"][0]["patterns"] = [" converge on ", "   "]
+    payload["senses"][0]["synonyms"] = [" meet ", ""]
+    payload["collocations"]["general"]["verb_object"] = [
+        " systems converge ",
+        "   ",
+    ]
+    payload["contrast"] = [
+        {"with": " diverge ", "diff_ja": " 方向が反対です。 "},
+        {"with": "", "diff_ja": "比較対象がありません。"},
+    ]
+    flow = WordPackFlow(llm=_SequencedWordPackLlm(payload))
+
+    pack = flow.run("converge", pronunciation_enabled=False)
+
+    assert pack.senses[0].patterns == ["converge on"]
+    assert pack.senses[0].synonyms == ["meet"]
+    assert pack.collocations.general.verb_object == ["systems converge"]
+    assert [(item.with_, item.diff_ja) for item in pack.contrast] == [
+        ("diverge", "方向が反対です。")
+    ]
+    assert pack.generation_provenance[0]["validation"] == {
+        "parse": True,
+        "schema": True,
+        "application": True,
+    }
+    normalization_fields = _structlog_events(
+        capsys.readouterr().err, "wordpack_llm_output_normalized"
+    )[0]
+    assert normalization_fields["reason_code"] == "WHITESPACE_NORMALIZED"
+    assert normalization_fields["removed_items"] == 4
+    assert set(normalization_fields["field_categories"]) == {
+        "collocations.general",
+        "contrast",
+        "sense.patterns",
+        "sense.synonyms",
+    }
+    assert "lemma" not in normalization_fields
+    assert "request_id" not in normalization_fields
+    assert "job_id" not in normalization_fields
+
+
+def test_wordpack_strict_mode_logs_safe_required_text_category(
+    monkeypatch,
+    capsys,
+) -> None:
+    configure_logging()
+    monkeypatch.setattr(settings, "strict_mode", True)
+    payload = _fixture()
+    payload["senses"][0]["gloss_ja"] = "   "
+    flow = WordPackFlow(llm=_SequencedWordPackLlm(payload))
+
+    with pytest.raises(RuntimeError, match="schema-valid usable data"):
+        flow._retrieve("converge")
+
+    validation_fields = _structlog_events(
+        capsys.readouterr().err, "wordpack_llm_application_validation_failed"
+    )[0]
+    assert validation_fields["reason_code"] == "BLANK_REQUIRED_TEXT"
+    assert validation_fields["field_categories"] == ["sense.required_text"]
+    assert "lemma" not in validation_fields
+    assert "request_id" not in validation_fields
+    assert "job_id" not in validation_fields
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Issue

Closes #570

## 変更内容

- Pydantic の生成契約を通過した WordPack 応答について、保存前に文字列の前後空白を正規化する。
- patterns / synonyms / antonyms / collocations の空白だけの要素を除去する。
- `contrast` の片側が空白だけの不完全な要素を、意味を補完せず行単位で除去する。
- 意味上必須の WordPack / sense / etymology / pronunciation 本文が空白だけの場合は、strict mode の失敗を維持する。
- 正規化件数、除去件数、reason code、フィールド種別だけを構造化ログへ追加する。raw prompt / output、ユーザー入力、追跡IDは新規ログ項目へ追加しない。
- Manual Live Evaluation も本番フローと同じ正規化境界を使う。
- 本番問題を固定fixtureへ置換した回帰テストと、安全なログ項目のテストを追加する。

## 保持した既存挙動

- JSON parse または Pydantic schema validation に失敗した応答は引き続き拒否する。
- 必須本文を空文字、placeholder、推測値で補完しない。
- 通常の有効応答で LLM 呼び出し回数を増やさない。
- model、reasoning effort、text verbosity、token上限、`store=False` を変更しない。
- WordPack 新規生成と再生成は既存の共通フローを維持する。

## 検証結果

- 修正前回帰確認: 空白配列要素を含む固定fixtureが strict mode で失敗することを確認
- 対象LLMOpsテスト: 77 passed
- `PYTHONPATH=apps/backend pytest` 相当を Firestore Emulator 上で実行: 437 passed、coverage 82.88%
- `git diff --check`: passed
- `python scripts/security_scan_text.py`: passed
- `python -m compileall -q apps/backend/backend scripts/llmops`: passed

## 未実行項目

- 実 OpenAI API: 費用と非決定性を伴い、raw production output を再取得しない方針のため未実行。固定fixtureで回帰条件を検証した。
- Frontend typecheck / tests / Playwright: UI、API schema、操作、文言を変更していないバックエンド内部契約修正のため未実行。
- スクリーンショット: UI変更がないため不要。

## ドキュメント

- LLMOps の privacy / operations 文書へ、正規化境界、安全な観測項目、Live Evaluationとの整合を追記した。
- README: 導入・主要機能・参照先に変更がないため更新不要。
- UserManual: 画面、操作、表示文言に変更がないため更新不要。

## 公開安全性

- private な本番ログは公開可能な事実だけに要約した。
- ログ原文、完全な調査クエリ、ユーザー入力全文、request / trace / job ID、完全なrevision名、本番project識別子を含めていない。
- raw LLM output をfixtureや文書へ転記していない。

## 残るリスク

- production 既定で raw output を保持しないため、報告時に空白だった正確なフィールドは不明。
- 必須本文自体が空白だけの場合は、データ品質を守るため引き続き失敗する。
- 実 OpenAI APIでの同一入力再現と、本番デプロイ後の生成確認はこのPR作成時点では未実施。
